### PR TITLE
feat: add quick config for CCT Downlight

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -259,7 +259,8 @@ template_t g_templates [] = {
 	{ Setup_Device_IntelligentLife_NF101A, "Intelligent Life NF101A"},
 	{ Setup_Device_TuyaLEDDimmerSingleChannel, "Tuya LED Dimmer Single Channel PWM WB3S"},
 	{ Setup_Device_CalexLEDDimmerFiveChannel, "Calex RGBWW LED Dimmer Five Channel PWM BK7231S"},
-	{ Setup_Device_CalexPowerStrip_900018_1v1_0UK, "Calex UK power strip 900018.1 v1.0 UK"}
+	{ Setup_Device_CalexPowerStrip_900018_1v1_0UK, "Calex UK power strip 900018.1 v1.0 UK"},
+	{ Setup_Device_ArlecCCTDownlight, "Arlec CCT LED Downlight ALD029CHA"}
 };
 
 int g_total_templates = sizeof(g_templates)/sizeof(g_templates[0]);

--- a/src/new_builtin_devices.c
+++ b/src/new_builtin_devices.c
@@ -149,3 +149,22 @@ void Setup_Device_CalexPowerStrip_900018_1v1_0UK() {
 	PIN_SaveToFlash();
 }
 
+// https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694
+void Setup_Device_ArlecCCTDownlight() {
+
+	// WB3L
+	// pins are:
+	// cold white - PWM1 = P6
+	// warm white - PWM2 = P24
+
+	PIN_ClearPins();
+
+	// cold white
+	PIN_SetPinChannelForPinIndex(6, 1);
+	PIN_SetPinRoleForPinIndex(6, IOR_PWM);
+	// warm white
+	PIN_SetPinChannelForPinIndex(24, 2);
+	PIN_SetPinRoleForPinIndex(24, IOR_PWM);
+
+	PIN_SaveToFlash();
+}

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -47,6 +47,7 @@ void Setup_Device_IntelligentLife_NF101A();
 void Setup_Device_TuyaLEDDimmerSingleChannel();
 void Setup_Device_CalexLEDDimmerFiveChannel();
 void Setup_Device_CalexPowerStrip_900018_1v1_0UK();
+void Setup_Device_ArlecCCTDownlight();
 
 #endif
 


### PR DESCRIPTION
Add quick config for [Arlec CCT 9W Downlight](https://www.bunnings.com.au/arlec-grid-connect-smart-9w-cct-led-downlight_p0168694) using WB3L chip. Flashable via UART after simple disassembly of power supply box.