### PR TITLE
fix: MQTT client never gets created

### DIFF
--- a/src/user_main.c
+++ b/src/user_main.c
@@ -156,7 +156,11 @@ static void app_led_timer_handler(void *data)
 			example_do_connect(mqtt_client);
 			loopsWithDisconnected = 0;
 		}
-	}
+	} else if (mqtt_client == 0) {
+        mqtt_client = mqtt_client_new();
+        example_do_connect(mqtt_client);
+        loopsWithDisconnected = 0;
+    }
 
 	g_secondsElapsed ++;
   ADDLOG_INFO(LOG_FEATURE_MAIN, "Timer is %i free mem %d\n", g_secondsElapsed, xPortGetFreeHeapSize());


### PR DESCRIPTION
After the shuffling of `mqtt_client_new()` in fac54bd376695981d9447f37f5e1ad834b517a89 it seemed to never get called even in the timer loop since `mqtt_client` was always == 0 and never initialsed the first time. Feel free to cancel if @btsimonh has already fixed.