### PR TITLE
fix: send pwm values (0...100) back via MQTT

### DIFF
--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -64,7 +64,7 @@ void example_publish(mqtt_client_t *client, int channel, int iVal)
 	char pub_payload[128];
 //  const char *pub_payload= "{\"temperature\": \"45.5\"}";
   err_t err;
-  int myValue;
+  //int myValue;
   u8_t qos = 2; /* 0 1 or 2, see MQTT specification */
   u8_t retain = 0; /* No don't retain such crappy payload... */
 	const char *baseName;
@@ -76,8 +76,8 @@ void example_publish(mqtt_client_t *client, int channel, int iVal)
 		return;
   }
 
-  myValue = CHANNEL_Check(channel);
-   sprintf(pub_payload,"%i",myValue);
+  //myValue = CHANNEL_Check(channel);
+   sprintf(pub_payload,"%i",iVal);
    
     PR_NOTICE("calling pub: \n");
 

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -277,19 +277,18 @@ void Channel_OnChanged(int ch) {
 	iVal = g_channelValues[ch];
 	bOn = iVal > 0;
 
-	if(g_channelChangeCallback!=0) {
-		g_channelChangeCallback(ch,iVal);
-	}
-
 	for(i = 0; i < GPIO_MAX; i++) {
 		if(g_pins.channels[i] == ch) {
 			if(g_pins.roles[i] == IOR_Relay || g_pins.roles[i] == IOR_LED) {
 				RAW_SetPinValue(i,bOn);
+				g_channelChangeCallback(ch,bOn);
 			}
 			if(g_pins.roles[i] == IOR_Relay_n || g_pins.roles[i] == IOR_LED_n) {
 				RAW_SetPinValue(i,!bOn);
+				g_channelChangeCallback(ch,bOn);
 			}
 			if(g_pins.roles[i] == IOR_PWM) {
+				g_channelChangeCallback(ch,iVal);
 				int pwmIndex = PIN_GetPWMIndexForPinIndex(i);
 
 #if WINDOWS
@@ -299,10 +298,7 @@ void Channel_OnChanged(int ch) {
 #else
 				// they are using 1kHz PWM
 				// See: https://www.elektroda.pl/rtvforum/topic3798114.html
-				float f;
-				f = g_channelValues[ch] * 0.01f;
-				bk_pwm_update_param(pwmIndex, 1000, f * 1000.0f);
-
+				bk_pwm_update_param(pwmIndex, 1000, iVal * 10.0f); // Duty cycle 0...100 * 10.0 = 0...1000
 #endif
 			}
 			


### PR DESCRIPTION
MQTT publish was only sending 0 or 1 even for PWM pins. Refactored `Channel_OnChanged` to still send 0/1 for relay & led pins but 0...100 for PWM enabled pins.