### PR TITLE
feat: add MQTT will and availability topic

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -835,6 +835,8 @@ int HTTP_ProcessPacket(http_request_t *request) {
 					poststr(request,"    payload_on: 0\n");
 					poststr(request,"    payload_off: 1\n");
 					poststr(request,"    retain: true\n");
+					sprintf(tmpA,"    availability_topic: \"%s/connected\"\n",baseName);
+					poststr(request,tmpA);
 				}
 			}
 		}
@@ -858,6 +860,8 @@ int HTTP_ProcessPacket(http_request_t *request) {
 					poststr(request,"    payload_off: 0\n");
 					poststr(request,"    retain: true\n");
 					poststr(request,"    optimistic: true\n");
+					sprintf(tmpA,"    availability_topic: \"%s/connected\"\n",baseName);
+					poststr(request,tmpA);
 				}
 			}
 		}

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -184,6 +184,14 @@ static void mqtt_connection_cb(mqtt_client_t *client, void *arg, mqtt_connection
       PR_NOTICE("mqtt_subscribe return: %d\n", err);
     }
 
+    sprintf(tmp,"%s/connected",baseName);
+    err = mqtt_publish(client, tmp, "online", strlen("online"), 2, true, mqtt_pub_request_cb, 0);
+    if(err != ERR_OK) {
+      PR_NOTICE("Publish err: %d\n", err);
+      if(err == ERR_CONN) {
+      // g_my_reconnect_mqtt_after_time = 5;
+      }
+    }
 
     //mqtt_sub_unsub(client,
     //        "topic_qos1", 1,
@@ -205,6 +213,7 @@ void example_do_connect(mqtt_client_t *client)
   const char *mqtt_userName, *mqtt_host, *mqtt_pass, *mqtt_clientID;
   int mqtt_port;
   struct hostent* hostEntry;
+  char will_topic[32];
 
   mqtt_userName = CFG_GetMQTTUserName();
   mqtt_pass = CFG_GetMQTTPass();
@@ -231,7 +240,12 @@ void example_do_connect(mqtt_client_t *client)
   mqtt_client_info.client_id = mqtt_clientID;
   mqtt_client_info.client_pass = mqtt_pass;
   mqtt_client_info.client_user = mqtt_userName;
-
+  
+	sprintf(will_topic,"%s/connected",CFG_GetShortDeviceName());
+  mqtt_client_info.will_topic = will_topic;
+  mqtt_client_info.will_msg = "offline";
+  mqtt_client_info.will_retain = true,
+  mqtt_client_info.will_qos = 2,
 
   hostEntry = gethostbyname(mqtt_host);
   if (NULL != hostEntry){


### PR DESCRIPTION
Uses library `will_topic` and `will_msg` to create a "Last Will and Testament" availability topic to enable Home Assistant (or other MQTT clients) to determine if the device is online or not. 

MQTT broker automatically sends `offline` when the client disconnects and added `online` publish on successful broker connection