### PR TITLE
Littlefs - more

### DIFF
--- a/src/httpserver/http_tcp_server.c
+++ b/src/httpserver/http_tcp_server.c
@@ -57,7 +57,9 @@ static void tcp_client_thread( beken_thread_arg_t arg )
 
   request.fd = fd;
   request.received = buf;
-  request.receivedLen = recv( fd, request.received, 1024, 0 );
+  request.receivedLenmax = 1024;
+  request.responseCode = HTTP_RESPONSE_OK;
+  request.receivedLen = recv( fd, request.received, request.receivedLenmax, 0 );
   request.received[request.receivedLen] = 0;
 
   request.reply = reply;

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -48,10 +48,11 @@ Connection: keep-alive
 
 #define DEFAULT_OTA_URL "http://raspberrypi:1880/firmware"
 
-const char httpHeader[] = "HTTP/1.1 200 OK\nContent-type: " ;  // HTTP header
+const char httpHeader[] = "HTTP/1.1 %d OK\nContent-type: %s" ;  // HTTP header
 const char httpMimeTypeHTML[] = "text/html" ;              // HTML MIME type
 const char httpMimeTypeText[] = "text/plain" ;           // TEXT MIME type
 const char httpMimeTypeJson[] = "application/json" ;           // TEXT MIME type
+const char httpMimeTypeBinary[] = "application/octet-stream" ;   // binary/file MIME type
 const char htmlHeader[] = "<!DOCTYPE html><html><body>" ;
 const char htmlEnd[] = "</body></html>" ;
 const char htmlReturnToMenu[] = "<a href=\"index\">Return to menu</a>";;
@@ -73,7 +74,8 @@ const char *methodNames[] = {
 #define os_malloc malloc
 #endif
 
-
+void misc_formatUpTimeString(int totalSeconds, char *o);
+int Time_getUpTimeSeconds();
 
 typedef struct http_callback_tag {
     char *url;
@@ -150,8 +152,7 @@ bool http_checkUrlBase(const char *base, const char *fileName) {
 }
 
 void http_setup(http_request_t *request, const char *type){
-	poststr(request,httpHeader);
-	poststr(request,type);
+	hprintf128(request, httpHeader, request->responseCode, type);
 	poststr(request,"\r\n"); // next header
 	poststr(request,httpCorsHeaders);
 	poststr(request,"\r\n"); // end headers with double CRLF
@@ -390,7 +391,7 @@ void misc_formatUpTimeString(int totalSeconds, char *o) {
 
 int hprintf128(http_request_t *request, const char *fmt, ...){
   va_list argList;
-  BaseType_t taken;
+  //BaseType_t taken;
 	char tmp[128];
 	va_start(argList, fmt);
 	vsprintf(tmp, fmt, argList);
@@ -494,6 +495,7 @@ int HTTP_ProcessPacket(http_request_t *request) {
 	} while(1);
 
 	request->bodystart = p;
+	request->bodylen = request->receivedLen - (p - request->received); 
 
 	// we will make this more general
 	http_getArg(urlStr,"a",tmpA,sizeof(tmpA));

--- a/src/httpserver/new_http.h
+++ b/src/httpserver/new_http.h
@@ -4,17 +4,26 @@ extern const char httpHeader[];  // HTTP header
 extern const char httpMimeTypeHTML[];              // HTML MIME type
 extern const char httpMimeTypeText[];           // TEXT MIME type
 extern const char httpMimeTypeJson[];
+extern const char httpMimeTypeBinary[];
 extern const char htmlHeader[];
 extern const char htmlEnd[];
 extern const char htmlReturnToMenu[];
 
 extern const char *htmlPinRoleNames[];
 
+
+#define HTTP_RESPONSE_OK 200
+#define HTTP_RESPONSE_NOT_FOUND 404
+#define HTTP_RESPONSE_SERVER_ERROR 500
+
+
+
 #define MAX_QUERY 16 
 #define MAX_HEADERS 16
 typedef struct http_request_tag {
     char *received; // partial or whole received data, up to 1024
     int receivedLen;
+    int receivedLenmax; // sizeof received
 
     // filled by HTTP_ProcessPacket
     int method;
@@ -25,7 +34,9 @@ typedef struct http_request_tag {
     int numheaders;
     char *headers[MAX_HEADERS];
     char *bodystart; /// start start of the body (maybe all of it)
+    int bodylen;
     int contentLength;
+    int responseCode;
 
     // used to respond
     char *reply;
@@ -38,6 +49,7 @@ typedef struct http_request_tag {
 int HTTP_ProcessPacket(http_request_t *request);
 void http_setup(http_request_t *request, const char *type);
 int poststr(http_request_t *request, const char *str);
+int postany(http_request_t *request, const char *str, int len);
 void misc_formatUpTimeString(int totalSeconds, char *o);
 
 // poststr with format - for results LESS THAN 128

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -12,6 +12,7 @@
 #include "lwip/sockets.h"
 
 
+
 extern int g_reset;
 
 extern UINT32 flash_read(char *user_buf, UINT32 count, UINT32 address);
@@ -110,12 +111,12 @@ static int http_rest_get_lfs_file(http_request_t *request){
     int total = 0;
     lfs_file_t *file;
 
-    fpath = malloc(strlen(request->url) - strlen("api/lfs/") + 1);
+    fpath = os_malloc(strlen(request->url) - strlen("api/lfs/") + 1);
 
     init_lfs();
 
-    buff = malloc(1024);
-    file = malloc(sizeof(lfs_file_t));
+    buff = os_malloc(1024);
+    file = os_malloc(sizeof(lfs_file_t));
     memset(file, 0, sizeof(lfs_file_t));
 
     strncpy(fpath, request->url + strlen("api/lfs/"), 63);
@@ -165,9 +166,9 @@ static int http_rest_get_lfs_file(http_request_t *request){
         hprintf128(request, "{\"fname\":\"%s\",\"error\":%d}", fpath, lfsres);
     }
     poststr(request,NULL);
-    if (fpath) free(fpath);
-    if (file) free(file);
-    if (buff) free(buff);
+    if (fpath) os_free(fpath);
+    if (file) os_free(file);
+    if (buff) os_free(buff);
     return 0;
 }
 
@@ -183,8 +184,8 @@ static int http_rest_post_lfs_file(http_request_t *request){
 
     init_lfs();
 
-    fpath = malloc(strlen(request->url) - strlen("api/lfs/") + 1);
-    file = malloc(sizeof(lfs_file_t));
+    fpath = os_malloc(strlen(request->url) - strlen("api/lfs/") + 1);
+    file = os_malloc(sizeof(lfs_file_t));
     memset(file, 0, sizeof(lfs_file_t));
 
     strcpy(fpath, request->url + strlen("api/lfs/"));
@@ -193,7 +194,7 @@ static int http_rest_post_lfs_file(http_request_t *request){
     folder = strchr(fpath, '/');
     if (folder){
         int folderlen = folder - fpath;
-        folder = malloc(folderlen+1);
+        folder = os_malloc(folderlen+1);
         strncpy(folder, fpath, folderlen);
         ADDLOG_DEBUG(LOG_FEATURE_API, "file is in folder %s try to create", folder);
         lfsres = lfs_mkdir(&lfs, folder);
@@ -253,9 +254,9 @@ static int http_rest_post_lfs_file(http_request_t *request){
     }
 exit:
     poststr(request,NULL);
-    if (folder) free(folder);
-    if (file) free(file);
-    if (fpath) free(fpath);
+    if (folder) os_free(folder);
+    if (file) os_free(file);
+    if (fpath) os_free(fpath);
     return 0;
 }
 
@@ -395,10 +396,10 @@ static int http_rest_post_logconfig(http_request_t *request){
 
     //https://github.com/zserge/jsmn/blob/master/example/simple.c
     //jsmn_parser p;
-    jsmn_parser *p = malloc(sizeof(jsmn_parser));
+    jsmn_parser *p = os_malloc(sizeof(jsmn_parser));
     //jsmntok_t t[128]; /* We expect no more than 128 tokens */
 #define TOKEN_COUNT 128
-    jsmntok_t *t = malloc(sizeof(jsmntok_t)*TOKEN_COUNT);
+    jsmntok_t *t = os_malloc(sizeof(jsmntok_t)*TOKEN_COUNT);
     char *json_str = request->bodystart;
     int json_len = strlen(json_str);
 
@@ -411,8 +412,8 @@ static int http_rest_post_logconfig(http_request_t *request){
     if (r < 0) {
         ADDLOG_ERROR(LOG_FEATURE_API, "Failed to parse JSON: %d", r);
         poststr(request, NULL);
-        free(p);
-        free(t);
+        os_free(p);
+        os_free(t);
         return 0;
     }
 
@@ -420,8 +421,8 @@ static int http_rest_post_logconfig(http_request_t *request){
     if (r < 1 || t[0].type != JSMN_OBJECT) {
         ADDLOG_ERROR(LOG_FEATURE_API, "Object expected", r);
         poststr(request, NULL);
-        free(p);
-        free(t);
+        os_free(p);
+        os_free(t);
         return 0;
     }
 
@@ -453,8 +454,8 @@ static int http_rest_post_logconfig(http_request_t *request){
     }
 
     poststr(request, NULL);
-    free(p);
-    free(t);
+    os_free(p);
+    os_free(t);
     return 0;
 }
 
@@ -510,10 +511,10 @@ static int http_rest_post_pins(http_request_t *request){
 
     //https://github.com/zserge/jsmn/blob/master/example/simple.c
     //jsmn_parser p;
-    jsmn_parser *p = malloc(sizeof(jsmn_parser));
+    jsmn_parser *p = os_malloc(sizeof(jsmn_parser));
     //jsmntok_t t[128]; /* We expect no more than 128 tokens */
 #define TOKEN_COUNT 128
-    jsmntok_t *t = malloc(sizeof(jsmntok_t)*TOKEN_COUNT);
+    jsmntok_t *t = os_malloc(sizeof(jsmntok_t)*TOKEN_COUNT);
     char *json_str = request->bodystart;
     int json_len = strlen(json_str);
 
@@ -528,8 +529,8 @@ static int http_rest_post_pins(http_request_t *request){
         sprintf(tmp,"Failed to parse JSON: %d\n", r);
         poststr(request, tmp);
         poststr(request, NULL);
-        free(p);
-        free(t);
+        os_free(p);
+        os_free(t);
         return 0;
     }
 
@@ -539,8 +540,8 @@ static int http_rest_post_pins(http_request_t *request){
         sprintf(tmp,"Object expected\n");
         poststr(request, tmp);
         poststr(request, NULL);
-        free(p);
-        free(t);
+        os_free(p);
+        os_free(t);
         return 0;
     }
 
@@ -588,8 +589,8 @@ static int http_rest_post_pins(http_request_t *request){
     }
 
     poststr(request, NULL);
-    free(p);
-    free(t);
+    os_free(p);
+    os_free(t);
     return 0;
 }
 
@@ -621,7 +622,7 @@ static int http_rest_post_flash(http_request_t *request, int startaddr){
 
     do {
         //ADDLOG_DEBUG(LOG_FEATURE_API, "%d bytes to write", writelen);
-        add_otadata(writebuf, writelen);
+        add_otadata((unsigned char *)writebuf, writelen);
         total += writelen;
         towrite -= writelen;
         if (towrite > 0){
@@ -656,7 +657,7 @@ static int http_rest_get_flash(http_request_t *request, int startaddr, int len){
     char *buffer;
     int res;
 
-    buffer = malloc(1024);
+    buffer = os_malloc(1024);
 
     http_setup(request, httpMimeTypeBinary);
     while(len){

--- a/src/littlefs/lfs_util.h
+++ b/src/littlefs/lfs_util.h
@@ -7,6 +7,8 @@
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H
 
+#include "mem_pub.h"
+
 // Users can override lfs_util.h with their own configuration by defining
 // LFS_CONFIG as a header file to include (-DLFS_CONFIG=lfs_config.h).
 //

--- a/src/littlefs/lfs_util.h
+++ b/src/littlefs/lfs_util.h
@@ -219,7 +219,7 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 // Note, memory must be 64-bit aligned
 static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
-    return malloc(size);
+    return os_malloc(size);
 #else
     (void)size;
     return NULL;
@@ -229,7 +229,7 @@ static inline void *lfs_malloc(size_t size) {
 // Deallocate memory, only used if buffers are not provided to littlefs
 static inline void lfs_free(void *p) {
 #ifndef LFS_NO_MALLOC
-    free(p);
+    os_free(p);
 #else
     (void)p;
 #endif

--- a/src/littlefs/our_lfs.c
+++ b/src/littlefs/our_lfs.c
@@ -13,10 +13,8 @@
 #include "../logging/logging.h"
 #include "flash_pub.h"
 
+
 //https://github.com/littlefs-project/littlefs
-
-
-
 
 
 #ifdef BK_LITTLEFS

--- a/src/littlefs/our_lfs.c
+++ b/src/littlefs/our_lfs.c
@@ -22,6 +22,7 @@
 #ifdef BK_LITTLEFS
 
 // variables used by the filesystem
+int lfs_initialised = 0;
 lfs_t lfs;
 lfs_file_t file;
 
@@ -73,28 +74,30 @@ const struct lfs_config cfg = {
 
 
 void init_lfs(){
-    int err = lfs_mount(&lfs, &cfg);
+    if (!lfs_initialised){
+        int err = lfs_mount(&lfs, &cfg);
 
-    // reformat if we can't mount the filesystem
-    // this should only happen on the first boot
-    if (err) {
-        ADDLOG_INFO(LOG_FEATURE_LFS, "Formatting LFS");
-        lfs_format(&lfs, &cfg);
-        lfs_mount(&lfs, &cfg);
+        // reformat if we can't mount the filesystem
+        // this should only happen on the first boot
+        if (err) {
+            ADDLOG_INFO(LOG_FEATURE_LFS, "Formatting LFS");
+            lfs_format(&lfs, &cfg);
+            lfs_mount(&lfs, &cfg);
+        }
+        // read current count
+        lfs_file_open(&lfs, &file, "boot_count", LFS_O_RDWR | LFS_O_CREAT);
+        lfs_file_read(&lfs, &file, &boot_count, sizeof(boot_count));
+
+        // update boot count
+        boot_count += 1;
+        lfs_file_rewind(&lfs, &file);
+        lfs_file_write(&lfs, &file, &boot_count, sizeof(boot_count));
+
+        // remember the storage is not updated until the file is closed successfully
+        lfs_file_close(&lfs, &file);
+        ADDLOG_INFO(LOG_FEATURE_LFS, "boot count %d", boot_count);
+        lfs_initialised = 1;
     }
-    // read current count
-    lfs_file_open(&lfs, &file, "boot_count", LFS_O_RDWR | LFS_O_CREAT);
-    lfs_file_read(&lfs, &file, &boot_count, sizeof(boot_count));
-
-    // update boot count
-    boot_count += 1;
-    lfs_file_rewind(&lfs, &file);
-    lfs_file_write(&lfs, &file, &boot_count, sizeof(boot_count));
-
-    // remember the storage is not updated until the file is closed successfully
-    lfs_file_close(&lfs, &file);
-    ADDLOG_INFO(LOG_FEATURE_LFS, "boot count %d", boot_count);
-
 }
 
 

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -6,9 +6,10 @@
 
 // comment out to remove component
 
-
 // comment out to remove littlefs
 #define BK_LITTLEFS
+
+// add further app wide defined here, and used them to control build inclusion.
 
 
 #endif

--- a/src/ota/ota.c
+++ b/src/ota/ota.c
@@ -61,8 +61,6 @@ void close_ota(){
 void add_otadata(unsigned char *data, int len){
     if (!sector) return;
     //addLog("OTA DataRxed start: %02.2x %02.2x len %d\r\n", data[0], data[1], len);
-    addLog(".");
-
     while (len){
         if (sectorlen < SECTOR_SIZE){
             int lenstore = SECTOR_SIZE - sectorlen;
@@ -85,7 +83,9 @@ void add_otadata(unsigned char *data, int len){
 }
 
 static void store_sector(unsigned int addr, unsigned char *data){
-    addLog("X");
+    if (!(addr % 0x4000)){
+      addLog("%x", addr);
+    }
     //addLog("writing OTA, addr 0x%x\n", addr);
     flash_ctrl(CMD_FLASH_WRITE_ENABLE, (void *)0);
     flash_ctrl(CMD_FLASH_ERASE_SECTOR, &addr);

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -60,6 +60,12 @@ static int g_secondsElapsed = 0;
 
 static int g_openAP = 0;
 
+// reset in this number of seconds
+int g_reset = 0;
+// from wlan_ui.c
+void bk_reboot(void);
+
+
 int Time_getUpTimeSeconds() {
 	return g_secondsElapsed;
 }
@@ -172,6 +178,14 @@ static void app_led_timer_handler(void *data)
     if (0 == g_openAP){
       setup_wifi_open_access_point();
     }
+  }
+
+
+  if (g_reset){
+      g_reset--;
+      if (!g_reset){
+        bk_reboot(); 
+      }
   }
 }
 


### PR DESCRIPTION
Looking pretty good now....

lfs file endpoints - 
POST /api/lfs/folder/filename to write a file.  
GET /api/lfs/folder/filename to read/serve a file.

add reboot POST /api/reboot (3 second delay)
add OTA POST /api/ota (not used this yet, but below work well)
add fs backup GET /api/fsblock (reads as 512k file)
add fs flash POST /api/fsblock (writes the data your provide - should be a 512k little FS image)

Note: LittleFS blocks are at OTA + 0x1000 (so we don't write the header).
It's overwritten by OTA, hence the ability to backup and restore it.....

I still have random crashes/disconnects.  serial logs have some clues, so will try to 'catch it at it' and look into the logs.
Most likely we still have some thread conflict issues.
