### PR TITLE
Add Quickconfig for Smart-PFW02-G

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -307,7 +307,8 @@ template_t g_templates [] = {
 	{ Setup_Device_CalexPowerStrip_900018_1v1_0UK, "Calex UK power strip 900018.1 v1.0 UK"},
 	{ Setup_Device_ArlecCCTDownlight, "Arlec CCT LED Downlight ALD029CHA"},
 	{ Setup_Device_NedisWIFIPO120FWT_16A, "Nedis WIFIPO120FWT 16A"},
-	{ Setup_Device_NedisWIFIP130FWT_10A, "Nedis WIFIP130FWT 10A"}
+	{ Setup_Device_NedisWIFIP130FWT_10A, "Nedis WIFIP130FWT 10A"},
+	{ Setup_Device_TuyaSmartPFW02G, "Tuya Smart PFW02-G"}
 	
 };
 

--- a/src/new_builtin_devices.c
+++ b/src/new_builtin_devices.c
@@ -221,3 +221,24 @@ void Setup_Device_NedisWIFIP130FWT_10A() {
 
 	PIN_SaveToFlash();
 }
+
+// https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456
+// Marked as Smart-PFW02-G
+// Relay (with npn-transistor) at PWM4 P24
+// Button PWM5 P26
+// LED PWM1 P7
+void Setup_Device_TuyaSmartPFW02G() {
+	PIN_ClearPins();
+
+	PIN_SetPinRoleForPinIndex(24, IOR_Relay_n);
+	PIN_SetPinChannelForPinIndex(24, 1);
+
+	PIN_SetPinRoleForPinIndex(26, IOR_Button);
+	PIN_SetPinChannelForPinIndex(26, 1);
+
+	PIN_SetPinRoleForPinIndex(7, IOR_LED);
+	PIN_SetPinChannelForPinIndex(7, 1);
+
+
+	PIN_SaveToFlash();
+}

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -63,6 +63,7 @@ void Setup_Device_CalexPowerStrip_900018_1v1_0UK();
 void Setup_Device_ArlecCCTDownlight();
 void Setup_Device_NedisWIFIPO120FWT_16A();
 void Setup_Device_NedisWIFIP130FWT_10A();
+void Setup_Device_TuyaSmartPFW02G();
 
 #endif
 


### PR DESCRIPTION
Quickconfig for what seems to be a "clean" Relabeled Tuya Smart-PFW02-G. One relay, One button, one LED.

https://www.tokmanni.fi/alypistorasia-home-connect-ip20-6419860720456