### PR TITLE
use Git version

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -65,7 +65,7 @@ const char htmlHeader[] = "<!DOCTYPE html><html><body>" ;
 const char htmlEnd[] = "</body></html>" ;
 const char htmlReturnToMenu[] = "<a href=\"index\">Return to menu</a>";;
 const char htmlReturnToCfg[] = "<a href=\"cfg\">Return to cfg</a>";;
-const char *g_build_str = "Build on " __DATE__ " " __TIME__;
+const char *g_build_str = "Build on " __DATE__ " " __TIME__ " version " USER_SW_VER; // Show GIT version at Build line
 
 const char httpCorsHeaders[] = "Access-Control-Allow-Origin: *\r\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept" ;           // TEXT MIME type
 


### PR DESCRIPTION
This change goes together with the pull request in the build_app.sh for the https://github.com/openshwprojects/OpenBK7231T/ repository.
This sets the version to be the Git version, easier to recall and automatically increased.

All lines are changed automatically by Github due to mixed Line Endings, now all Windows-style
Only real change is on line 68