### PR TITLE
Logcmnd

### DIFF
--- a/src/drv_tuyaMCU.c
+++ b/src/drv_tuyaMCU.c
@@ -23,6 +23,10 @@
 
 void TuyaMCU_RunFrame();
 
+// from http_fns.  should move to a utils file.
+extern unsigned char hexbyte( const char* hex );
+
+
 const char *TuyaMCU_GetCommandTypeLabel(int t) {
 	if(t == TUYA_CMD_HEARTBEAT)
 		return "Hearbeat";

--- a/src/drv_tuyaMCU.h
+++ b/src/drv_tuyaMCU.h
@@ -1,3 +1,5 @@
 
 
 void TuyaMCU_Init();
+void TuyaMCU_RunFrame();
+void TuyaMCU_Send(byte *data, int size);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -616,14 +616,14 @@ int http_fn_flash_read_tool(http_request_t *request) {
 }
 
 int http_fn_cmd_tool(http_request_t *request) {
-    int res;
-    int rem;
-    int now;
-    int nowOfs;
-    int hex;
+    //int res;
+    //int rem;
+    //int now;
+    //int nowOfs;
+    //int hex;
     int i;
 	char tmpA[128];
-	char tmpB[64];
+	//char tmpB[64];
 
     http_setup(request, httpMimeTypeHTML);
     poststr(request,htmlHeader);
@@ -671,7 +671,7 @@ int http_fn_uart_tool(http_request_t *request) {
     if(http_getArg(request->url,"data",tmpA,sizeof(tmpA))) {
         hprintf128(request,"<h3>Sent %s!</h3>",tmpA);
 		if(0){
-			TuyaMCU_Send(tmpA, strlen(tmpA));
+			TuyaMCU_Send((byte *)tmpA, strlen(tmpA));
 		//	bk_send_string(0,tmpA);
 		} else {
 			byte b;

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -5,6 +5,7 @@
 #include "../new_cfg.h"
 #include "../ota/ota.h"
 #include "../new_cmd.h"
+#include "../drv_tuyaMCU.h"
 
 #ifdef WINDOWS
     // nothing

--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -6,6 +6,7 @@
 #include "../httpserver/new_http.h"
 #include "str_pub.h"
 #include "../logging/logging.h"
+#include "../new_cmd.h"
 
 SemaphoreHandle_t g_mutex = 0;
 static char tmp[1024];
@@ -32,7 +33,9 @@ char *logfeaturenames[] = {
     "GEN:", //              = 7
     "API:", // = 8
     "LFS:", // = 9
+    "CMD:", // = 10
 };
+
 
 #ifdef DEBUG_USE_SIMPLE_LOGGER
 
@@ -135,6 +138,9 @@ static void initLog() {
     HTTP_RegisterCallback( "/logs", HTTP_GET, http_getlog);
     HTTP_RegisterCallback( "/lograw", HTTP_GET, http_getlograw);
     bk_printf("Init log done!\r\n");
+
+    CMD_RegisterCommand("loglevel", "", log_command, "set log level <0..6>", NULL);
+    CMD_RegisterCommand("logfeature", "", log_command, "set log feature filter, <0..10> <0|1>", NULL);
 }
 
 // adds a log to the log memory
@@ -454,6 +460,55 @@ static int http_getlog(http_request_t *request){
 }
 
 
+int log_command(const void *context, const char *cmd, char *args){
+    int result = 0;
+    if (!cmd) return -1;
+    if (!args) return -1;
+    do{
+        if (!stricmp(cmd, "loglevel")){
+            int res, level;
+            res = sscanf(args, "%d", &level);
+            if (res == 1){
+                if ((level >= 0) && (level <= 9)){
+                    loglevel = level;
+                    result = 1;
+                    ADDLOG_DEBUG(LOG_FEATURE_CMD, "loglevel set %d", level);
+                } else {
+                    ADDLOG_ERROR(LOG_FEATURE_CMD, "loglevel %d out of range", level);
+                    result = -1;
+                }
+            } else {
+                ADDLOG_ERROR(LOG_FEATURE_CMD, "loglevel %s invalid?", args);
+                result = -1;
+            }
+            break;
+        }
+        if (!stricmp(cmd, "logfeature")){
+            int res, feat;
+            int val = 1;
+            res = sscanf(args, "%d %d", &feat, &val);
+            if (res >= 1){
+                if ((feat >= 0) && (feat < LOG_FEATURE_MAX)){
+                    logfeatures &= ~(1 << feat);
+                    if (val){
+                        logfeatures |= (1 << feat);
+                    }
+                    ADDLOG_DEBUG(LOG_FEATURE_CMD, "logfeature set 0x%08X", logfeatures);
+                    result = 1;
+                } else {
+                    ADDLOG_ERROR(LOG_FEATURE_CMD, "logfeature %d out of range", feat);
+                    result = -1;
+                }
+            } else {
+                ADDLOG_ERROR(LOG_FEATURE_CMD, "logfeature %s invalid?", args);
+                result = -1;
+            }
+            break;
+        }
+    } while (0);
+
+    return result;
+}
 
 
 #endif

--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -391,7 +391,6 @@ static char tcplogbuf[TCPLOGBUFSIZE];
 static void log_client_thread( beken_thread_arg_t arg )
 {
     int fd = (int) arg;
-    int len = 0;
     while ( 1 ){
         int count = getTcp(tcplogbuf, TCPLOGBUFSIZE);
         if (count){

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -17,6 +17,8 @@
 void addLog(char *fmt, ...);
 void addLogAdv(int level, int feature, char *fmt, ...);
 
+int log_command(const void *context, const char *cmd, char *args);
+
 #define ADDLOG_ERROR(x, y, ...) addLogAdv(LOG_ERROR, x, y, ##__VA_ARGS__)
 #define ADDLOG_WARN(x, y, ...)  addLogAdv(LOG_WARN, x, y, ##__VA_ARGS__)
 #define ADDLOG_INFO(x, y, ...)  addLogAdv(LOG_INFO, x, y, ##__VA_ARGS__)

--- a/src/new_cmd.c
+++ b/src/new_cmd.c
@@ -25,6 +25,12 @@ static int generateHashValue(const char *fname) {
 }
 
 command_t *g_commands[HASH_SIZE];
+static int cmnd_backlog(void * context, const char *cmd, char *args);
+
+void CMD_Init() {
+	CMD_RegisterCommand("backlog", "", cmnd_backlog, "run a sequence of ; separated commands", NULL);
+}
+
 
 void CMD_ListAllCommands(void *userData, void (*callback)(command_t *cmd, void *userData)) {
 	int i;
@@ -183,3 +189,32 @@ int CMD_ExecuteCommand(char *s) {
 */
 }
 
+
+static int cmnd_backlog(const void * context, const char *cmd, char *args){
+	char *subcmd;
+	char *p;
+	int count = 0;
+	if (stricmp(cmd, "backlog")){
+		return -1;
+	}
+	ADDLOG_DEBUG(LOG_FEATURE_CMD, "backlog [%s]", args);
+
+	subcmd = args;
+	p = args;
+	while (*subcmd){
+		while (*p){
+			if (*p == ';'){
+				*p = '\0';
+				p++;
+				break;
+			}
+			p++;
+		}
+		count++;
+		CMD_ExecuteCommand(subcmd);
+		subcmd = p;
+	}
+	ADDLOG_DEBUG(LOG_FEATURE_CMD, "backlog executed %d", count);
+
+	return 1;
+}

--- a/src/new_cmd.h
+++ b/src/new_cmd.h
@@ -11,7 +11,7 @@ typedef struct command_s {
 	struct command_s *next;
 } command_t;
 
-void CMD_Init();
+void CMD_Init(int runautoexec);
 command_t *CMD_Find(const char *name);
 void CMD_RegisterCommand(const char *name, const char *args, commandHandler_t handler, const char *userDesc, void *context);
 // allow modification of s

--- a/src/new_cmd.h
+++ b/src/new_cmd.h
@@ -11,6 +11,7 @@ typedef struct command_s {
 	struct command_s *next;
 } command_t;
 
+void CMD_Init();
 command_t *CMD_Find(const char *name);
 void CMD_RegisterCommand(const char *name, const char *args, commandHandler_t handler, const char *userDesc, void *context);
 // allow modification of s

--- a/src/new_cmd.h
+++ b/src/new_cmd.h
@@ -1,18 +1,20 @@
 
 
-typedef void (*commandHandler_t)();
+typedef int (*commandHandler_t)(const void *context, const char *cmd, char *args);
 
 typedef struct command_s {
 	const char *name;
 	const char *argsFormat;
 	commandHandler_t handler;
 	const char *userDesc;
+	const void *context;
 	struct command_s *next;
 } command_t;
 
 command_t *CMD_Find(const char *name);
-void CMD_RegisterCommand(const char *name, const char *args, commandHandler_t handler, const char *userDesc);
-int CMD_ExecuteCommand(const char *s);
+void CMD_RegisterCommand(const char *name, const char *args, commandHandler_t handler, const char *userDesc, void *context);
+// allow modification of s
+int CMD_ExecuteCommand(char *s);
 // NOTE: argsCount includes commands name, so 1 tells "only command"
 int CMD_GetArgsCount() ;
 // NOTE: arg0 is command name

--- a/src/ntp_time.c
+++ b/src/ntp_time.c
@@ -19,6 +19,7 @@
 
 #else
 #include "lwip/sockets.h"
+#include "logging/logging.h"
 
 
 #endif

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -343,7 +343,6 @@ void user_main(void)
 
 	CFG_InitAndLoad();
 	TuyaMCU_Init();
-  CMD_Init();
   
 	wifi_ssid = CFG_GetWiFiSSID();
 	wifi_pass = CFG_GetWiFiPass();
@@ -406,6 +405,12 @@ void user_main(void)
   // initialise MQTT - just sets up variables.
   // all MQTT happens in timer thread?
   MQTT_init();
+
+
+  // NOTE: this will try to read autoexec.bat,
+  // so ALL commands expected in autoexec.bat should have been registered by now...
+  // but DON't run autoexec if we have had 2+ boot failures
+  CMD_Init(bootFailures < 2);
 
   err = rtos_init_timer(&led_timer,
                         1 * 1000,

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -57,6 +57,7 @@
 #include "flash_config/flash_vars_vars.h"
 #include "drv_tuyaMCU.h"
 #include "ntp_time.h"
+#include "new_cmd.h"
 
 
 #undef Malloc
@@ -342,7 +343,8 @@ void user_main(void)
 
 	CFG_InitAndLoad();
 	TuyaMCU_Init();
-
+  CMD_Init();
+  
 	wifi_ssid = CFG_GetWiFiSSID();
 	wifi_pass = CFG_GetWiFiPass();
 

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -56,6 +56,7 @@
 #include "flash_config/flash_config.h"
 #include "flash_config/flash_vars_vars.h"
 #include "drv_tuyaMCU.h"
+#include "ntp_time.h"
 
 
 #undef Malloc

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -55,6 +55,8 @@
 
 #include "flash_config/flash_config.h"
 #include "flash_config/flash_vars_vars.h"
+#include "drv_tuyaMCU.h"
+
 
 #undef Malloc
 #undef Free


### PR DESCRIPTION
new_cmd - make it not based on globals.  Now command can be re-entrant?
don't parse args in new_cmd - just cmd & args string. (we can have glbal fns to perform this if required, but current implementation not good for "my name" type args.
Add context in command fn structure.  This is generic ptr for any purpose.
modify extsing command usage to fit.
Add logging commands loglevel n and logfeature m n

merge latest, and warning cleanup.