### PR TITLE
tune-ups & bugfixes

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -409,9 +409,9 @@ int HTTP_ProcessPacket(http_request_t *request) {
 	}
 
 	if (request->method == HTTP_GET) {
-		ADDLOG_INFO(LOG_FEATURE_HTTP, "HTTP request\n");
+		//ADDLOG_INFO(LOG_FEATURE_HTTP, "HTTP request\n");
 	} else {
-		ADDLOG_INFO(LOG_FEATURE_HTTP, "Other request\n");
+		//ADDLOG_INFO(LOG_FEATURE_HTTP, "Other request\n");
 	}
 
 	// if OPTIONS, return now - for CORS

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -284,16 +284,17 @@ static int http_rest_get_lfs_file(http_request_t *request){
     file = os_malloc(sizeof(lfs_file_t));
     memset(file, 0, sizeof(lfs_file_t));
 
-    strncpy(fpath, request->url + strlen("api/lfs/"), 63);
+    strcpy(fpath, request->url + strlen("api/lfs/"));
+    
     ADDLOG_DEBUG(LOG_FEATURE_API, "LFS read of %s", fpath);
     lfsres = lfs_file_open(&lfs, file, fpath, LFS_O_RDONLY);
 
     if (lfsres == -21){
         lfs_dir_t *dir;
+        ADDLOG_DEBUG(LOG_FEATURE_API, "%s is a folder", fpath);
         dir = os_malloc(sizeof(lfs_dir_t));
         os_memset(dir, 0, sizeof(*dir));
         // if the thing is a folder.
-        ADDLOG_DEBUG(LOG_FEATURE_API, "%s is a folder", fpath);
         lfsres = lfs_dir_open(&lfs, dir, fpath);
 
         if (lfsres >= 0){
@@ -337,6 +338,7 @@ static int http_rest_get_lfs_file(http_request_t *request){
             hprintf128(request, "{\"fname\":\"%s\",\"error\":%d}", fpath, lfsres);
         }
     } else {
+        ADDLOG_DEBUG(LOG_FEATURE_API, "LFS open [%s] gives %d", fpath, lfsres);
         if (lfsres >= 0){
             const char *mimetype = httpMimeTypeBinary;
             do {

--- a/src/littlefs/our_lfs.c
+++ b/src/littlefs/our_lfs.c
@@ -22,7 +22,7 @@
 // variables used by the filesystem
 int lfs_initialised = 0;
 lfs_t lfs;
-lfs_file_t file;
+//lfs_file_t file;
 
 // from flash.c
 extern UINT32 flash_read(char *user_buf, UINT32 count, UINT32 address);


### PR DESCRIPTION
initialise g_commands (was this the issue?)
debug in exec.
fix a logging bug.
add commands: 
logtype direct|all - set direct to go direct to serial
logdelay <ms> - delay after log so we can see it before a crash? useful in debug.

exec not works as expected.  not sure why LFS was playing up.

