### PR TITLE
Publish UG artifacts in releases for stock OTA

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -88,7 +88,9 @@ jobs:
           name: ${{ env.APP_NAME }}_${{ needs.refs.outputs.version }}
           path: |
             output/${{ needs.refs.outputs.version }}/OpenBK7231T_UA_${{ needs.refs.outputs.version }}.bin
+            output/${{ needs.refs.outputs.version }}/OpenBK7231T_UG_${{ needs.refs.outputs.version }}.bin
             output/${{ needs.refs.outputs.version }}/OpenBK7231N_QIO_${{ needs.refs.outputs.version }}.bin
+            output/${{ needs.refs.outputs.version }}/OpenBK7231N_UG_${{ needs.refs.outputs.version }}.bin
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.rbl
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.img
           if-no-files-found: warn         


### PR DESCRIPTION
Changes the GH workflow to publish UG files (Tuya OTA format) as well. This is useful for users who want a quick n' easy download for a particular OpenBK7231 image to remotely OTA with the stock firmware.