### PR TITLE
fix(ci): Add missing glob pattern to releaserc for UG assets

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -71,6 +71,7 @@ publish:
     addReleases: "bottom"
     assets:
       - path: "output/**/*_UA_*.bin"
+      - path: "output/**/*_UG_*.bin"
       - path: "output/**/*_QIO_*.bin"
       - path: "output/**/*.rbl"
       - path: "output/**/*.img"


### PR DESCRIPTION
Sorry about that, made a mistake in the previous PR #70.
This one fixes it by adding a missing glob pattern for the releases step.