### PR TITLE
Modify startup when in AP mode.

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -653,7 +653,7 @@ int http_fn_flash_read_tool(http_request_t *request) {
     poststr(request,"<label for=\"offset\">offset:</label><br>\
             <input type=\"number\" id=\"offset\" name=\"offset\"");
     hprintf128(request," value=\"%i\"><br>",ofs);
-    poststr(request,"<label for=\"lenght\">lenght:</label><br>\
+    poststr(request,"<label for=\"len\">length:</label><br>\
             <input type=\"number\" id=\"len\" name=\"len\" ");
     hprintf128(request,"value=\"%i\">",len);
     poststr(request,"<br><br>\

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -55,6 +55,8 @@ static int g_my_reconnect_mqtt_after_time = -1;
 ip_addr_t mqtt_ip LWIP_MQTT_EXAMPLE_IPADDR_INIT;
 mqtt_client_t* mqtt_client;
 
+static int mqtt_initialised = 0;
+
 typedef struct mqtt_callback_tag {
     char *topic;
     char *subscriptionTopic;
@@ -595,11 +597,15 @@ void MQTT_init(){
   // note: this may REPLACE an existing entry with the same ID.  ID 2 !!!
   MQTT_RegisterCallback( cbtopicbase, cbtopicsub, 2, tasCmnd);
 
+  mqtt_initialised = 1;
+
 }
 
 
 // called from user timer.
 void MQTT_RunEverySecondUpdate() {
+
+  if (!mqtt_initialised) return;
 
   // if asked to reconnect (e.g. change of topic(s))
   if (mqtt_reconnect > 0){

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -42,6 +42,10 @@ typedef struct pinButton_ {
 	new_btn_callback  cb[BTN_number_of_event];
 }pinButton_s;
 
+// overall pins enable.
+// if zero, all hardware action is disabled.
+char g_enable_pins = 0;
+
 
 #if WINDOWS
 
@@ -72,9 +76,6 @@ typedef struct item_pins_config
 	pinsState_t pins;
 }ITEM_PINS_CONFIG,*ITEM_PINS_CONFIG_PTR;
 
-// overall pins enable.
-// if zero, all hardware action is disabled.
-char g_enable_pins = 0;
 
 void testI2C()
 {
@@ -543,6 +544,7 @@ int PIN_GetPinChannel2ForPinIndex(int index) {
 	return g_pins.channels2[index];
 }
 void RAW_SetPinValue(int index, int iVal){
+	if (g_enable_pins) {
 #if WINDOWS
 
 #elif PLATFORM_XR809
@@ -553,10 +555,9 @@ void RAW_SetPinValue(int index, int iVal){
 
 	HAL_GPIO_WritePin(xr_port, xr_pin, iVal);
 #else
-	if (g_enable_pins) {
 	    bk_gpio_output(index, iVal);
-	}
 #endif
+	}
 }
 void Button_OnShortClick(int index)
 {

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -53,11 +53,13 @@ typedef struct pinsState_s {
 
 extern pinsState_t g_pins;
 
+extern char g_enable_pins;
 
 #define GPIO_MAX 27
 #define CHANNEL_MAX 32
 
 void PIN_Init(void);
+void PIN_SetupPins();
 void PIN_ClearPins();
 int PIN_GetPinRoleForPinIndex(int index);
 int PIN_GetPinChannelForPinIndex(int index);

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -72,6 +72,7 @@ static int g_secondsElapsed = 0;
 
 static int g_openAP = 0;
 static int g_connectToWiFi = 0;
+int bSafeMode = 0;
 
 // reset in this number of seconds
 int g_reset = 0;
@@ -397,8 +398,11 @@ void user_main(void)
   bootFailures = boot_failures();
   if (bootFailures > 3){
     bForceOpenAP = 1;
-		ADDLOGF_INFO("###### force AP mode - boot failures %d", bootFailures);
-  } else {
+    ADDLOGF_INFO("###### force AP mode - boot failures %d", bootFailures);
+  }
+  if (bootFailures > 4){
+    bSafeMode = 1;
+		ADDLOGF_INFO("###### safe mode activated - boot failures %d", bootFailures);
   }
 
 	CFG_InitAndLoad();
@@ -434,7 +438,7 @@ void user_main(void)
 	ADDLOGF_DEBUG("Started http tcp server\r\n");
 
   // only initialise certain things if we are not in AP mode
-  if (!g_openAP){
+  if (!bSafeMode){
     g_enable_pins = 1;
     // this actually sets the pins, moved out so we could avoid if necessary
     PIN_SetupPins();


### PR DESCRIPTION
NOTE:
Builds, but untested.  Please review carefully.

The intent is that by causing three boot failures, (three times less than 30s up time), it goes into AP mode (as it did).  But now, when in AP mode, most configuration is skipped.  Pin config is loaded (so it can be changed), but h/w is not initialised.  mqtt is not initialised (no point in AP mode?), drivers not initialised, etc.

Pls check....

Pins: Separate actual pin h/w config from PIN_LoadFromFlash into new fn PIN_Setup(), so that we can load the pin config without setting it as active.

new variable g_enable_pins - if zero, no h/w config can be done.
new static var mqtt_initialised - set in mqtt_init, used to prevent mqtt__RunEverySecond if mqtt not initialised.
user_main.c - don't enable many functions if in AP mode.