### PR TITLE
feat: add OpenW800 Platform

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [OpenBK7231T, OpenBK7231N, OpenXR809, OpenBL602]
+        platform: [OpenBK7231T, OpenBK7231N, OpenXR809, OpenBL602, OpenW800]
     steps:
       - name: Source checkout
         uses: actions/checkout@v2
@@ -94,6 +94,7 @@ jobs:
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.rbl
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.img
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.bin
+            output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.fls
           if-no-files-found: warn
 
   release:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -95,6 +95,7 @@ jobs:
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.img
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.bin
             output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}.fls
+            output/${{ needs.refs.outputs.version }}/${{ matrix.platform }}_${{ needs.refs.outputs.version }}_ota.img
           if-no-files-found: warn
 
   release:

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/openshwprojects/OpenBL602.git
 [submodule "sdk/OpenW800"]
 	path = sdk/OpenW800
-	url = https://github.com/talltechdude/OpenW800.git
+	url = https://github.com/openshwprojects/OpenW800.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "sdk/OpenBL602"]
 	path = sdk/OpenBL602
 	url = https://github.com/openshwprojects/OpenBL602.git
+[submodule "sdk/OpenW800"]
+	path = sdk/OpenW800
+	url = https://github.com/talltechdude/OpenW800.git

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -78,6 +78,7 @@ publish:
       - path: "output/**/*.rbl"
       - path: "output/**/*.img"
       - path: "output/**/OpenBL602*.bin"
+      - path: "output/**/OpenW800*.fls"
 
 success:
   - "@semantic-release/github"

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -78,7 +78,7 @@ publish:
       - path: "output/**/*.rbl"
       - path: "output/**/*.img"
       - path: "output/**/OpenBL602*.bin"
-      - path: "output/**/OpenW800*.fls"
+      - path: "output/**/OpenW800*"
 
 success:
   - "@semantic-release/github"

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ OpenW800: sdk/OpenW800/tools/w800/csky/bin sdk/OpenW800/sharedAppContainer/share
 	$(MAKE) -C sdk/OpenW800 EXTRA_CCFLAGS=-DPLATFORM_W800 CONFIG_W800_USE_LIB=n CONFIG_W800_TOOLCHAIN_PATH="$(shell realpath sdk/OpenW800/tools/w800/csky/bin)/"
 	mkdir -p output/$(APP_VERSION)
 	cp sdk/OpenW800/bin/w800/w800.fls output/$(APP_VERSION)/OpenW800_$(APP_VERSION).fls
+	cp sdk/OpenW800/bin/w800/w800_ota.img output/$(APP_VERSION)/OpenW800_$(APP_VERSION)_ota.img
 
 # clean .o files and output directory
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,15 @@ OpenBK7231N:
 sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2:
 	cd sdk/OpenXR809/tools && wget -q "https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q2-update/+download/gcc-arm-none-eabi-4_9-2015q2-20150609-linux.tar.bz2" && tar -xf *.tar.bz2 && rm -f *.tar.bz2
 
-OpenXR809: submodules sdk/OpenXR809/project/oxr_sharedApp/shared sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2
+
+	
+.PHONY: OpenXR809 build-XR809
+# Retry OpenXR809 a few times to account for calibration file issues
+RETRY = 3
+OpenXR809:
+	for i in `seq 1 ${RETRY}`; do ($(MAKE) -k build-XR809; echo Finished attempt $$i/${RETRY}); done
+
+build-XR809: submodules sdk/OpenXR809/project/oxr_sharedApp/shared sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2
 	$(MAKE) -C sdk/OpenXR809/src CC_DIR=$(PWD)/sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2/bin
 	$(MAKE) -C sdk/OpenXR809/src install CC_DIR=$(PWD)/sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2/bin
 	$(MAKE) -C sdk/OpenXR809/project/oxr_sharedApp/gcc CC_DIR=$(PWD)/sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2/bin

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ full: clean all
 # Update/init git submodules
 .PHONY: submodules
 submodules:
+ifdef GITHUB_ACTIONS
+	@echo Submodules already checked out during setup
+else
 	git submodule update --init --recursive --remote
+endif
 
 update-submodules: submodules
 	git add sdk/OpenBK7231T sdk/OpenBK7231N sdk/OpenXR809 sdk/OpenBL602
@@ -54,6 +58,11 @@ sdk/OpenXR809/project/oxr_sharedApp/shared:
 sdk/OpenBL602/customer_app/bl602_sharedApp/bl602_sharedApp/shared:
 	@echo Create symlink for $(APP_NAME) into sdk folder
 	ln -s "$(shell pwd)/" "sdk/OpenBL602/customer_app/bl602_sharedApp/bl602_sharedApp/shared"
+
+sdk/OpenW800/sharedAppContainer/sharedApp:
+	@echo Create symlink for $(APP_NAME) into sdk folder
+	@mkdir "sdk/OpenW800/sharedAppContainer"
+	ln -s "$(shell pwd)/" "sdk/OpenW800/sharedAppContainer/sharedApp"
 
 # Build main binaries
 OpenBK7231T:
@@ -84,6 +93,15 @@ OpenBL602: submodules sdk/OpenBL602/customer_app/bl602_sharedApp/bl602_sharedApp
 	mkdir -p output/$(APP_VERSION)
 	cp sdk/OpenBL602/customer_app/bl602_sharedApp/build_out/bl602_sharedApp.bin output/$(APP_VERSION)/OpenBL602_$(APP_VERSION).bin
 
+sdk/OpenW800/tools/w800/csky/bin: submodules
+	mkdir -p sdk/OpenW800/tools/w800/csky
+	cd sdk/OpenW800/tools/w800/csky && wget -q "https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource/1356021/1619529111421/csky-elfabiv2-tools-x86_64-minilibc-20210423.tar.gz" && tar -xf *.tar.gz && rm -f *.tar.gz
+
+OpenW800: sdk/OpenW800/tools/w800/csky/bin sdk/OpenW800/sharedAppContainer/sharedApp
+	$(MAKE) -C sdk/OpenW800 EXTRA_CCFLAGS=-DPLATFORM_W800 CONFIG_W800_USE_LIB=n CONFIG_W800_TOOLCHAIN_PATH="$(shell realpath sdk/OpenW800/tools/w800/csky/bin)/"
+	mkdir -p output/$(APP_VERSION)
+	cp sdk/OpenW800/bin/w800/w800.fls output/$(APP_VERSION)/OpenW800_$(APP_VERSION).fls
+
 # clean .o files and output directory
 .PHONY: clean
 clean: 
@@ -91,6 +109,7 @@ clean:
 	$(MAKE) -C sdk/OpenBK7231N/platforms/bk7231n/bk7231n_os APP_BIN_NAME=$(APP_NAME) USER_SW_VER=$(APP_VERSION) clean
 	$(MAKE) -C sdk/OpenXR809/src clean
 	$(MAKE) -C sdk/OpenXR809/project/oxr_sharedApp/gcc clean
+	$(MAKE) -C sdk/OpenW800 clean
 
 # Add custom Makefile if required
 -include custom.mk

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,9 @@ sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2:
 # Retry OpenXR809 a few times to account for calibration file issues
 RETRY = 3
 OpenXR809:
-	for i in `seq 1 ${RETRY}`; do ($(MAKE) -k build-XR809; echo Finished attempt $$i/${RETRY}); done
+	@for i in `seq 1 ${RETRY}`; do ($(MAKE) -k build-XR809; echo Prebuild attempt $$i/${RETRY}); done
+	@echo Running build final time to check output
+	$(MAKE) build-XR809;
 
 build-XR809: submodules sdk/OpenXR809/project/oxr_sharedApp/shared sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2
 	$(MAKE) -C sdk/OpenXR809/src CC_DIR=$(PWD)/sdk/OpenXR809/tools/gcc-arm-none-eabi-4_9-2015q2/bin


### PR DESCRIPTION
Adding the new OpenW800 platform to the auto-build Github actions and releases.

As before, there's some SDK changes required too in https://github.com/openshwprojects/OpenW800/pull/1 to get this to work and once merged I can update the submodule back to `openshwprojects` repo.

One thing to note though is that each required source files need to be added to the OpenW800's `app/Makefile` similar to the `.project` file under the GUI IDE. Alternatively, we'd could add `#ifdef PLATFORM_W800` to all the `.c` files that aren't required for the W800 and recursively build all `.c` files if the list to exclude is much shorter.