### PR TITLE
feat: add template for Arlec RGB+CCT downlight

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -72,7 +72,7 @@ template_t g_templates [] = {
 	{ Setup_Device_BK7231T_Gosund_Switch_SW5_A_V2_1, "BK7231T Gosund Smart Switch SW5-A-V2.1"},
 	{ Setup_Device_13A_Socket_CB2S, "BK7231N CB2S 13A Aliexpress socket"},
     { Setup_Device_Deta_Smart_Double_Power_Point_6922HA_Series2, "BK7231T DETA SMART Double Power Point 6922HA-Series 2"},
-
+    { Setup_Device_ArlecRGBCCTDownlight, "Arlec RGB+CCT LED Downlight ALD092RHA"},
 };
 
 int g_total_templates = sizeof(g_templates)/sizeof(g_templates[0]);

--- a/src/new_builtin_devices.c
+++ b/src/new_builtin_devices.c
@@ -260,10 +260,41 @@ void Setup_Device_ArlecCCTDownlight() {
 	CFG_ClearPins();
 
 	// cold white
-	PIN_SetPinChannelForPinIndex(6, 1);
+	PIN_SetPinChannelForPinIndex(6, 4);
 	PIN_SetPinRoleForPinIndex(6, IOR_PWM);
 	// warm white
-	PIN_SetPinChannelForPinIndex(24, 2);
+	PIN_SetPinChannelForPinIndex(24, 5);
+	PIN_SetPinRoleForPinIndex(24, IOR_PWM);
+
+	CFG_Save_SetupTimer();
+}
+
+// https://www.bunnings.com.au/arlec-grid-connect-smart-9w-rgb-cct-led-downlight_p0168695
+void Setup_Device_ArlecRGBCCTDownlight() {
+
+	// WB3L
+	// pins are:
+	// red = PWM1 = P8
+	// green = PWM2 = P7
+	// blue = PWM3 = P9
+	// cold white - PWM4 = P6
+	// warm white - PWM5 = P24
+
+	CFG_ClearPins();
+	// red
+	PIN_SetPinChannelForPinIndex(8, 1);
+	PIN_SetPinRoleForPinIndex(8, IOR_PWM);
+	// green
+	PIN_SetPinChannelForPinIndex(7, 2);
+	PIN_SetPinRoleForPinIndex(7, IOR_PWM);
+	// blue
+	PIN_SetPinChannelForPinIndex(9, 3);
+	PIN_SetPinRoleForPinIndex(9, IOR_PWM);
+	// cold white
+	PIN_SetPinChannelForPinIndex(6, 4);
+	PIN_SetPinRoleForPinIndex(6, IOR_PWM);
+	// warm white
+	PIN_SetPinChannelForPinIndex(24, 5);
 	PIN_SetPinRoleForPinIndex(24, IOR_PWM);
 
 	CFG_Save_SetupTimer();

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -201,6 +201,7 @@ void Setup_Device_TuyaLEDDimmerSingleChannel();
 void Setup_Device_CalexLEDDimmerFiveChannel();
 void Setup_Device_CalexPowerStrip_900018_1v1_0UK();
 void Setup_Device_ArlecCCTDownlight();
+void Setup_Device_ArlecRGBCCTDownlight();
 void Setup_Device_NedisWIFIPO120FWT_16A();
 void Setup_Device_NedisWIFIP130FWT_10A();
 void Setup_Device_EmaxHome_EDU8774();


### PR DESCRIPTION
Adding new quick config for [RGB+CCT Arlec Downlight](https://www.bunnings.com.au/arlec-9w-grid-connect-smart-rgb-cct-led-downlight_p0168695).

Also updating my original CCT one to use channels 4 & 5 which seem to be the standard for colour temp mixing currently.