### PR TITLE
feat: add release notes to Github releases

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,16 +26,17 @@ jobs:
         with:
           submodules: recursive        
       - name: Update SDKs if required
-        run: make update-submodules        
+        run: make update-submodules
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           dry_run: true
-          semantic_version: 18
+          semantic_version: 19
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set outputs
@@ -102,7 +103,7 @@ jobs:
     name: Semantic Release Images and Artifacts
     runs-on: ubuntu-latest
     needs: [ refs, build ]
-    if: always() && needs.refs.outputs.new_release == 'true' && github.ref == 'refs/heads/main'
+    if: always() && needs.refs.outputs.new_release == 'true' && (github.ref == 'refs/heads/main' || github.ref_name == 'alpha')
     steps:
       - name: Source checkout
         uses: actions/checkout@v2
@@ -113,13 +114,14 @@ jobs:
           path: output/${{ needs.refs.outputs.version }}
       - name: Run Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           dry_run: false
-          semantic_version: 18
+          semantic_version: 19
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Echo Semantic Release Versions

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -94,18 +94,18 @@ generateNotes:
 
         ### Assets
         Refer to the following table for the usage of the various assests included in this release
-        | Filename                                                                                                                           | Platform | Usage      |
-        | ---                                                                                                                                | ---      | ---        |
-        | [OpenBK7231T_{{version}}.rbl]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_{{version}}.rbl)         | BK7231T  | OTA Update |
-        | [OpenBK7231T_UG_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_UG_{{version}}.bin)   | BK7231T  | UART Flash |
-        | [OpenBK7231T_UA_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_UA_{{version}}.bin)   | BK7231T  |            |
-        | [OpenBK7231N_{{version}}.rbl]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_{{version}}.rbl)         | BK7231N  | OTA Update |
-        | [OpenBK7231N_UG_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_UG_{{version}}.bin)   | BK7231N  | UART Flash |
-        | [OpenBK7231N_QIO_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_QIO_{{version}}.bin) | BK7231N  | SPI Flash  |
-        | [OpenXR809_{{version}}.img]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenXR809_{{version}}.img)             | XR809    |            |
-        | [OpenBL602_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBL602_{{version}}.bin)             | BL602    | UART Flash |
-        | [OpenW800_{{version}}_ota.img]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenW800_{{version}}_ota.img)       | W800     | OTA Update |
-        | [OpenW800_{{version}}.fls]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenW800_{{version}}.fls)               | W800     | UART Flash |
+        | Platform | Usage      | Filename                                                                                                                           |
+        | ---      | ---        | ---                                                                                                                                |
+        | BK7231T  | OTA Update | [OpenBK7231T_{{version}}.rbl]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_{{version}}.rbl)         |
+        | BK7231T  | UART Flash | [OpenBK7231T_UG_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_UG_{{version}}.bin)   |
+        | BK7231T  |            | [OpenBK7231T_UA_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_UA_{{version}}.bin)   |
+        | BK7231N  | OTA Update | [OpenBK7231N_{{version}}.rbl]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_{{version}}.rbl)         |
+        | BK7231N  | UART Flash | [OpenBK7231N_UG_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_UG_{{version}}.bin)   |
+        | BK7231N  | SPI Flash  | [OpenBK7231N_QIO_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_QIO_{{version}}.bin) |
+        | XR809    |            | [OpenXR809_{{version}}.img]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenXR809_{{version}}.img)             |
+        | BL602    | UART Flash | [OpenBL602_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBL602_{{version}}.bin)             |
+        | W800     | OTA Update | [OpenW800_{{version}}_ota.img]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenW800_{{version}}_ota.img)       |
+        | W800     | UART Flash | [OpenW800_{{version}}.fls]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenW800_{{version}}.fls)               |
 
         Flashing instructions are available on the project's [README.md]({{host}}/{{owner}}/{{repository}}#readme)
     preset: conventionalcommits
@@ -121,7 +121,7 @@ generateNotes:
           section: "Bug Fixes"
           hidden: false
         - type: "chore"
-          section: "Bug Fixes"
+          section: "Changes"
           hidden: false
         - type: "docs"
           section: "Changes"

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,5 +1,7 @@
 branches: 
   - 'main'
+  - name: 'alpha'
+    prerelease: true
 preset: "angular"
 tagFormat: "${version}"
 plugins:
@@ -40,34 +42,110 @@ generateNotes:
         - "perf"
         - "fix"
       commitsSort: "header"
-    types:
-    - type: "feat"
-    - section: "Features"
-    # Tracked bug fix with a hotfix branch
-    - type: "hotfix"
-    - section: "Bug Fixes"
-    # Uninmportent fix (CI testing, etc)
-    - type: "fix"
-    - section: "Bug Fixes"
-    - type: "chore"
-    - section: "Bug Fixes"
-    - type: "docs"
-    - hidden: true
-    - type: "doc"
-    - hidden: true
-    - type: "style"
-    - hidden: true
-    - type: "refactor"
-    - hidden: true
-    - type: "perf"
-    - hidden: true
-    - type: "test"
-    - hidden: true
-    presetConfig: true
+      mainTemplate: |
+        {{> header}}
+
+        {{#if noteGroups}}
+        {{#each noteGroups}}
+
+        ### ⚠ {{title}}
+
+        {{#each notes}}
+        * {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}
+        {{/each}}
+        {{/each}}
+        {{/if}}
+        {{#each commitGroups}}
+
+        {{#if title}}
+        ### {{title}}
+
+        {{/if}}
+        {{#each commits}}
+        {{> commit root=@root}}
+        {{/each}}
+
+        {{/each}}
+
+        {{> footer}}
+      headerPartial: |
+        ## OpenBK7231T/OpenBeken release {{version}}
+        
+        OpenBK7231T/OpenBeken is a Tasmota/Esphome replacement for new Tuya modules featuring MQTT and Home Assistant compatibility. This repository is named <code>OpenBK7231T_App</code>, but now it's a multiplatform app, supporting build for multiple separate chips:
+
+        - BK7231T (WB3S, WB2S, WB2L, etc)
+        - BK7231N (CB2S, CB2L, WB2L_M1, etc)
+        - T34 (T34 is based on BK7231N)
+        - XR809 (XR3, etc)
+        - BL602
+        - W800 (W800-C400, WinnerMicro WiFi & Bluetooth), W801
+
+      footerPartial: |
+        {{#if noteGroups}}
+        {{#each noteGroups}}
+
+        ### {{title}}
+
+        {{#each notes}}
+        * {{text}}
+        {{/each}}
+        {{/each}}
+        {{/if}}
+
+        ### Assets
+        Refer to the following table for the usage of the various assests included in this release
+        | Filename                                                                                                                           | Platform | Usage      |
+        | ---                                                                                                                                | ---      | ---        |
+        | [OpenBK7231T_{{version}}.rbl]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_{{version}}.rbl)         | BK7231T  | OTA Update |
+        | [OpenBK7231T_UG_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_UG_{{version}}.bin)   | BK7231T  | UART Flash |
+        | [OpenBK7231T_UA_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231T_UA_{{version}}.bin)   | BK7231T  |            |
+        | [OpenBK7231N_{{version}}.rbl]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_{{version}}.rbl)         | BK7231N  | OTA Update |
+        | [OpenBK7231N_UG_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_UG_{{version}}.bin)   | BK7231N  | UART Flash |
+        | [OpenBK7231N_QIO_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBK7231N_QIO_{{version}}.bin) | BK7231N  | SPI Flash  |
+        | [OpenXR809_{{version}}.img]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenXR809_{{version}}.img)             | XR809    |            |
+        | [OpenBL602_{{version}}.bin]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenBL602_{{version}}.bin)             | BL602    | UART Flash |
+        | [OpenW800_{{version}}_ota.img]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenW800_{{version}}_ota.img)       | W800     | OTA Update |
+        | [OpenW800_{{version}}.fls]({{host}}/{{owner}}/{{repository}}/releases/download/{{version}}/OpenW800_{{version}}.fls)               | W800     | UART Flash |
+
+        Flashing instructions are available on the project's [README.md]({{host}}/{{owner}}/{{repository}}#readme)
+    preset: conventionalcommits
+    presetConfig:
+      types:
+        - type: "feat"
+          section: "Features"
+        # Tracked bug fix with a hotfix branch
+        - type: "hotfix"
+          section: "Bug Fixes"
+        # Uninmportent fix (CI testing, etc)
+        - type: "fix"
+          section: "Bug Fixes"
+          hidden: false
+        - type: "chore"
+          section: "Bug Fixes"
+          hidden: false
+        - type: "docs"
+          section: "Changes"
+          hidden: false
+        - type: "doc"
+          section: "Changes"
+          hidden: false
+        - type: "style"
+          section: "Changes"
+          hidden: false
+        - type: "refactor"
+          section: "Changes"
+          hidden: false
+        - type: "perf"
+          section: "Changes"
+          hidden: false
+        - type: "test"
+          section: "Changes"
+          hidden: false
+        - type: ""
+          section: "Changes"
+          hidden: false          
 prepare:
   - path: "@semantic-release/git"
-  - path: "@semantic-release/changelog"
-    changelogFile: "CHANGELOG.md"
 publish:
   - path: "@semantic-release/github"
     addReleases: "bottom"


### PR DESCRIPTION
Updated the automated release tooling to produce human-readable Release Notes for the GitHub releases with better change logs and a table explaining what each release asset is for (to the best of my knowledge at least). Also helps somewhat with https://github.com/openshwprojects/OpenBK7231T_App/issues/112.

Example in an alpha release on my dev repo here: https://github.com/talltechdude/OpenBK7231T_App/releases/tag/1.0.0-alpha.10