### PR TITLE
Public more device statuses via MQTT

### DIFF
--- a/src/hal/bk7231/hal_adc_bk7231.c
+++ b/src/hal/bk7231/hal_adc_bk7231.c
@@ -24,7 +24,7 @@ static int adcToGpio[] = {
 	12,//GPIO12, // ADC6
 	13,//GPIO13, // ADC7
 };
-static int c_adcToGpio = sizeof(adcToGpio)/sizeof(adcToGpio[0]);
+//static int c_adcToGpio = sizeof(adcToGpio)/sizeof(adcToGpio[0]);
 
 
 static uint8_t gpioToAdc(int gpio) {

--- a/src/hal/bk7231/hal_wifi_bk7231.c
+++ b/src/hal/bk7231/hal_wifi_bk7231.c
@@ -160,6 +160,13 @@ void HAL_PrintNetworkInfo(){
 
 }
 
+int HAL_GetWifiStrength() {
+    LinkStatusTypeDef linkStatus;
+    os_memset(&linkStatus, 0x0, sizeof(LinkStatusTypeDef));
+    bk_wlan_get_link_status(&linkStatus);
+    return linkStatus.wifi_strength;
+}
+
 // receives status change notifications about wireless - could be useful
 // ctxt is pointer to a rw_evt_type
 void wl_status( void *ctxt ){

--- a/src/hal/bl602/hal_wifi_bl602.c
+++ b/src/hal/bl602/hal_wifi_bl602.c
@@ -158,6 +158,10 @@ void HAL_WiFi_SetupStatusCallback(void (*cb)(int code)) {
 void HAL_PrintNetworkInfo() {
 
 }
+int HAL_GetWifiStrength() {
+    return -1;
+}
+
 const char *HAL_GetMyIPString() {
 	uint32_t ip;
 	uint32_t gw;

--- a/src/hal/hal_wifi.h
+++ b/src/hal/hal_wifi.h
@@ -22,4 +22,5 @@ const char *HAL_GetMACStr(char *macstr);
 void WiFI_GetMacAddress(char *mac);
 int WiFI_SetMacAddress(char *mac);
 void HAL_PrintNetworkInfo();
+int HAL_GetWifiStrength();
 

--- a/src/hal/w800/hal_adc_w800.c
+++ b/src/hal/w800/hal_adc_w800.c
@@ -14,7 +14,7 @@ static int adcToGpio[] = {
 	12,//GPIO12, // ADC6
 	13,//GPIO13, // ADC7
 };
-static int c_adcToGpio = sizeof(adcToGpio)/sizeof(adcToGpio[0]);
+//static int c_adcToGpio = sizeof(adcToGpio)/sizeof(adcToGpio[0]);
 
 static uint16_t adcData[1];
 

--- a/src/hal/w800/hal_wifi_w800.c
+++ b/src/hal/w800/hal_wifi_w800.c
@@ -54,6 +54,9 @@ const char *HAL_GetMACStr(char *macstr){
 void HAL_PrintNetworkInfo(){
 
 }
+int HAL_GetWifiStrength() {
+    return -1;
+}
 
 static void apsta_demo_net_status(u8 status)
 {

--- a/src/hal/xr809/hal_adc_xr809.c
+++ b/src/hal/xr809/hal_adc_xr809.c
@@ -2,9 +2,10 @@
 
 #include "../hal_adc.h"
 
-void HAL_ADC_Init(int pinNumber) {
+//HAL_ADC_Init is already definied in OpenXR809\src\driver\chip\hal_adc.c with a different signature.
+//void HAL_ADC_Init(int pinNumber) {
+//}
 
-}
 int HAL_ADC_Read(int pinNumber) {
 	// TODO
 	return 123;

--- a/src/hal/xr809/hal_wifi_xr809.c
+++ b/src/hal/xr809/hal_wifi_xr809.c
@@ -123,6 +123,10 @@ void WiFI_GetMacAddress(char *mac) {
 void HAL_PrintNetworkInfo() {
 
 }
+int HAL_GetWifiStrength() {
+    return -1;
+}
+
 const char *HAL_GetMyIPString() {
 	strcpy(g_ipStr,inet_ntoa(g_wlan_netif->ip_addr));
 

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -758,13 +758,18 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx) {
       return MQTT_DoItemPublishString("mac", HAL_GetMACStr(dataStr));
     
     case PUBLISHITEM_SELF_DATETIME:
-      if (DRV_IsRunning("NTP")) {
-        sprintf(dataStr,"%d",NTP_GetCurrentTime());
-        return MQTT_DoItemPublishString("datetime", dataStr);
-      }
-      else{
+      //Drivers are only built on BK7231 chips
+      #ifndef OBK_DISABLE_ALL_DRIVERS
+        if (DRV_IsRunning("NTP")) {
+          sprintf(dataStr,"%d",NTP_GetCurrentTime());
+          return MQTT_DoItemPublishString("datetime", dataStr);
+        }
+        else{
+          return OBK_PUBLISH_WAS_NOT_REQUIRED;
+        }
+      #else
         return OBK_PUBLISH_WAS_NOT_REQUIRED;
-      }
+      #endif
 
     case PUBLISHITEM_SELF_SOCKETS:
       sprintf(dataStr,"%d",LWIP_GetActiveSockets());

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -760,8 +760,13 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx) {
       return MQTT_DoItemPublishString("mac", HAL_GetMACStr(dataStr));
     
     case PUBLISHITEM_SELF_DATETIME:
-      sprintf(dataStr,"%d",NTP_GetCurrentTime());
-      return MQTT_DoItemPublishString("datetime", dataStr);
+      if (DRV_IsRunning("NTP")) {
+        sprintf(dataStr,"%d",NTP_GetCurrentTime());
+        return MQTT_DoItemPublishString("datetime", dataStr);
+      }
+      else{
+        return OBK_PUBLISH_WAS_NOT_REQUIRED;
+      }
 
     case PUBLISHITEM_SELF_SOCKETS:
       sprintf(dataStr,"%d",LWIP_GetActiveSockets());

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -7,8 +7,8 @@
 // Commands register, execution API and cmd tokenizer
 #include "../cmnds/cmd_public.h"
 #include "../hal/hal_wifi.h"
+#include "../driver/drv_public.h"
 #include "../driver/drv_ntp.h"
-
 
 #ifndef LWIP_MQTT_EXAMPLE_IPADDR_INIT
 #if LWIP_IPV4
@@ -74,7 +74,7 @@ int g_bPublishAllStatesNow = 0;
 #define PUBLISHITEM_SELF_STATIC_RESERVED_2 -13
 #define PUBLISHITEM_SELF_STATIC_RESERVED_1 -12
 #define PUBLISHITEM_SELF_HOSTNAME -11  //Device name
-#define PUBLISHITEM_SELF_VERSION  -10  //Device version
+#define PUBLISHITEM_SELF_BUILD    -10  //Build
 #define PUBLISHITEM_SELF_MAC      -9   //Device mac
 
 //These values are dynamic
@@ -739,8 +739,6 @@ OBK_Publish_Result MQTT_DoItemPublishString(const char *sChannel, const char *va
 }
 
 OBK_Publish_Result MQTT_DoItemPublish(int idx) {
-  OBK_Publish_Result ret;
-  LinkStatusTypeDef linkStatus;
   char dataStr[3*6+1];  //This is sufficient to hold mac value
 
 	switch(idx) {
@@ -753,8 +751,8 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx) {
     case PUBLISHITEM_SELF_HOSTNAME:
       return MQTT_DoItemPublishString("host", CFG_GetShortDeviceName());
 
-    case PUBLISHITEM_SELF_VERSION:
-      return MQTT_DoItemPublishString("version", USER_SW_VER);
+    case PUBLISHITEM_SELF_BUILD:
+      return MQTT_DoItemPublishString("build", g_build_str);
       
     case PUBLISHITEM_SELF_MAC:
       return MQTT_DoItemPublishString("mac", HAL_GetMACStr(dataStr));
@@ -773,9 +771,7 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx) {
       return MQTT_DoItemPublishString("sockets", dataStr);
 
     case PUBLISHITEM_SELF_RSSI:
-      os_memset(&linkStatus, 0x0, sizeof(LinkStatusTypeDef));
-      bk_wlan_get_link_status(&linkStatus);
-      sprintf(dataStr,"%d",linkStatus.wifi_strength);
+      sprintf(dataStr,"%d",HAL_GetWifiStrength());
       return MQTT_DoItemPublishString("rssi", dataStr);
 
     case PUBLISHITEM_SELF_UPTIME:

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -2,35 +2,31 @@
 // specify which parts of the app we wish to be active
 //
 #ifndef OBK_CONFIG_H
-#define OBK_CONFIG_H
+	#define OBK_CONFIG_H
 
-#if PLATFORM_XR809
+	#if PLATFORM_XR809
+		///#define DEBUG_USE_SIMPLE_LOGGER
+		#define OBK_DISABLE_ALL_DRIVERS 1
 
+	#elif PLATFORM_W800
 
-#elif PLATFORM_W800
+		#define OBK_DISABLE_ALL_DRIVERS 1
+		
+	#elif WINDOWS
 
-#define OBK_DISABLE_ALL_DRIVERS 1
-#elif WINDOWS
-
-#elif PLATFORM_BL602
-///#define DEBUG_USE_SIMPLE_LOGGER
-#define OBK_DISABLE_ALL_DRIVERS 1
-
-
-#elif PLATFORM_XR809
-///#define DEBUG_USE_SIMPLE_LOGGER
-#define OBK_DISABLE_ALL_DRIVERS 1
-
-#else
-
-// comment out to remove component
-
-// comment out to remove littlefs
-#define BK_LITTLEFS
-
-// add further app wide defined here, and used them to control build inclusion.
-
-#endif
+	#elif PLATFORM_BL602
+		///#define DEBUG_USE_SIMPLE_LOGGER
+		#define OBK_DISABLE_ALL_DRIVERS 1
 
 
+	#else
+
+		// comment out to remove component
+
+		// comment out to remove littlefs
+		#define BK_LITTLEFS
+
+		// add further app wide defined here, and used them to control build inclusion.
+
+	#endif
 #endif


### PR DESCRIPTION
#104

This merge broadcasts the following values:
* host, mac, build: these are sent out once on startup
* datetime (if NTP driver is running), sockets, rssi, uptime, freeheap, ip: these get sent out every minute.

The values are similar to those broadcasted in Espurna. The ESP chip also provides internal voltage which is useful for battery based operations but I did not find any voltage level in the sdk.

Both sets of values are enabled by the `OBK_FLAG_MQTT_BROADCASTSELFSTATEPERMINUTE` flag.

I also fixed a few unused compile warnings due to unused variables.
