### PR TITLE
Ntp config

### DIFF
--- a/src/driver/drv_ntp.c
+++ b/src/driver/drv_ntp.c
@@ -68,6 +68,8 @@ int NTP_SetTimeZoneOfs(const void *context, const char *cmd, const char *args, i
 	addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"NTP offset set, wait for next ntp packet to apply changes\n");
 	return 1;
 }
+
+//Set custom NTP server
 int NTP_SetServer(const void *context, const char *cmd, const char *args, int cmdFlags) {
 	Tokenizer_TokenizeString(args);
 	if(Tokenizer_GetArgsCount() < 1) {
@@ -79,10 +81,20 @@ int NTP_SetServer(const void *context, const char *cmd, const char *args, int cm
 	addLogAdv(LOG_INFO, LOG_FEATURE_NTP, "NTP server set to %s\n", newValue);
 	return 1;
 }
+
+//Display settings used by the NTP driver
+int NTP_Info(const void *context, const char *cmd, const char *args, int cmdFlags) {
+	addLogAdv(LOG_INFO, LOG_FEATURE_NTP, "Server=%s, Time offset=%d\n", CFG_GetNTPServer(), g_timeOffsetHours);
+	return 1;
+}
+
 void NTP_Init() {
 
 	CMD_RegisterCommand("ntp_timeZoneOfs","",NTP_SetTimeZoneOfs, "Sets the time zone offset in hours", NULL);
 	CMD_RegisterCommand("ntp_setServer", "", NTP_SetServer, "Sets the NTP server", NULL);
+	CMD_RegisterCommand("ntp_info", "", NTP_Info, "Display NTP related settings", NULL);
+
+	addLogAdv(LOG_INFO, LOG_FEATURE_NTP, "NTP driver initialized with server=%s, offset=%d\n", CFG_GetNTPServer(), g_timeOffsetHours);
 }
 
 unsigned int NTP_GetCurrentTime() {

--- a/src/driver/drv_ntp.c
+++ b/src/driver/drv_ntp.c
@@ -3,6 +3,7 @@
 // https://www.elektroda.pl/rtvforum/topic3712112.html
 
 #include "../new_common.h"
+#include "../new_cfg.h"
 // Commands register, execution API and cmd tokenizer
 #include "../cmnds/cmd_public.h"
 
@@ -67,9 +68,21 @@ int NTP_SetTimeZoneOfs(const void *context, const char *cmd, const char *args, i
 	addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"NTP offset set, wait for next ntp packet to apply changes\n");
 	return 1;
 }
+int NTP_SetServer(const void *context, const char *cmd, const char *args, int cmdFlags) {
+	Tokenizer_TokenizeString(args);
+	if(Tokenizer_GetArgsCount() < 1) {
+		addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"Argument missing e.g. ntp_setServer ipAddress\n");
+		return 0;
+	}
+	char *newValue = Tokenizer_GetArg(0);
+	CFG_SetNTPServer(newValue);
+	addLogAdv(LOG_INFO, LOG_FEATURE_NTP, "NTP server set to %s\n", newValue);
+	return 1;
+}
 void NTP_Init() {
 
 	CMD_RegisterCommand("ntp_timeZoneOfs","",NTP_SetTimeZoneOfs, "Sets the time zone offset in hours", NULL);
+	CMD_RegisterCommand("ntp_setServer", "", NTP_SetServer, "Sets the NTP server", NULL);
 }
 
 unsigned int NTP_GetCurrentTime() {
@@ -122,7 +135,7 @@ void NTP_SendRequest(bool bBlocking) {
     memset((char *) &g_address, 0, sizeof(g_address));
 
         g_address.sin_family = AF_INET;
-        g_address.sin_addr.s_addr = inet_addr("217.147.223.78"); // this is address of host which I want to send the socket
+        g_address.sin_addr.s_addr = inet_addr(CFG_GetNTPServer()); // this is address of host which I want to send the socket
         g_address.sin_port = htons(123);
 
 

--- a/src/new_cfg.c
+++ b/src/new_cfg.c
@@ -137,6 +137,8 @@ void CFG_SetDefaultConfig() {
 	sprintf(g_cfg.longDeviceName,DEVICENAME_PREFIX_FULL"_%02X%02X%02X%02X",mac[2],mac[3],mac[4],mac[5]);
 	sprintf(g_cfg.shortDeviceName,DEVICENAME_PREFIX_SHORT"%02X%02X%02X%02X",mac[2],mac[3],mac[4],mac[5]);
 
+	strcpy(g_cfg.ntpServer, "217.147.223.78");	//bart.nexellent.net
+
 	g_cfg_pendingChanges++;
 }
 
@@ -446,6 +448,16 @@ void PIN_SetPinChannel2ForPinIndex(int index, int ch) {
 //		}
 //	}
 //}
+
+const char *CFG_GetNTPServer() {
+	return g_cfg.ntpServer;
+}
+void CFG_SetNTPServer(const char *s) {	
+	if(strcpy_safe_checkForChanges(g_cfg.ntpServer, s,sizeof(g_cfg.ntpServer))) {
+		g_cfg_pendingChanges++;
+	}
+}
+
 void CFG_InitAndLoad() {
 	byte chkSum;
 

--- a/src/new_cfg.h
+++ b/src/new_cfg.h
@@ -61,7 +61,8 @@ int CFG_DeviceGroups_GetRecvFlags();
 void CFG_SetFlag(int flag, bool bValue);
 bool CFG_HasFlag(int flag);
 int CFG_GetFlags();
-
+const char* CFG_GetNTPServer();
+void CFG_SetNTPServer(const char *s);
 
 
 #endif 

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -146,7 +146,8 @@ typedef struct mainConfig_s {
 	int dgr_sendFlags;
 	int dgr_recvFlags;
 	char dgr_name[16];
-	byte unusedSectorA[104];
+	char ntpServer[20];
+	byte unusedSectorA[84];
 	byte unusedSectorB[128];
 	byte unusedSectorC[55];
 	byte timeRequiredToMarkBootSuccessfull;

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -146,8 +146,8 @@ typedef struct mainConfig_s {
 	int dgr_sendFlags;
 	int dgr_recvFlags;
 	char dgr_name[16];
-	char ntpServer[20];
-	byte unusedSectorA[84];
+	char ntpServer[32];
+	byte unusedSectorA[72];
 	byte unusedSectorB[128];
 	byte unusedSectorC[55];
 	byte timeRequiredToMarkBootSuccessfull;


### PR DESCRIPTION
This request adds supports for custom NTP server in place of the default `217.147.223.78`. This allows NTP functionality to work even in firewalled devices.

* A new setting 20 char long has been created for this purpose.
* The new setting can be set using the command `ntp_setServer ipAddress`.
* Added another command `ntp_info` to view current NTP driver settings.
