### PR TITLE
Status information auto-updates, tweaked HTML, replaces #177

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -214,8 +214,9 @@ int http_fn_index(http_request_t *request) {
 			int iValue;
 
 			iValue = CHANNEL_Get(i);
-            
+            poststr(request, "<tr><td>");
             hprintf128(request,"Temperature Channel %i value %i C<br>",i, iValue);
+            poststr(request, "</td></tr>");
             
         } else if(channelType == ChType_Temperature_div10) {
 			int iValue;
@@ -224,14 +225,18 @@ int http_fn_index(http_request_t *request) {
 			iValue = CHANNEL_Get(i);
 			fValue = iValue * 0.1f;
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"Temperature Channel %i value %f C<br>",i, fValue);
+            poststr(request, "</td></tr>");
 
 		} else  if(channelType == ChType_Humidity) {
 			int iValue;
 
 			iValue = CHANNEL_Get(i);
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"Humidity Channel %i value %i Percent<br>",i, iValue);
+            poststr(request, "</td></tr>");
 
 		} else if(channelType == ChType_Humidity_div10) {
 			int iValue;
@@ -240,12 +245,16 @@ int http_fn_index(http_request_t *request) {
 			iValue = CHANNEL_Get(i);
 			fValue = iValue * 0.1f;
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"Humidity Channel %i value %f Percent<br>",i, fValue);
+            poststr(request, "</td></tr>");
+
 		} else if(channelType == ChType_LowMidHigh) {
 			const char *types[]={"Low","Mid","High"};
 			int iValue;
 			iValue = CHANNEL_Get(i);
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"<p>Select speed:</p><form action=\"index\">");
             hprintf128(request,"<input type=\"hidden\" name=\"setIndex\" value=\"%i\">",i);
 			for(j = 0; j < 3; j++) {
@@ -257,7 +266,8 @@ int http_fn_index(http_request_t *request) {
 				hprintf128(request,"<input type=\"radio\" name=\"set\" value=\"%i\" onchange=\"this.form.submit()\" %s>%s",j,check,types[j]);
 			}
             hprintf128(request,"</form>");
-            hprintf128(request,"<br>");
+            poststr(request, "</td></tr>");
+
 		} else if(channelType == ChType_OffLowMidHigh || channelType == ChType_OffLowestLowMidHighHighest || channelType == ChType_LowestLowMidHighHighest) {
 			const char **types;
 			const char *types4[] = {"Off","Low","Mid","High"};
@@ -279,6 +289,7 @@ int http_fn_index(http_request_t *request) {
 
 			iValue = CHANNEL_Get(i);
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"<p>Select speed:</p><form action=\"index\">");
             hprintf128(request,"<input type=\"hidden\" name=\"setIndex\" value=\"%i\">",i);
 			for(j = 0; j < numTypes; j++) {
@@ -290,23 +301,27 @@ int http_fn_index(http_request_t *request) {
 				hprintf128(request,"<input type=\"radio\" name=\"set\" value=\"%i\" onchange=\"this.form.submit()\" %s>%s",j,check,types[j]);
 			}
             hprintf128(request,"</form>");
-            hprintf128(request,"<br>");
+            poststr(request, "</td></tr>");
+
 		} else if(channelType == ChType_TextField) {
 			int iValue;
 			iValue = CHANNEL_Get(i);
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"<p>Change channel %i value:</p><form action=\"index\">",i);
             hprintf128(request,"<input type=\"hidden\" name=\"setIndex\" value=\"%i\">",i);
-            hprintf128(request,"<input type=\"number\" name=\"set\" value=\"%i\">",iValue);
+            hprintf128(request,"<input type=\"number\" name=\"set\" value=\"%i\" onblur=\"this.form.submit()\">",iValue);
             hprintf128(request,"<input type=\"submit\" value=\"Set!\"/></form>");
             hprintf128(request,"</form>");
-            hprintf128(request,"<br>");
+            poststr(request, "</td></tr>");
+
 		} else if(channelType == ChType_ReadOnly) {
 			int iValue;
 			iValue = CHANNEL_Get(i);
 
+            poststr(request, "<tr><td>");
             hprintf128(request,"Channel %i = %i",i,iValue);
-            hprintf128(request,"<br>");
+            poststr(request, "</td></tr>");
 
         }
         else if (h_isChannelRelay(i) || channelType == ChType_Toggle) {
@@ -341,6 +356,7 @@ int http_fn_index(http_request_t *request) {
             poststr(request, "</td></tr>");
         }
     }
+
 	if(bRawPWMs == 0 || forceShowRGBCW) {
 		int c_pwms;
 		int lm;
@@ -394,7 +410,7 @@ int http_fn_index(http_request_t *request) {
 			poststr(request, "<tr><td>");
             hprintf128(request,"<h5> LED RGB Color %s </h5>",activeStr);
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",SPECIAL_CHANNEL_BASECOLOR);
-			hprintf128(request,"<input type=\"color\" name=\"%s\" id=\"color%i\" value=\"#%s\" onmouseup=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_BASECOLOR,colorValue);
+			hprintf128(request,"<input type=\"color\" name=\"%s\" id=\"color%i\" value=\"#%s\" onchange=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_BASECOLOR,colorValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,SPECIAL_CHANNEL_BASECOLOR);
             hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle Light\"/></form>");
 			poststr(request, "</td></tr>");
@@ -480,8 +496,11 @@ int http_fn_index(http_request_t *request) {
                 "req=new XMLHttpRequest();"
                 "req.onreadystatechange=()=>{"
                     "if(req.readyState==4 && req.status==200){"
-                        "var s=req.responseText;"
-                        "eb('state').innerHTML=s;" 
+                        "if (!(document.activeElement.tagName=='INPUT' && "
+                            "(document.activeElement.type=='number' || document.activeElement.type=='color'))) {"
+                                "var s=req.responseText;"
+                                "eb('state').innerHTML=s;" 
+                        "}"
                         "clearTimeout(firstTime);"
                         "clearTimeout(lastTime);"
                         "lastTime=setTimeout(showState, 3e3);"

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -350,7 +350,7 @@ int http_fn_index(http_request_t *request) {
             pwmValue = CHANNEL_Get(i);
             poststr(request, "<tr><td>");
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",i);
-            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\" onmouseup=\"this.form.submit()\">",inputName,i,pwmValue);
+            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\" onchange=\"this.form.submit()\">",inputName,i,pwmValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,i);
             hprintf128(request,"<input type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",i);
             poststr(request, "</td></tr>");
@@ -393,7 +393,7 @@ int http_fn_index(http_request_t *request) {
 			poststr(request, "<tr><td>");
             hprintf128(request,"<h5> LED Dimmer/Brightness </h5>");
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",SPECIAL_CHANNEL_BRIGHTNESS);
-            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\" onmouseup=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_BRIGHTNESS,pwmValue);
+            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\" onchange=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_BRIGHTNESS,pwmValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,SPECIAL_CHANNEL_BRIGHTNESS);
             hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",SPECIAL_CHANNEL_BRIGHTNESS);
 			poststr(request, "</td></tr>");
@@ -432,7 +432,7 @@ int http_fn_index(http_request_t *request) {
             hprintf128(request,"<h5> LED Temperature Slider %s (cur=%i, min=%i, max=%i) (Cold <--- ---> Warm) </h5>",activeStr,pwmValue,HASS_TEMPERATURE_MIN,HASS_TEMPERATURE_MAX);
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",SPECIAL_CHANNEL_TEMPERATURE);
             hprintf128(request,"<input type=\"range\" min=\"%i\" max=\"%i\"", HASS_TEMPERATURE_MIN,HASS_TEMPERATURE_MAX);
-			hprintf128(request,"name=\"%s\" id=\"slider%i\" value=\"%i\" onmouseup=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_TEMPERATURE,pwmValue);
+			hprintf128(request,"name=\"%s\" id=\"slider%i\" value=\"%i\" onchange=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_TEMPERATURE,pwmValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,SPECIAL_CHANNEL_TEMPERATURE);
             hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",SPECIAL_CHANNEL_TEMPERATURE);
 			poststr(request, "</td></tr>");

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -119,61 +119,67 @@ int http_fn_index(http_request_t *request) {
     if(!http_getArg(request->url, "state", tmpA, sizeof(tmpA))) {
         http_setup(request, httpMimeTypeHTML);
         http_html_start(request, NULL);
-        poststr(request, "<div id=\"statediv\">"); // replaceable content follows
-    }
 
-    if(http_getArg(request->url,"tgl",tmpA,sizeof(tmpA))) {
-        j = atoi(tmpA);
-		if(j == SPECIAL_CHANNEL_LEDPOWER) {
-			hprintf128(request,"<h3>Toggled LED power!</h3>",j);
-		} else {
-			hprintf128(request,"<h3>Toggled %i!</h3>",j);
-		}
-        CHANNEL_Toggle(j);
-    }
-    if(http_getArg(request->url,"on",tmpA,sizeof(tmpA))) {
-        j = atoi(tmpA);
-        hprintf128(request,"<h3>Enabled %i!</h3>",j);
-        CHANNEL_Set(j,255,1);
-    }
-    if(http_getArg(request->url,"rgb",tmpA,sizeof(tmpA))) {
-        hprintf128(request,"<h3>Set RGB to %s!</h3>",tmpA);
-		LED_SetBaseColor(0,"led_basecolor",tmpA,0);
-    }
-	
-    if(http_getArg(request->url,"off",tmpA,sizeof(tmpA))) {
-        j = atoi(tmpA);
-        hprintf128(request,"<h3>Disabled %i!</h3>",j);
-        CHANNEL_Set(j,0,1);
-    }
-    if(http_getArg(request->url,"pwm",tmpA,sizeof(tmpA))) {
-        int newPWMValue = atoi(tmpA);
-        http_getArg(request->url,"pwmIndex",tmpA,sizeof(tmpA));
-        j = atoi(tmpA);
-		if(j == SPECIAL_CHANNEL_TEMPERATURE) {
-			hprintf128(request,"<h3>Changed Temperature to %i!</h3>",newPWMValue);
-		} else {
-			hprintf128(request,"<h3>Changed pwm %i to %i!</h3>",j,newPWMValue);
-		}
-        CHANNEL_Set(j,newPWMValue,1);
-    }
-    if(http_getArg(request->url,"dim",tmpA,sizeof(tmpA))) {
-        int newDimmerValue = atoi(tmpA);
-        http_getArg(request->url,"dimIndex",tmpA,sizeof(tmpA));
-		j  = atoi(tmpA);
-		if(j == SPECIAL_CHANNEL_BRIGHTNESS) {
-			hprintf128(request,"<h3>Changed LED brightness to %i!</h3>",newDimmerValue);
-		} else {
-			hprintf128(request,"<h3>Changed dimmer %i to %i!</h3>",j,newDimmerValue);
-		}
-        CHANNEL_Set(j,newDimmerValue,1);
-    }
-    if(http_getArg(request->url,"set",tmpA,sizeof(tmpA))) {
-        int newSetValue = atoi(tmpA);
-        http_getArg(request->url,"setIndex",tmpA,sizeof(tmpA));
-        j = atoi(tmpA);
-        hprintf128(request,"<h3>Changed channel %i to %i!</h3>",j,newSetValue);
-        CHANNEL_Set(j,newSetValue,1);
+        poststr(request, "<div id=\"changed\">");
+        if(http_getArg(request->url,"tgl",tmpA,sizeof(tmpA))) {
+            j = atoi(tmpA);
+            if(j == SPECIAL_CHANNEL_LEDPOWER) {
+                hprintf128(request,"<h3>Toggled LED power!</h3>",j);
+            } else {
+                hprintf128(request,"<h3>Toggled %i!</h3>",j);
+            }
+            CHANNEL_Toggle(j);
+        }
+        if(http_getArg(request->url,"on",tmpA,sizeof(tmpA))) {
+            j = atoi(tmpA);
+            hprintf128(request,"<h3>Enabled %i!</h3>",j);
+            CHANNEL_Set(j,255,1);
+        }
+        if(http_getArg(request->url,"rgb",tmpA,sizeof(tmpA))) {
+            hprintf128(request,"<h3>Set RGB to %s!</h3>",tmpA);
+            LED_SetBaseColor(0,"led_basecolor",tmpA,0);
+        }
+        
+        if(http_getArg(request->url,"off",tmpA,sizeof(tmpA))) {
+            j = atoi(tmpA);
+            hprintf128(request,"<h3>Disabled %i!</h3>",j);
+            CHANNEL_Set(j,0,1);
+        }
+        if(http_getArg(request->url,"pwm",tmpA,sizeof(tmpA))) {
+            int newPWMValue = atoi(tmpA);
+            http_getArg(request->url,"pwmIndex",tmpA,sizeof(tmpA));
+            j = atoi(tmpA);
+            if(j == SPECIAL_CHANNEL_TEMPERATURE) {
+                hprintf128(request,"<h3>Changed Temperature to %i!</h3>",newPWMValue);
+            } else {
+                hprintf128(request,"<h3>Changed pwm %i to %i!</h3>",j,newPWMValue);
+            }
+            CHANNEL_Set(j,newPWMValue,1);
+        }
+        if(http_getArg(request->url,"dim",tmpA,sizeof(tmpA))) {
+            int newDimmerValue = atoi(tmpA);
+            http_getArg(request->url,"dimIndex",tmpA,sizeof(tmpA));
+            j  = atoi(tmpA);
+            if(j == SPECIAL_CHANNEL_BRIGHTNESS) {
+                hprintf128(request,"<h3>Changed LED brightness to %i!</h3>",newDimmerValue);
+            } else {
+                hprintf128(request,"<h3>Changed dimmer %i to %i!</h3>",j,newDimmerValue);
+            }
+            CHANNEL_Set(j,newDimmerValue,1);
+        }
+        if(http_getArg(request->url,"set",tmpA,sizeof(tmpA))) {
+            int newSetValue = atoi(tmpA);
+            http_getArg(request->url,"setIndex",tmpA,sizeof(tmpA));
+            j = atoi(tmpA);
+            hprintf128(request,"<h3>Changed channel %i to %i!</h3>",j,newSetValue);
+            CHANNEL_Set(j,newSetValue,1);
+        }
+        if(http_getArg(request->url,"restart",tmpA,sizeof(tmpA))) {
+            poststr(request,"<h5> Module will restart soon</h5>");
+            RESET_ScheduleModuleReset(3);
+        }
+        poststr(request, "</div>"); // end div#change
+        poststr(request, "<div id=\"state\">"); // replaceable content follows
     }
 
     poststr(request, "<table width=\"100%\">");
@@ -183,7 +189,7 @@ int http_fn_index(http_request_t *request) {
         channelType = CHANNEL_GetType(i);
         if (h_isChannelRelay(i) || channelType == ChType_Toggle) {
             if (i <= 1) {
-                hprintf128(request, "<tr colspan=\"%i\">", CHANNEL_MAX);
+                hprintf128(request, "<tr>");
             }
             if (CHANNEL_Check(i)) {
                 poststr(request, "<td style=\"text-align:center; font-weight:bold; font-size:54px\">ON</td>");
@@ -196,7 +202,7 @@ int http_fn_index(http_request_t *request) {
             }
         }
     }
-    poststr(request, "<table width=\"100%\">");
+    poststr(request, "</table>");
     
     poststr(request, "<table width=\"100%\">");
     for(i = 0; i < CHANNEL_MAX; i++) {
@@ -305,7 +311,7 @@ int http_fn_index(http_request_t *request) {
         }
         else if (h_isChannelRelay(i) || channelType == ChType_Toggle) {
             if (i <= 1) {
-                hprintf128(request, "<tr colspan=\"%i\">", CHANNEL_MAX);
+                hprintf128(request, "<tr>");
             }
             const char *c;
             if(CHANNEL_Check(i)) {
@@ -327,18 +333,12 @@ int http_fn_index(http_request_t *request) {
             int pwmValue;
 
             pwmValue = CHANNEL_Get(i);
+            poststr(request, "<tr><td>");
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",i);
-            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\">",inputName,i,pwmValue);
+            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\" onmouseup=\"this.form.submit()\">",inputName,i,pwmValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,i);
-            hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",i);
-
-
-            poststr(request,"<script>");
-            hprintf128(request,"var slider = document.getElementById(\"slider%i\");\n",i);
-            poststr(request,"slider.onmouseup = function () {\n");
-            hprintf128(request," document.getElementById(\"form%i\").submit();\n",i);
-            poststr(request,"}\n");
-            poststr(request,"</script>");
+            hprintf128(request,"<input type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",i);
+            poststr(request, "</td></tr>");
         }
     }
 	if(bRawPWMs == 0 || forceShowRGBCW) {
@@ -359,11 +359,11 @@ int http_fn_index(http_request_t *request) {
 			} else {
 				c = "bred";
 			}
-			poststr(request, "<tr>");
-			poststr(request,"<td><form action=\"index\">");
+			poststr(request, "<tr><td>");
+			poststr(request,"<form action=\"index\">");
 			hprintf128(request,"<input type=\"hidden\" name=\"tgl\" value=\"%i\">",SPECIAL_CHANNEL_LEDPOWER);
-			hprintf128(request,"<input class=\"%s\" type=\"submit\" value=\"Toggle Light\"/></form></td>",c);
-			poststr(request, "</tr>");
+			hprintf128(request,"<input class=\"%s\" type=\"submit\" value=\"Toggle Light\"/></form>",c);
+			poststr(request, "</td></tr>");
 		}
 
 		if(c_pwms > 0) {
@@ -374,21 +374,13 @@ int http_fn_index(http_request_t *request) {
 
             pwmValue = LED_GetDimmer();
 
-			poststr(request, "<tr>");
+			poststr(request, "<tr><td>");
             hprintf128(request,"<h5> LED Dimmer/Brightness </h5>");
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",SPECIAL_CHANNEL_BRIGHTNESS);
-            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\">",inputName,SPECIAL_CHANNEL_BRIGHTNESS,pwmValue);
+            hprintf128(request,"<input type=\"range\" min=\"0\" max=\"100\" name=\"%s\" id=\"slider%i\" value=\"%i\" onmouseup=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_BRIGHTNESS,pwmValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,SPECIAL_CHANNEL_BRIGHTNESS);
             hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",SPECIAL_CHANNEL_BRIGHTNESS);
-
-
-            poststr(request,"<script>");
-            hprintf128(request,"var slider = document.getElementById(\"slider%i\");\n",SPECIAL_CHANNEL_BRIGHTNESS);
-            poststr(request,"slider.onmouseup = function () {\n");
-            hprintf128(request," document.getElementById(\"form%i\").submit();\n",SPECIAL_CHANNEL_BRIGHTNESS);
-            poststr(request,"}\n");
-            poststr(request,"</script>");
-			poststr(request, "</tr>");
+			poststr(request, "</td></tr>");
 		}
 		if(c_pwms >= 3) {
 			char colorValue[16];
@@ -399,21 +391,13 @@ int http_fn_index(http_request_t *request) {
 			}
 
 			LED_GetBaseColorString(colorValue);
-
+			poststr(request, "<tr><td>");
             hprintf128(request,"<h5> LED RGB Color %s </h5>",activeStr);
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",SPECIAL_CHANNEL_BASECOLOR);
-			hprintf128(request,"<input type=\"color\" name=\"%s\" id=\"color%i\" value=\"#%s\">",inputName,SPECIAL_CHANNEL_BASECOLOR,colorValue);
+			hprintf128(request,"<input type=\"color\" name=\"%s\" id=\"color%i\" value=\"#%s\" onmouseup=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_BASECOLOR,colorValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,SPECIAL_CHANNEL_BASECOLOR);
             hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle Light\"/></form>");
-
-
-            poststr(request,"<script>");
-            hprintf128(request,"var color = document.getElementById(\"color%i\");\n",SPECIAL_CHANNEL_BASECOLOR);
-            poststr(request,"color.onchange = function () {\n");
-            hprintf128(request," document.getElementById(\"form%i\").submit();\n",SPECIAL_CHANNEL_BASECOLOR);
-            poststr(request,"}\n");
-            poststr(request,"</script>");
-
+			poststr(request, "</td></tr>");
 		}
 		if(c_pwms == 2 || c_pwms == 5) {
 			// TODO: temperature slider
@@ -428,24 +412,14 @@ int http_fn_index(http_request_t *request) {
 
             pwmValue = LED_GetTemperature();
 
-			poststr(request, "<tr>");
+			poststr(request, "<tr><td>");
             hprintf128(request,"<h5> LED Temperature Slider %s (cur=%i, min=%i, max=%i) (Cold <--- ---> Warm) </h5>",activeStr,pwmValue,HASS_TEMPERATURE_MIN,HASS_TEMPERATURE_MAX);
             hprintf128(request,"<form action=\"index\" id=\"form%i\">",SPECIAL_CHANNEL_TEMPERATURE);
             hprintf128(request,"<input type=\"range\" min=\"%i\" max=\"%i\"", HASS_TEMPERATURE_MIN,HASS_TEMPERATURE_MAX);
-			hprintf128(request,"name=\"%s\" id=\"slider%i\" value=\"%i\">",inputName,SPECIAL_CHANNEL_TEMPERATURE,pwmValue);
+			hprintf128(request,"name=\"%s\" id=\"slider%i\" value=\"%i\" onmouseup=\"this.form.submit()\">",inputName,SPECIAL_CHANNEL_TEMPERATURE,pwmValue);
             hprintf128(request,"<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">",inputName,SPECIAL_CHANNEL_TEMPERATURE);
             hprintf128(request,"<input  type=\"submit\" style=\"display:none;\" value=\"Toggle %i\"/></form>",SPECIAL_CHANNEL_TEMPERATURE);
-
-
-            poststr(request,"<script>");
-            hprintf128(request,"var slider = document.getElementById(\"slider%i\");\n",SPECIAL_CHANNEL_TEMPERATURE);
-            poststr(request,"slider.onmouseup = function () {\n");
-            hprintf128(request," document.getElementById(\"form%i\").submit();\n",SPECIAL_CHANNEL_TEMPERATURE);
-            poststr(request,"}\n");
-            poststr(request,"</script>");
-			poststr(request, "</tr>");
-
-			
+			poststr(request, "</td></tr>");
 		} 
 
 	}
@@ -453,11 +427,6 @@ int http_fn_index(http_request_t *request) {
 #ifndef OBK_DISABLE_ALL_DRIVERS
 	DRV_AppendInformationToHTTPIndexPage(request);
 #endif
-
-    if(http_getArg(request->url,"restart",tmpA,sizeof(tmpA))) {
-        poststr(request,"<h5> Module will restart soon</h5>");
-        RESET_ScheduleModuleReset(3);
-    }
 
 	if(1) {
 		int bFirst = true;
@@ -482,7 +451,7 @@ int http_fn_index(http_request_t *request) {
 
     // for normal page loads, show the rest of the HTML
     if(!http_getArg(request->url,"state",tmpA,sizeof(tmpA))) {
-        poststr(request, "</div>"); // end id=statediv
+        poststr(request, "</div>"); // end div#state
 
         // Shared UI elements 
         poststr(request, "<form action=\"cfg\"><input type=\"submit\" value=\"Config\"/></form>");
@@ -512,16 +481,18 @@ int http_fn_index(http_request_t *request) {
                 "req.onreadystatechange=()=>{"
                     "if(req.readyState==4 && req.status==200){"
                         "var s=req.responseText;"
-                        "eb('statediv').innerHTML=s;" 
+                        "eb('state').innerHTML=s;" 
                         "clearTimeout(firstTime);"
                         "clearTimeout(lastTime);"
-                        "lastTime=setTimeout(showState, 3000);"
+                        "lastTime=setTimeout(showState, 3e3);"
                 "}};"
                 "req.open('GET','index?state=1', true);"
                 "req.send();"
-                "firstTime=setTimeout(showState, 3000);"
+                "firstTime=setTimeout(showState, 3e3);"
             "}"
             "window.addEventListener('load', showState);"
+            "history.pushState(null, '', 'index');" // drop actions like 'toggle' from URL
+            "setTimeout(()=>{eb('changed').innerHTML=''}, 5e3);" // hide change info
             "</script>"
         );
     }
@@ -1574,7 +1545,11 @@ int http_fn_cfg_pins(http_request_t *request) {
         }
     }
     if(iChangedRequested>0) {
-		CFG_Save_SetupTimer();
+        // Anecdotally, if pins are configured badly, the
+        // second-timer breaks. To reconfigure, force
+        // saving the configuration instead of waiting.
+		//CFG_Save_SetupTimer(); 
+        CFG_Save_IfThereArePendingChanges(); 
         hprintf128(request, "Pins update - %i reqs, %i changed!<br><br>",iChangedRequested,iChanged);
     }
 //	strcat(outbuf,"<button type=\"button\">Click Me!</button>");

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -105,6 +105,7 @@ int http_fn_testmsg(http_request_t *request) {
     return 0;
 
 }
+
 int http_fn_index(http_request_t *request) {
     int j, i;
 	char tmpA[128];
@@ -118,61 +119,67 @@ int http_fn_index(http_request_t *request) {
     if(!http_getArg(request->url, "state", tmpA, sizeof(tmpA))) {
         http_setup(request, httpMimeTypeHTML);
         http_html_start(request, NULL);
-        poststr(request, "<div id=\"statediv\">"); // replaceable content follows
-    }
 
-    if(http_getArg(request->url,"tgl",tmpA,sizeof(tmpA))) {
-        j = atoi(tmpA);
-		if(j == SPECIAL_CHANNEL_LEDPOWER) {
-			hprintf128(request,"<h3>Toggled LED power!</h3>",j);
-		} else {
-			hprintf128(request,"<h3>Toggled %i!</h3>",j);
-		}
-        CHANNEL_Toggle(j);
-    }
-    if(http_getArg(request->url,"on",tmpA,sizeof(tmpA))) {
-        j = atoi(tmpA);
-        hprintf128(request,"<h3>Enabled %i!</h3>",j);
-        CHANNEL_Set(j,255,1);
-    }
-    if(http_getArg(request->url,"rgb",tmpA,sizeof(tmpA))) {
-        hprintf128(request,"<h3>Set RGB to %s!</h3>",tmpA);
-		LED_SetBaseColor(0,"led_basecolor",tmpA,0);
-    }
-	
-    if(http_getArg(request->url,"off",tmpA,sizeof(tmpA))) {
-        j = atoi(tmpA);
-        hprintf128(request,"<h3>Disabled %i!</h3>",j);
-        CHANNEL_Set(j,0,1);
-    }
-    if(http_getArg(request->url,"pwm",tmpA,sizeof(tmpA))) {
-        int newPWMValue = atoi(tmpA);
-        http_getArg(request->url,"pwmIndex",tmpA,sizeof(tmpA));
-        j = atoi(tmpA);
-		if(j == SPECIAL_CHANNEL_TEMPERATURE) {
-			hprintf128(request,"<h3>Changed Temperature to %i!</h3>",newPWMValue);
-		} else {
-			hprintf128(request,"<h3>Changed pwm %i to %i!</h3>",j,newPWMValue);
-		}
-        CHANNEL_Set(j,newPWMValue,1);
-    }
-    if(http_getArg(request->url,"dim",tmpA,sizeof(tmpA))) {
-        int newDimmerValue = atoi(tmpA);
-        http_getArg(request->url,"dimIndex",tmpA,sizeof(tmpA));
-		j  = atoi(tmpA);
-		if(j == SPECIAL_CHANNEL_BRIGHTNESS) {
-			hprintf128(request,"<h3>Changed LED brightness to %i!</h3>",newDimmerValue);
-		} else {
-			hprintf128(request,"<h3>Changed dimmer %i to %i!</h3>",j,newDimmerValue);
-		}
-        CHANNEL_Set(j,newDimmerValue,1);
-    }
-    if(http_getArg(request->url,"set",tmpA,sizeof(tmpA))) {
-        int newSetValue = atoi(tmpA);
-        http_getArg(request->url,"setIndex",tmpA,sizeof(tmpA));
-        j = atoi(tmpA);
-        hprintf128(request,"<h3>Changed channel %i to %i!</h3>",j,newSetValue);
-        CHANNEL_Set(j,newSetValue,1);
+        poststr(request, "<div id=\"changed\">");
+        if(http_getArg(request->url,"tgl",tmpA,sizeof(tmpA))) {
+            j = atoi(tmpA);
+            if(j == SPECIAL_CHANNEL_LEDPOWER) {
+                hprintf128(request,"<h3>Toggled LED power!</h3>",j);
+            } else {
+                hprintf128(request,"<h3>Toggled %i!</h3>",j);
+            }
+            CHANNEL_Toggle(j);
+        }
+        if(http_getArg(request->url,"on",tmpA,sizeof(tmpA))) {
+            j = atoi(tmpA);
+            hprintf128(request,"<h3>Enabled %i!</h3>",j);
+            CHANNEL_Set(j,255,1);
+        }
+        if(http_getArg(request->url,"rgb",tmpA,sizeof(tmpA))) {
+            hprintf128(request,"<h3>Set RGB to %s!</h3>",tmpA);
+            LED_SetBaseColor(0,"led_basecolor",tmpA,0);
+        }
+        
+        if(http_getArg(request->url,"off",tmpA,sizeof(tmpA))) {
+            j = atoi(tmpA);
+            hprintf128(request,"<h3>Disabled %i!</h3>",j);
+            CHANNEL_Set(j,0,1);
+        }
+        if(http_getArg(request->url,"pwm",tmpA,sizeof(tmpA))) {
+            int newPWMValue = atoi(tmpA);
+            http_getArg(request->url,"pwmIndex",tmpA,sizeof(tmpA));
+            j = atoi(tmpA);
+            if(j == SPECIAL_CHANNEL_TEMPERATURE) {
+                hprintf128(request,"<h3>Changed Temperature to %i!</h3>",newPWMValue);
+            } else {
+                hprintf128(request,"<h3>Changed pwm %i to %i!</h3>",j,newPWMValue);
+            }
+            CHANNEL_Set(j,newPWMValue,1);
+        }
+        if(http_getArg(request->url,"dim",tmpA,sizeof(tmpA))) {
+            int newDimmerValue = atoi(tmpA);
+            http_getArg(request->url,"dimIndex",tmpA,sizeof(tmpA));
+            j  = atoi(tmpA);
+            if(j == SPECIAL_CHANNEL_BRIGHTNESS) {
+                hprintf128(request,"<h3>Changed LED brightness to %i!</h3>",newDimmerValue);
+            } else {
+                hprintf128(request,"<h3>Changed dimmer %i to %i!</h3>",j,newDimmerValue);
+            }
+            CHANNEL_Set(j,newDimmerValue,1);
+        }
+        if(http_getArg(request->url,"set",tmpA,sizeof(tmpA))) {
+            int newSetValue = atoi(tmpA);
+            http_getArg(request->url,"setIndex",tmpA,sizeof(tmpA));
+            j = atoi(tmpA);
+            hprintf128(request,"<h3>Changed channel %i to %i!</h3>",j,newSetValue);
+            CHANNEL_Set(j,newSetValue,1);
+        }
+        if(http_getArg(request->url,"restart",tmpA,sizeof(tmpA))) {
+            poststr(request,"<h5> Module will restart soon</h5>");
+            RESET_ScheduleModuleReset(3);
+        }
+        poststr(request, "</div>"); // end div#change
+        poststr(request, "<div id=\"state\">"); // replaceable content follows
     }
 
     poststr(request, "<table width=\"100%\">");
@@ -421,11 +428,6 @@ int http_fn_index(http_request_t *request) {
 	DRV_AppendInformationToHTTPIndexPage(request);
 #endif
 
-    if(http_getArg(request->url,"restart",tmpA,sizeof(tmpA))) {
-        poststr(request,"<h5> Module will restart soon</h5>");
-        RESET_ScheduleModuleReset(3);
-    }
-
 	if(1) {
 		int bFirst = true;
 		hprintf128(request,"<h5>");
@@ -449,7 +451,7 @@ int http_fn_index(http_request_t *request) {
 
     // for normal page loads, show the rest of the HTML
     if(!http_getArg(request->url,"state",tmpA,sizeof(tmpA))) {
-        poststr(request, "</div>"); // end id=statediv
+        poststr(request, "</div>"); // end div#state
 
         // Shared UI elements 
         poststr(request, "<form action=\"cfg\"><input type=\"submit\" value=\"Config\"/></form>");
@@ -479,16 +481,18 @@ int http_fn_index(http_request_t *request) {
                 "req.onreadystatechange=()=>{"
                     "if(req.readyState==4 && req.status==200){"
                         "var s=req.responseText;"
-                        "eb('statediv').innerHTML=s;" 
+                        "eb('state').innerHTML=s;" 
                         "clearTimeout(firstTime);"
                         "clearTimeout(lastTime);"
-                        "lastTime=setTimeout(showState, 3000);"
+                        "lastTime=setTimeout(showState, 3e3);"
                 "}};"
                 "req.open('GET','index?state=1', true);"
                 "req.send();"
-                "firstTime=setTimeout(showState, 3000);"
+                "firstTime=setTimeout(showState, 3e3);"
             "}"
             "window.addEventListener('load', showState);"
+            "history.pushState(null, '', 'index');" // drop actions like 'toggle' from URL
+            "setTimeout(()=>{eb('changed').innerHTML=''}, 5e3);" // hide change info
             "</script>"
         );
     }
@@ -499,12 +503,10 @@ int http_fn_index(http_request_t *request) {
 
 int http_fn_about(http_request_t *request){
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "About");
     poststr(request,"<h2>Open source firmware for BK7231N, BK7231T, XR809 and BL602 by OpenSHWProjects</h2>");
-    poststr(request,htmlReturnToMenu);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToMenu);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -515,8 +517,7 @@ int http_fn_about(http_request_t *request){
 int http_fn_cfg_mqtt(http_request_t *request) {
     int i;
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "MQTT");
     poststr(request,"<h2> Use this to connect to your MQTT</h2>");
     poststr(request,"<form action=\"/cfg_mqtt_set\">\
             <label for=\"host\">Host:</label><br>\
@@ -544,9 +545,8 @@ int http_fn_cfg_mqtt(http_request_t *request) {
     poststr(request,"\"><br>\
             <input type=\"submit\" value=\"Submit\" onclick=\"return confirm('Are you sure? Please check MQTT data twice?')\">\
         </form> ");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -554,8 +554,7 @@ int http_fn_cfg_mqtt(http_request_t *request) {
 int http_fn_cfg_mqtt_set(http_request_t *request) {
 	char tmpA[128];
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Saving MQTT");
 
     if(http_getArg(request->url,"host",tmpA,sizeof(tmpA))) {
         CFG_SetMQTTHost(tmpA);
@@ -580,21 +579,15 @@ int http_fn_cfg_mqtt_set(http_request_t *request) {
     poststr(request,"<br>");
     poststr(request,"<a href=\"cfg_mqtt\">Return to MQTT settings</a>");
     poststr(request,"<br>");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
 
-
-
-
 int http_fn_cfg_webapp(http_request_t *request) {
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set Webapp");
     poststr(request,"<h2> Use this to set the URL of the Webapp</h2>");
     poststr(request,"<form action=\"/cfg_webapp_set\">\
             <label for=\"url\">Url:</label><br>\
@@ -603,9 +596,8 @@ int http_fn_cfg_webapp(http_request_t *request) {
     poststr(request,"\"><br>\
             <input type=\"submit\" value=\"Submit\">\
         </form> ");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -613,8 +605,7 @@ int http_fn_cfg_webapp(http_request_t *request) {
 int http_fn_cfg_webapp_set(http_request_t *request) {
 	char tmpA[128];
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Saving Webapp");
 
     if(http_getArg(request->url,"url",tmpA,sizeof(tmpA))) {
         if(CFG_SetWebappRoot(tmpA)) {
@@ -627,9 +618,8 @@ int http_fn_cfg_webapp_set(http_request_t *request) {
     }
 
     poststr(request,"<br>");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -645,8 +635,7 @@ int http_fn_cfg_ping(http_request_t *request) {
 	int bChanged;
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set Watchdog");
     bChanged = 0;
     poststr(request,"<h3> Ping watchdog (backup reconnect mechanism)</h3>");
     poststr(request,"<p> By default, all OpenBeken devices automatically tries to reconnect to WiFi when a connection is lost.");
@@ -706,10 +695,8 @@ int http_fn_cfg_ping(http_request_t *request) {
     poststr(request,"\"><br><br>\
             <input type=\"submit\" value=\"Submit\" onclick=\"return confirm('Are you sure?')\">\
         </form> ");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -719,8 +706,7 @@ int http_fn_cfg_wifi(http_request_t *request) {
 	char tmpA[128];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set Wifi");
     /*bChanged = 0;
     if(http_getArg(recvbuf,"ssid",tmpA,sizeof(tmpA))) {
         CFG_SetWiFiSSID(tmpA);
@@ -803,10 +789,8 @@ int http_fn_cfg_wifi(http_request_t *request) {
     poststr(request,"\"><br><br>\
             <input type=\"submit\" value=\"Submit\" onclick=\"return confirm('Are you sure? Please check SSID and pass twice?')\">\
         </form> ");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -817,8 +801,7 @@ int http_fn_cfg_name(http_request_t *request) {
 	char tmpA[128];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set name");
 
     poststr(request,"<h2> Change device names for display. </h2> Remember that short name is used by MQTT.<br>");
     if(http_getArg(request->url,"shortName",tmpA,sizeof(tmpA))) {
@@ -843,20 +826,18 @@ int http_fn_cfg_name(http_request_t *request) {
     poststr(request,"\"><br><br>\
             <input type=\"submit\" value=\"Submit\" onclick=\"return confirm('Are you sure? Short name might be used by MQTT, so you will have to reconfig some stuff.')\">\
         </form> ");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
+
 int http_fn_cfg_wifi_set(http_request_t *request) {
 	char tmpA[128];
 	addLogAdv(LOG_INFO, LOG_FEATURE_HTTP,"HTTP_ProcessPacket: generating cfg_wifi_set \r\n");
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Saving Wifi");
     if(http_getArg(request->url,"open",tmpA,sizeof(tmpA))) {
         CFG_SetWiFiSSID("");
         CFG_SetWiFiPass("");
@@ -878,24 +859,18 @@ int http_fn_cfg_wifi_set(http_request_t *request) {
     poststr(request,"<br>");
     poststr(request,"<a href=\"cfg_wifi\">Return to WiFi settings</a>");
     poststr(request,"<br>");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
-
-
-
 
 int http_fn_cfg_loglevel_set(http_request_t *request) {
 	char tmpA[128];
     addLogAdv(LOG_INFO, LOG_FEATURE_HTTP,"HTTP_ProcessPacket: generating cfg_loglevel_set \r\n");
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set log level");
     if(http_getArg(request->url,"loglevel",tmpA,sizeof(tmpA))) {
 #if WINDOWS
 #else
@@ -918,9 +893,8 @@ int http_fn_cfg_loglevel_set(http_request_t *request) {
     poststr(request,"<br>");
     poststr(request,"<a href=\"cfg\">Return to config settings</a>");
     poststr(request,"<br>");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -933,8 +907,7 @@ int http_fn_cfg_mac(http_request_t *request) {
     int i;
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set MAC address");
 
     if(http_getArg(request->url,"mac",tmpA,sizeof(tmpA))) {
         for( i = 0; i < 6; i++ )
@@ -952,7 +925,6 @@ int http_fn_cfg_mac(http_request_t *request) {
 
     WiFI_GetMacAddress((char *)mac);
 
-
     poststr(request,"<h2> Here you can change MAC address.</h2>");
     poststr(request,"<form action=\"/cfg_mac\">\
             <label for=\"mac\">MAC:</label><br>\
@@ -961,10 +933,8 @@ int http_fn_cfg_mac(http_request_t *request) {
     poststr(request,"\"><br><br>\
             <input type=\"submit\" value=\"Submit\" onclick=\"return confirm('Are you sure? Please check MAC hex string twice?')\">\
         </form> ");
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -982,8 +952,7 @@ int http_fn_flash_read_tool(http_request_t *request) {
 	char tmpB[64];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Flash read");
     poststr(request,"<h4>Flash Read Tool</h4>");
     if(	http_getArg(request->url,"hex",tmpA,sizeof(tmpA))){
         hex = atoi(tmpA);
@@ -1057,11 +1026,8 @@ int http_fn_flash_read_tool(http_request_t *request) {
             <input type=\"submit\" value=\"Submit\">\
         </form> ");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1077,8 +1043,7 @@ int http_fn_cmd_tool(http_request_t *request) {
 	//char tmpB[64];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Command tool");
     poststr(request,"<h4>Command Tool</h4>");
 
     if(	http_getArg(request->url,"cmd",tmpA,sizeof(tmpA))) {
@@ -1099,11 +1064,8 @@ int http_fn_cmd_tool(http_request_t *request) {
             <input type=\"submit\" value=\"Submit\">\
         </form> ");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1112,8 +1074,7 @@ int http_fn_startup_command(http_request_t *request) {
 	char tmpA[512];
 	const char *cmd;
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Set startup command");
     poststr(request,"<h4>Set/Change/Clear startup command line</h4>");
     poststr(request,"<h5>Startup command is a shorter, smaller alternative to LittleFS autoexec.bat."
 		"The startup commands are ran at device startup."
@@ -1142,11 +1103,8 @@ int http_fn_startup_command(http_request_t *request) {
             <input type=\"submit\" value=\"Submit\">\
         </form> ");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1154,11 +1112,8 @@ int http_fn_uart_tool(http_request_t *request) {
 	char tmpA[256];
 	int resultLen = 0;
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "UART tool");
     poststr(request,"<h4>UART Tool</h4>");
-
-
 
     if(http_getArg(request->url,"data",tmpA,sizeof(tmpA))) {
 #ifndef OBK_DISABLE_ALL_DRIVERS
@@ -1195,25 +1150,19 @@ int http_fn_uart_tool(http_request_t *request) {
             <input type=\"submit\" value=\"Submit\">\
         </form> ");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
 
 int http_fn_config_dump_table(http_request_t *request) {
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
-
+    http_html_start(request, "Dump config");
     poststr(request,"Not implemented <br>");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1225,8 +1174,7 @@ int http_fn_cfg_quick(http_request_t *request) {
 	char tmpA[128];
     int j;
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Quick Config");
     poststr(request,"<h4>Quick Config</h4>");
 
     if(http_getArg(request->url,"dev",tmpA,sizeof(tmpA))) {
@@ -1242,10 +1190,8 @@ int http_fn_cfg_quick(http_request_t *request) {
     poststr(request,"</select>");
     poststr(request,"<input type=\"submit\" value=\"Set\"/></form>");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1275,8 +1221,7 @@ int http_fn_cfg_ha(http_request_t *request) {
     baseName = CFG_GetShortDeviceName();
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Home Assistant Setup");
     poststr(request,"<h4>Home Assistant Cfg</h4>");
 	hprintf128(request,"<h4>Note that your short device name is: %s</h4>",baseName);
     poststr(request,"<h4>Paste this to configuration yaml</h4>");
@@ -1359,10 +1304,8 @@ int http_fn_cfg_ha(http_request_t *request) {
 
     poststr(request,"</textarea>");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1500,8 +1443,7 @@ int http_fn_cm(http_request_t *request) {
 
 int http_fn_cfg(http_request_t *request) {
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Config");
     poststr(request,"<form action=\"cfg_pins\"><input type=\"submit\" value=\"Configure Module\"/></form>");
     poststr(request,"<form action=\"cfg_generic\"><input type=\"submit\" value=\"Configure General\"/></form>");
     poststr(request,"<form action=\"cfg_startup\"><input type=\"submit\" value=\"Configure Startup\"/></form>");
@@ -1533,9 +1475,8 @@ int http_fn_cfg(http_request_t *request) {
 	}
 #endif
 #endif
-    poststr(request,htmlReturnToMenu);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToMenu);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1548,8 +1489,7 @@ int http_fn_cfg_pins(http_request_t *request) {
 	char tmpB[64];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Pin config");
     poststr(request,"<h5> First textfield is used to enter channel index (relay index), used to support multiple relays and buttons</h5>");
     poststr(request,"<h5> (so, first button and first relay should have channel 1, second button and second relay have channel 2, etc)</h5>");
     poststr(request,"<h5> Second textfield (only for buttons) is used to enter channel to toggle when doing double click</h5>");
@@ -1664,10 +1604,8 @@ int http_fn_cfg_pins(http_request_t *request) {
     }
     poststr(request,"<input type=\"submit\" value=\"Save\"/></form>");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1695,8 +1633,7 @@ int http_fn_cfg_generic(http_request_t *request) {
 	char tmpB[64];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Generic config");
 
     if(	http_getArg(request->url,"boot_ok_delay",tmpA,sizeof(tmpA))) {
 		i = atoi(tmpA);
@@ -1752,10 +1689,8 @@ int http_fn_cfg_generic(http_request_t *request) {
     poststr(request,"\"><br>");
     poststr(request,"<input type=\"submit\" value=\"Save\"/></form>");
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1766,9 +1701,7 @@ int http_fn_cfg_startup(http_request_t *request) {
 	char tmpA[128];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
-
+    http_html_start(request, "Config startup");
 	hprintf128(request,"<h5>Here you can set pin start values<h5>");
 	hprintf128(request,"<h5>For relays, simply use 1 or 0</h5>");
 	hprintf128(request,"<h5>For 'remember last power state', use -1 as a special value</h5>");
@@ -1812,10 +1745,8 @@ int http_fn_cfg_startup(http_request_t *request) {
 		}
 	}
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1824,8 +1755,7 @@ int http_fn_cfg_dgr(http_request_t *request) {
 	char tmpA[128];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Device groups");
 
 	hprintf128(request,"<h5>Here you can configure Tasmota Device Groups<h5>");
 
@@ -1904,10 +1834,8 @@ int http_fn_cfg_dgr(http_request_t *request) {
 		poststr(request,"    </tr></table>  <input type=\"submit\" value=\"Submit\"></form>");
 	}
 
-    poststr(request,htmlReturnToCfg);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToCfgLink);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
@@ -1919,7 +1847,7 @@ int http_fn_ota_exec(http_request_t *request) {
 	//char tmpB[64];
 
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
+    http_html_start(request, "OTA request");
     if(http_getArg(request->url,"host",tmpA,sizeof(tmpA))) {
         hprintf128(request,"<h3>OTA requested for %s!</h3>",tmpA);
     	addLogAdv(LOG_INFO, LOG_FEATURE_HTTP,"http_fn_ota_exec: will try to do OTA for %s \r\n",tmpA);
@@ -1935,17 +1863,15 @@ int http_fn_ota_exec(http_request_t *request) {
     otarequest(tmpA);
 #endif
     }
-    poststr(request,htmlReturnToMenu);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToMenu);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
 
 int http_fn_ota(http_request_t *request) {
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
+    http_html_start(request, "OTA system");
     poststr(request,"<p>Simple OTA system (you should rather use the OTA from App panel where you can drag and drop file easily without setting up server). Use RBL file for OTA. In the OTA below, you should paste link to RBL file (you need HTTP server).</p>");
     poststr(request,"<form action=\"/ota_exec\">\
             <label for=\"host\">URL for new bin file:</label><br>\
@@ -1953,22 +1879,18 @@ int http_fn_ota(http_request_t *request) {
     poststr(request,"\"><br>\
             <input type=\"submit\" value=\"Submit\" onclick=\"return confirm('Are you sure?')\">\
         </form> ");
-    poststr(request,htmlReturnToMenu);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
-
+    poststr(request,htmlFooterReturnToMenu);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }
 
 int http_fn_other(http_request_t *request) {
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    HTTP_AddHeader(request);
+    http_html_start(request, "Not found");
     poststr(request,"Not found.<br/>");
-    poststr(request,htmlReturnToMenu);
-    HTTP_AddBuildFooter(request);
-    poststr(request,htmlEnd);
+    poststr(request,htmlFooterReturnToMenu);
+    http_html_end(request);
 	poststr(request, NULL);
     return 0;
 }

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -60,7 +60,7 @@ const char htmlHeadStyle[] =
 		".hf{display:none;}"
 		".hdiv{width:95%;white-space:nowrap;}"
 		".hele{width:210px;display:inline-block;margin-left:2px;}"
-		"div#statediv{padding:0}"
+		"div#state{padding:0} div#changed{padding:0}"
 		"div#main{text-align:left; display:inline-block; color:#eaeaea;min-width:340px;max-width:800px;}"
 	"</style>";
 const char htmlBodyStart[] =
@@ -198,6 +198,46 @@ void http_setup(http_request_t *request, const char *type){
 	poststr(request,httpCorsHeaders);
 	poststr(request,"\r\n"); // end headers with double CRLF
 	poststr(request,"\r\n");
+}
+
+void http_html_start(http_request_t *request, const char *pagename) {
+// void HTTP_AddHeader(http_request_t *request) {
+	poststr(request, htmlDoctype);
+	poststr(request, "<title>");
+	poststr(request, CFG_GetDeviceName()); // todo: check escaping
+	if (pagename) {
+		poststr(request, " - ");
+		poststr(request, pagename);
+	} 
+	poststr(request, "</title>");
+	poststr(request, htmlHeadMain);
+	poststr(request, htmlHeadStyle);
+	poststr(request, htmlBodyStart);
+	poststr(request, CFG_GetDeviceName()); // todo: check escaping
+	poststr(request, htmlBodyStart2);
+}
+
+void http_html_end(http_request_t *request) {
+// was void HTTP_AddBuildFooter(http_request_t *request) {
+	char upTimeStr[128];
+	unsigned char mac[32];
+
+	poststr(request, " | ");
+	poststr(request, htmlFooterInfo);
+	poststr(request, "<br>");
+	poststr(request, g_build_str);
+	poststr(request, "<br>Online for ");
+	misc_formatUpTimeString(Time_getUpTimeSeconds(), upTimeStr);
+	poststr(request, upTimeStr);
+
+	WiFI_GetMacAddress((char *)mac);
+
+	sprintf(upTimeStr, "<br>Device MAC: %02X:%02X:%02X:%02X:%02X:%02X",mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+	poststr(request, upTimeStr);
+	sprintf(upTimeStr, "<br>Short name: %s, Chipset %s",CFG_GetShortDeviceName(),PLATFORM_MCU_NAME);
+	poststr(request, upTimeStr);
+
+	poststr(request, htmlBodyEnd);
 }
 
 const char *http_checkArg(const char *p, const char *n) {
@@ -351,37 +391,6 @@ void setupAllWB2SPinsAsButtons() {
 
 		PIN_SetPinRoleForPinIndex(27,IOR_Button);
 		PIN_SetPinChannelForPinIndex(27,1);
-}
-
-
-
-
-const char *g_header_start = "<h1><a href=\"https://github.com/openshwprojects/OpenBK7231T_App/\">";
-const char *g_header_end = "</a></h1><h3><a href=\"https://www.elektroda.com/rtvforum/viewtopic.php?p=19841301#19841301\">[Read more]</a><a href=\"https://paypal.me/openshwprojects\">[Support project]</a></h3>";
-
-
-void HTTP_AddHeader(http_request_t *request) {
-	poststr(request,g_header_start);
-	poststr(request,CFG_GetDeviceName());
-	poststr(request,g_header_end);
-}
-
-void HTTP_AddBuildFooter(http_request_t *request) {
-	char upTimeStr[128];
-	unsigned char mac[32];
-
-	poststr(request,"<br>");
-	poststr(request,g_build_str);
-	poststr(request,"<br> Online for ");
-	misc_formatUpTimeString(Time_getUpTimeSeconds(), upTimeStr);
-	poststr(request,upTimeStr);
-
-	WiFI_GetMacAddress((char *)mac);
-
-	sprintf(upTimeStr,"<br> Device MAC: %02X%02X%02X%02X%02X%02X",mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
-	poststr(request,upTimeStr);
-	sprintf(upTimeStr,"<br> Short name: %s, Chipset %s",CFG_GetShortDeviceName(),PLATFORM_MCU_NAME);
-	poststr(request,upTimeStr);
 }
 
 // add some more output safely, sending if necessary.

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -60,7 +60,7 @@ const char htmlHeadStyle[] =
 		".hf{display:none;}"
 		".hdiv{width:95%;white-space:nowrap;}"
 		".hele{width:210px;display:inline-block;margin-left:2px;}"
-		"div#statediv{padding:0}"
+		"div#state{padding:0} div#changed{padding:0}"
 		"div#main{text-align:left; display:inline-block; color:#eaeaea;min-width:340px;max-width:800px;}"
 	"</style>";
 const char htmlBodyStart[] =

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -62,6 +62,7 @@ const char htmlHeadStyle[] =
 		".hele{width:210px;display:inline-block;margin-left:2px;}"
 		"div#state{padding:0} div#changed{padding:0}"
 		"div#main{text-align:left; display:inline-block; color:#eaeaea;min-width:340px;max-width:800px;}"
+		"table{table-layout:fixed}"
 	"</style>";
 const char htmlBodyStart[] =
 	"<body>"

--- a/src/httpserver/new_http.h
+++ b/src/httpserver/new_http.h
@@ -7,11 +7,10 @@ extern const char httpMimeTypeHTML[];              // HTML MIME type
 extern const char httpMimeTypeText[];           // TEXT MIME type
 extern const char httpMimeTypeJson[];
 extern const char httpMimeTypeBinary[];
-extern const char htmlHeader[];
-extern const char htmlEnd[];
-extern const char htmlReturnToMenu[];
-extern const char htmlRefresh[];
-extern const char htmlReturnToCfg[];
+
+extern const char htmlFooterReturnToMenu[];
+extern const char htmlFooterRefreshLink[];
+extern const char htmlFooterReturnToCfgLink[];
 
 extern const char *htmlPinRoleNames[];
 
@@ -20,8 +19,6 @@ extern const char *g_build_str;
 #define HTTP_RESPONSE_OK 200
 #define HTTP_RESPONSE_NOT_FOUND 404
 #define HTTP_RESPONSE_SERVER_ERROR 500
-
-
 
 #define MAX_QUERY 16
 #define MAX_HEADERS 16
@@ -53,11 +50,13 @@ typedef struct http_request_tag {
 
 int HTTP_ProcessPacket(http_request_t *request);
 void http_setup(http_request_t *request, const char *type);
+void http_html_start(http_request_t *request, const char *pagename);
+void http_html_end(http_request_t *request);
 int poststr(http_request_t *request, const char *str);
 int postany(http_request_t *request, const char *str, int len);
 void misc_formatUpTimeString(int totalSeconds, char *o);
-void HTTP_AddBuildFooter(http_request_t *request);
-void HTTP_AddHeader(http_request_t *request);
+// void HTTP_AddBuildFooter(http_request_t *request);
+// void HTTP_AddHeader(http_request_t *request);
 int http_getArg(const char *base, const char *name, char *o, int maxSize);
 int http_getArgInteger(const char *base, const char *name);
 

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -179,7 +179,6 @@ static int http_rest_get(http_request_t *request){
         return http_rest_get_flash_advanced(request);
     }
 
-
     if (!strcmp(request->url, "api/dumpconfig")){
         return http_rest_get_dumpconfig(request);
     }
@@ -192,13 +191,11 @@ static int http_rest_get(http_request_t *request){
         return http_rest_get_flash_vars_test(request);
     }
 
-
-
-
     http_setup(request, httpMimeTypeHTML);
+    http_html_start(request, "GET REST API");
     poststr(request, "GET of ");
     poststr(request, request->url);
-    poststr(request, htmlEnd);
+    http_html_end(request);
     poststr(request,NULL);
     return 0;
 }
@@ -257,6 +254,7 @@ static int http_rest_post(http_request_t *request){
 #endif
 
     http_setup(request, httpMimeTypeHTML);
+    http_html_start(request, "POST REST API");
     poststr(request, "POST to ");
     poststr(request, request->url);
     poststr(request, "<br/>Content Length:");
@@ -265,15 +263,10 @@ static int http_rest_post(http_request_t *request){
     poststr(request, "<br/>Content:[");
     poststr(request, request->bodystart);
     poststr(request, "]<br/>");
-    poststr(request, htmlEnd);
+    http_html_end(request);
     poststr(request,NULL);
     return 0;
 }
-
-
-
-
-
 
 static int http_rest_app(http_request_t *request){
     const char *webhost = CFG_GetWebappRoot();
@@ -288,9 +281,10 @@ static int http_rest_app(http_request_t *request){
         poststr(request, webhost);
         poststr(request, apppage4);
     } else {
-        poststr(request,htmlHeader);
-        poststr(request,htmlReturnToMenu);
-        poststr(request,"no APP available<br/>");
+        http_html_start(request, "Not available");
+        poststr(request, htmlFooterReturnToMenu);
+        poststr(request, "no APP available<br/>");
+        http_html_end(request);
     }
     poststr(request,NULL);
     return 0;

--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -481,8 +481,8 @@ static int http_getlograw(http_request_t *request){
 
 static int http_getlog(http_request_t *request){
     http_setup(request, httpMimeTypeHTML);
-    poststr(request,htmlHeader);
-    poststr(request,htmlReturnToMenu);
+    http_html_start(request, "Log");
+    poststr(request,htmlFooterReturnToMenu);
 
     poststr(request, "<pre>");
     char *post = "</pre>";
@@ -490,7 +490,7 @@ static int http_getlog(http_request_t *request){
     http_getlograw(request);
 
     poststr(request, post);
-    poststr(request, htmlEnd);
+    http_html_end(request);
     poststr(request, NULL);
 
     return 0;


### PR DESCRIPTION
First steps to HTML & JavaScript changes in the UI. I'd like to update things to be a bit easier to use, potentially more consistent with Tasmota. Starting small as I figure things out in the code.

* Made the links to repo, forum thread, donation open with target=_blank (in a new tab)
* Tweaked the UI to move all the status-information (state of devices, watchdog) together (this moves the shared UI items down a bit)
* Made it possible to just request the status information via http://url/index?state=
* Made the status-information section auto-updating with JavaScript every 3 seconds
* Moved forum thread & donation link to below main UI elements
* Moved auto-submit JS from separate script to inline with input elements
* Removes URL parameters from main page after the page loads with History API (reduces chances that people will reload the page and change something unwanted)
* Hides status-update information after 5 seconds (setting values, toggles, etc.) for cleaner UI
* Added http_html_start(...) and http_html_end(...) to deduplicate & unify HTML on pages
* Tested button/relay + PWM/dimmer settings