### PR TITLE
Remove old, breaking debug code in ConnectToWifi

### DIFF
--- a/src/hal/bk7231/hal_wifi_bk7231.c
+++ b/src/hal/bk7231/hal_wifi_bk7231.c
@@ -236,23 +236,6 @@ void HAL_ConnectToWiFi(const char *oob_ssid,const char *connect_key)
 {
 	g_bOpenAccessPointMode = 0;
 
-#if 1
-	network_InitTypeDef_adv_st	wNetConfigAdv;
-
-	os_memset( &wNetConfigAdv, 0x0, sizeof(network_InitTypeDef_adv_st) );
-
-	os_strcpy((char*)wNetConfigAdv.ap_info.ssid, oob_ssid);
-	hwaddr_aton("48:ee:0c:48:93:12", (unsigned char *)wNetConfigAdv.ap_info.bssid);
-	wNetConfigAdv.ap_info.security = SECURITY_TYPE_WPA2_MIXED;
-	wNetConfigAdv.ap_info.channel = 5;
-
-	os_strcpy((char*)wNetConfigAdv.key, connect_key);
-	wNetConfigAdv.key_len = os_strlen(connect_key);
-	wNetConfigAdv.dhcp_mode = DHCP_CLIENT;
-	wNetConfigAdv.wifi_retry_interval = 100;
-
-	bk_wlan_start_sta_adv(&wNetConfigAdv);
-#else
     network_InitTypeDef_st network_cfg;
 
     os_memset(&network_cfg, 0x0, sizeof(network_InitTypeDef_st));
@@ -267,7 +250,6 @@ void HAL_ConnectToWiFi(const char *oob_ssid,const char *connect_key)
     ADDLOGF_INFO("ssid:%s key:%s\r\n", network_cfg.wifi_ssid, network_cfg.wifi_key);
 
     bk_wlan_start(&network_cfg);
-#endif
 }
 
 


### PR DESCRIPTION
HAL_ConnectToWiFi() in src/hal/bk7231/hal_wifi_bk7231.c was added with some debug code enabled, which forced connection to a specific Wifi AP MAC address, rather than using the SSID information from the configs. I removed this block - now I can get it to connect normally. 

(I'm not quite sure how execution ends up - it was initially not a problem. I noticed it when syncing to the newer BK7231N SDK.)