### PR TITLE
Update BK7231T build info

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,44 +1,43 @@
-
-
 # Building for BK7231T
 
 Get the SDK repo:
 https://github.com/openshwprojects/OpenBK7231T
-Clone it to a folder, e.g. bk7231sdk/
+Clone it to a folder, e.g. `bk7231sdk/`
 
-Clone the [app](https://github.com/openshwprojects/OpenBK7231T_App) repo into bk7231sdk/apps/<appname> - e.g. bk7231sdk\apps\openbk7231app
+Clone the [app](https://github.com/openshwprojects/OpenBK7231T_App) repo into `bk7231sdk/apps/<appname>` - e.g. `bk7231sdk/apps/openbk7231app`.
 
-On Windows, start a cygwin prompt.
+On Windows, install [Cygwin](https://www.cygwin.com). Manually search for and install the "make" and "python3" packages during the setup. Note that Cygwin must be installed in a directory without whitespaces in the path.
 
-go to the SDK folder.
+Open Cygwin and browse to the SDK repo folder (`cd /cygdrive/c/Users/<path to folder>`).
 
-build using:
+Build using:
 `./b.sh`
-  
-you can also do advanced build by build_app.sh:
+
+You can also do advanced builds using `build_app.sh`:
 `./build_app.sh apps/<appname> <appname> <appversion>`
-(appname must be identical to foldername in apps/ folder)
-  
-e.g. `./build_app.sh apps/openbk7231app openbk7231app 1.0.0`
-  
-  
- 
+(appname must be identical to foldername in `apps/` folder)
+
+e.g. `./build_app.sh apps/openbk7231app openbk7231app 1.0.0`.
+
+The output binaries can be found at `apps/<appname>/output/<appversion>`.
+
+
 # Building for BK7231N
 
 Same as for BK7231T, but use BK7231N SDK and you also might need to rename project directory from OpenBK7231T_App to OpenBK7231N_App:
 https://github.com/openshwprojects/OpenBK7231N
-  
-   
+
+
 # Building for XR809
 
 Get XR809 SDK:
 https://github.com/openshwprojects/OpenXR809
 
 Checkout [this repository](https://github.com/openshwprojects/OpenBK7231T_App) to openxr809/project/oxr_sharedApp/shared/
-  
+
 Run ./build_oxr_sharedapp.sh
-  
-    
+
+
 # Building for W800/W801
 
 To build for W800, you need our W800 SDK fork:
@@ -55,14 +54,3 @@ Get it from here (you'd need to register):
 https://occ.t-head.cn/community/download
 
 The IDE/compiler bundle I used was: cds-windows-mingw-elf_tools-V5.2.11-20220512-2012.zip
-
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  


### PR DESCRIPTION
Elaborate on necessary steps to make the build process easier for new users and contributors. The side note about whitespaces not being allowed on the Cygwin installation folder is because a python script somewhere in the build is not properly constructed, parsing paths with whitespaces as two separate arguments.