### PR TITLE
BP1658(CJ) support

### DIFF
--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -75,9 +75,9 @@ float led_temperature_current = 0;
 
 int isCWMode() {
 	int pwmCount;
-	
+
 	pwmCount = PIN_CountPinsWithRoleOrRole(IOR_PWM, IOR_PWM_n);
-	
+
 	if(pwmCount == 2)
 		return 1;
 	return 0;
@@ -85,7 +85,7 @@ int isCWMode() {
 
 int shouldSendRGB() {
 	int pwmCount;
-	
+
 	// forced RGBCW means 'send rgb'
 	// This flag should be set for SM2315 and BP5758
 	// This flag also could be used for dummy Device Groups driver-module
@@ -93,7 +93,7 @@ int shouldSendRGB() {
 		return 1;
 
 	pwmCount = PIN_CountPinsWithRoleOrRole(IOR_PWM, IOR_PWM_n);
-	
+
 	// single colors and CW don't send rgb
 	if(pwmCount <= 2)
 		return 0;
@@ -192,6 +192,9 @@ void apply_smart_light() {
 	if(DRV_IsRunning("BP5758D")) {
 		BP5758D_Write(finalRGBCW);
 	}
+	if(DRV_IsRunning("BP1658CJ")) {
+		BP5758D_Write(finalRGBCW);
+	}
 #endif
 	if(CFG_HasFlag(OBK_FLAG_LED_REMEMBERLASTSTATE)) {
 		HAL_FlashVars_SaveLED(g_lightMode,g_brightness / g_cfg_brightnessMult, led_temperature_current,baseColors[0],baseColors[1],baseColors[2]);
@@ -209,7 +212,7 @@ static OBK_Publish_Result sendColorChange() {
 	c[0] = (byte)(baseColors[0]);
 	c[1] = (byte)(baseColors[1]);
 	c[2] = (byte)(baseColors[2]);
-	
+
 	sprintf(s,"%02X%02X%02X",c[0],c[1],c[2]);
 
 	return MQTT_PublishMain_StringString("led_basecolor_rgb",s, 0);
@@ -220,7 +223,7 @@ void LED_GetBaseColorString(char * s) {
 	c[0] = (byte)(baseColors[0]);
 	c[1] = (byte)(baseColors[1]);
 	c[2] = (byte)(baseColors[2]);
-	
+
 	sprintf(s,"%02X%02X%02X",c[0],c[1],c[2]);
 }
 static void sendFinalColor() {
@@ -234,7 +237,7 @@ static void sendFinalColor() {
 	c[0] = (byte)(finalColors[0]);
 	c[1] = (byte)(finalColors[1]);
 	c[2] = (byte)(finalColors[2]);
-	
+
 	sprintf(s,"%02X%02X%02X",c[0],c[1],c[2]);
 
 	MQTT_PublishMain_StringString("led_finalcolor_rgb",s, 0);
@@ -279,7 +282,7 @@ float LED_GetTemperature0to1Range() {
 }
 void LED_SetTemperature(int tmpInteger, bool bApply) {
 	float f;
-	
+
 	led_temperature_current = tmpInteger;
 
 	f = LED_GetTemperature0to1Range();
@@ -335,7 +338,7 @@ static int enableAll(const void *context, const char *cmd, const char *args, int
 
 		LED_SetEnableAll(bEnable);
 
-	
+
 	//	sendColorChange();
 	//	sendDimmerChange();
 	//	sendTemperatureChange();
@@ -391,7 +394,7 @@ static int dimmer(const void *context, const char *cmd, const char *args, int cm
 }
 void LED_SetFinalRGB(byte r, byte g, byte b) {
 	g_lightMode = Light_RGB;
-			
+
 	baseColors[0] = r;
 	baseColors[1] = g;
 	baseColors[2] = b;
@@ -460,7 +463,7 @@ int LED_SetBaseColor(const void *context, const char *cmd, const char *args, int
 				}
 				// keep hsv in sync
 			}
-			
+
 			RGBtoHSV(baseColors[0]/255.0f, baseColors[1]/255.0f, baseColors[2]/255.0f, &g_hsv_h, &g_hsv_s, &g_hsv_v);
 
 			apply_smart_light();
@@ -517,7 +520,7 @@ static void onHSVChanged() {
 
 	apply_smart_light();
 
-	
+
 	if(CFG_HasFlag(OBK_FLAG_MQTT_BROADCASTLEDFINALCOLOR)) {
 		sendFinalColor();
 	}
@@ -529,7 +532,7 @@ static void led_setSaturation(float sat){
 	onHSVChanged();
 }
 static void led_setHue(float hue){
-	
+
 	g_hsv_h = hue;
 
 	onHSVChanged();
@@ -539,7 +542,7 @@ static int setSaturation(const void *context, const char *cmd, const char *args,
 
 	f = atof(args);
 
-	// input is in 0-100 range 
+	// input is in 0-100 range
 	f *= 0.01f;
 
 	led_setSaturation(f);

--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -193,7 +193,7 @@ void apply_smart_light() {
 		BP5758D_Write(finalRGBCW);
 	}
 	if(DRV_IsRunning("BP1658CJ")) {
-		BP5758D_Write(finalRGBCW);
+		BP1658CJ_Write(finalRGBCW);
 	}
 #endif
 	if(CFG_HasFlag(OBK_FLAG_LED_REMEMBERLASTSTATE)) {

--- a/src/driver/drv_bp1658cj.c
+++ b/src/driver/drv_bp1658cj.c
@@ -1,0 +1,225 @@
+#include "../new_common.h"
+#include "../new_pins.h"
+#include "../new_cfg.h"
+// Commands register, execution API and cmd tokenizer
+#include "../cmnds/cmd_public.h"
+#include "../mqtt/new_mqtt.h"
+#include "../logging/logging.h"
+#include "drv_local.h"
+#include "drv_uart.h"
+#include "../httpserver/new_http.h"
+#include "../hal/hal_pins.h"
+
+#include "drv_bp1658cj.h"
+
+static int g_pin_clk = 26;
+static int g_pin_data = 24;
+// Mapping between RGBCW to current BP1658CJ channels
+static byte g_channelOrder[5] = { 1, 0, 2, 3, 4 }; //in our case: Hama 5.5W GU10 RGBCW the channel order is: [Green][Red][Blue][Warm][Cold]
+
+const int BP1658CJ_DELAY = 10; //delay*3 --> nop's
+
+
+void usleep(int r) //delay function do 3*r nothing, because rtos_delay_milliseconds is too much
+{
+  for(volatile int i=0; i<r; i++)
+    __asm__("nop\nnop\nnop");
+}
+
+static void BP1658CJ_Stop() {
+	HAL_PIN_SetOutputValue(g_pin_clk, 1);
+	usleep(BP1658CJ_DELAY);
+	HAL_PIN_SetOutputValue(g_pin_data, 1);
+	usleep(BP1658CJ_DELAY);
+}
+
+
+static void BP1658CJ_WriteByte(uint8_t value) {
+	int bit_idx;
+	bool bit;
+
+	for (bit_idx = 7; bit_idx >= 0; bit_idx--) {
+		bit = BIT_CHECK(value, bit_idx);
+		HAL_PIN_SetOutputValue(g_pin_data, bit);
+		usleep(BP1658CJ_DELAY);
+		HAL_PIN_SetOutputValue(g_pin_clk, 1);
+		usleep(BP1658CJ_DELAY);
+		HAL_PIN_SetOutputValue(g_pin_clk, 0);
+		usleep(BP1658CJ_DELAY);
+	}
+	// Wait for ACK
+	// TODO: pullup?
+	HAL_PIN_Setup_Input(g_pin_data);
+	HAL_PIN_SetOutputValue(g_pin_clk, 1);
+	usleep(BP1658CJ_DELAY);
+	HAL_PIN_SetOutputValue(g_pin_clk, 0);
+	usleep(BP1658CJ_DELAY);
+	HAL_PIN_Setup_Output(g_pin_data);
+}
+
+static void BP1658CJ_Start(uint8_t addr) {
+	HAL_PIN_SetOutputValue(g_pin_data, 0);
+	usleep(BP1658CJ_DELAY);
+	HAL_PIN_SetOutputValue(g_pin_clk, 0);
+	usleep(BP1658CJ_DELAY);
+	BP1658CJ_WriteByte(addr);
+}
+
+static void BP1658CJ_PreInit() {
+	HAL_PIN_Setup_Output(g_pin_clk);
+	HAL_PIN_Setup_Output(g_pin_data);
+
+	BP1658CJ_Stop();
+
+	usleep(BP1658CJ_DELAY);
+}
+
+
+
+void BP1658CJ_Write(byte *rgbcw) {
+  //ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp (int): %i,%i,%i,%i,%i", rgbcw[0], rgbcw[1], rgbcw[2], rgbcw[3], rgbcw[4]);
+  ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp: #%02X%02X%02X%02X%02X", rgbcw[0], rgbcw[1], rgbcw[2], rgbcw[3], rgbcw[4]);
+  //ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp (test): #%i%i%i%i%i", rgbcw[0], rgbcw[1], rgbcw[2], rgbcw[3], rgbcw[4]);
+  unsigned short cur_col_10[5];
+
+	for(int i = 0; i < 5; i++){
+		// convert 0-255 to 0-1023
+		cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
+	}
+
+	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP1658CJ's sleep mode ([80] ).
+	if (cur_col_10[0]==0 && cur_col_10[1]==0 && cur_col_10[2]==0 && cur_col_10[3]==0 && cur_col_10[4]==0) {
+		BP1658CJ_Start(BP1658CJ_ADDR_SLEEP);
+                BP1658CJ_WriteByte(BP1658CJ_SUBADDR);
+                for(int i = 0; i<10; ++i) //set all 10 channels to 00
+                    BP1658CJ_WriteByte(0x00);
+		BP1658CJ_Stop();
+		return;
+	}
+
+	// Even though we could address changing channels only, in practice we observed that the lightbulb always sets all channels.
+	BP1658CJ_Start(BP1658CJ_ADDR_OUT);
+
+        // The First Byte is the Subadress
+        BP1658CJ_WriteByte(BP1658CJ_SUBADDR);
+	// Brigtness values are transmitted as two bytes. The light-bulb accepts a 10-bit integer (0-1023) as an input value.
+	// The first 5bits of this input are transmitted in second byte, the second 5bits in the first byte.
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[0] & 0x1F));  //Red
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[0] >> 5));
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[1] & 0x1F)); //Green
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[1] >> 5));
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[2] & 0x1F)); //Blue
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[2] >> 5));
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[4] & 0x1F)); //Cold
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[4] >> 5));
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[3] & 0x1F)); //Warm
+	BP1658CJ_WriteByte((uint8_t)(cur_col_10[3] >> 5));
+
+	BP1658CJ_Stop();
+	return true;
+}
+
+
+static int BP1658CJ_RGBCW(const void *context, const char *cmd, const char *args, int flags){
+	const char *c = args;
+	byte col[5] = { 0, 0, 0, 0, 0 };
+	int ci;
+	int val;
+
+	ci = 0;
+
+	// some people prefix colors with #
+	if(c[0] == '#')
+		c++;
+	while (*c){
+		char tmp[3];
+		int r;
+		tmp[0] = *(c++);
+		if (!*c)
+			break;
+		tmp[1] = *(c++);
+		tmp[2] = '\0';
+		r = sscanf(tmp, "%x", &val);
+		if (!r) {
+			ADDLOG_ERROR(LOG_FEATURE_CMD, "BP1658CJ_RGBCW no sscanf hex result from %s", tmp);
+			break;
+		}
+
+		ADDLOG_DEBUG(LOG_FEATURE_CMD, "BP1658CJ_RGBCW found chan %d -> val255 %d (from %s)", ci, val, tmp);
+
+		col[ci] = val;
+
+		// move to next channel.
+		ci ++;
+		if(ci>=5)
+			break;
+	}
+
+	BP1658CJ_Write(col);
+
+	return 0;
+}
+// BP1658CJ_Map is used to map the RGBCW indices to BP1658CJ indices
+// This is how you uset RGB CW order:
+// BP1658CJ_Map 0 1 2 3 4
+
+static int BP1658CJ_Map(const void *context, const char *cmd, const char *args, int flags){
+
+	Tokenizer_TokenizeString(args);
+
+	if(Tokenizer_GetArgsCount()==0) {
+		ADDLOG_DEBUG(LOG_FEATURE_CMD, "BP1658CJ_Map current order is %i %i %i    %i %i! ",
+			(int)g_channelOrder[0],(int)g_channelOrder[1],(int)g_channelOrder[2],(int)g_channelOrder[3],(int)g_channelOrder[4]);
+		return 0;
+	}
+
+	g_channelOrder[0] = Tokenizer_GetArgIntegerRange(0, 0, 4);
+	g_channelOrder[1] = Tokenizer_GetArgIntegerRange(1, 0, 4);
+	g_channelOrder[2] = Tokenizer_GetArgIntegerRange(2, 0, 4);
+	g_channelOrder[3] = Tokenizer_GetArgIntegerRange(3, 0, 4);
+	g_channelOrder[4] = Tokenizer_GetArgIntegerRange(4, 0, 4);
+
+	ADDLOG_DEBUG(LOG_FEATURE_CMD, "BP1658CJ_Map new order is %i %i %i    %i %i! ",
+		(int)g_channelOrder[0],(int)g_channelOrder[1],(int)g_channelOrder[2],(int)g_channelOrder[3],(int)g_channelOrder[4]);
+
+	return 0;
+}
+
+
+// startDriver BP1658CJ
+// BP1658CJ_RGBCW FF00000000
+void BP1658CJ_Init() {
+
+	g_pin_clk = PIN_FindPinIndexForRole(IOR_BP1658CJ_CLK,g_pin_clk);
+	g_pin_data = PIN_FindPinIndexForRole(IOR_BP1658CJ_DAT,g_pin_data);
+
+    BP1658CJ_PreInit();
+
+    CMD_RegisterCommand("BP1658CJ_RGBCW", "", BP1658CJ_RGBCW, "qq", NULL);
+    CMD_RegisterCommand("BP1658CJ_Map", "", BP1658CJ_Map, "qq", NULL);
+}
+
+void BP1658CJ_RunFrame() {
+
+}
+
+
+void BP1658CJ_OnChannelChanged(int ch, int value) {
+#if 0
+	byte col[5];
+	int channel;
+	int c;
+
+	for(channel = 0; channel < CHANNEL_MAX; channel++){
+		if(IOR_PWM == CHANNEL_GetRoleForOutputChannel(channel)){
+			col[c] = CHANNEL_Get(channel);
+			c++;
+		}
+	}
+	for( ; c < 5; c++){
+		col[c] = 0;
+	}
+
+	BP1658CJ_Write(col);
+#endif
+}

--- a/src/driver/drv_bp1658cj.c
+++ b/src/driver/drv_bp1658cj.c
@@ -17,13 +17,13 @@ static int g_pin_data = 24;
 // Mapping between RGBCW to current BP1658CJ channels
 static byte g_channelOrder[5] = { 1, 0, 2, 3, 4 }; //in our case: Hama 5.5W GU10 RGBCW the channel order is: [Green][Red][Blue][Warm][Cold]
 
-const int BP1658CJ_DELAY = 10; //delay*3 --> nop's
+const int BP1658CJ_DELAY = 1; //delay*10 --> nops
 
 
-void usleep(int r) //delay function do 3*r nothing, because rtos_delay_milliseconds is too much
+void usleep(int r) //delay function do 10*r nops, because rtos_delay_milliseconds is too much
 {
   for(volatile int i=0; i<r; i++)
-    __asm__("nop\nnop\nnop");
+    __asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 }
 
 static void BP1658CJ_Stop() {

--- a/src/driver/drv_bp1658cj.c
+++ b/src/driver/drv_bp1658cj.c
@@ -77,9 +77,7 @@ static void BP1658CJ_PreInit() {
 
 
 void BP1658CJ_Write(byte *rgbcw) {
-  //ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp (int): %i,%i,%i,%i,%i", rgbcw[0], rgbcw[1], rgbcw[2], rgbcw[3], rgbcw[4]);
   ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp: #%02X%02X%02X%02X%02X", rgbcw[0], rgbcw[1], rgbcw[2], rgbcw[3], rgbcw[4]);
-  //ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp (test): #%i%i%i%i%i", rgbcw[0], rgbcw[1], rgbcw[2], rgbcw[3], rgbcw[4]);
   unsigned short cur_col_10[5];
 
 	for(int i = 0; i < 5; i++){
@@ -87,7 +85,7 @@ void BP1658CJ_Write(byte *rgbcw) {
 		cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
 	}
 
-	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP1658CJ's sleep mode ([80] ).
+	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP1658CJ's sleep mode ([0x80] ).
 	if (cur_col_10[0]==0 && cur_col_10[1]==0 && cur_col_10[2]==0 && cur_col_10[3]==0 && cur_col_10[4]==0) {
 		BP1658CJ_Start(BP1658CJ_ADDR_SLEEP);
                 BP1658CJ_WriteByte(BP1658CJ_SUBADDR);
@@ -100,8 +98,8 @@ void BP1658CJ_Write(byte *rgbcw) {
 	// Even though we could address changing channels only, in practice we observed that the lightbulb always sets all channels.
 	BP1658CJ_Start(BP1658CJ_ADDR_OUT);
 
-        // The First Byte is the Subadress
-        BP1658CJ_WriteByte(BP1658CJ_SUBADDR);
+  // The First Byte is the Subadress
+  BP1658CJ_WriteByte(BP1658CJ_SUBADDR);
 	// Brigtness values are transmitted as two bytes. The light-bulb accepts a 10-bit integer (0-1023) as an input value.
 	// The first 5bits of this input are transmitted in second byte, the second 5bits in the first byte.
 	BP1658CJ_WriteByte((uint8_t)(cur_col_10[0] & 0x1F));  //Red

--- a/src/driver/drv_bp1658cj.h
+++ b/src/driver/drv_bp1658cj.h
@@ -1,19 +1,8 @@
 
 // Thx to the work of https://github.com/arendst (Tasmota) for making the initial version of the driver
 
-// Layout: Bits B[7:8]=10 (address selection identification bits), B[5:6] sleep mode if set to 00, B[0:4] Address selection
-#define BP1658CJ_ADDR_OUT     0xB0  // Device Adress
-#define BP1658CJ_ADDR_SLEEP   0x80
+#define BP1658CJ_ADDR_OUT     0xB0  //
+#define BP1658CJ_ADDR_SLEEP   0x80  // When this command and 00 for every channel is send the device goes to sleep --> was send by original firmware
 
 // Sub Addr
-#define BP1658CJ_SUBADDR 0x23 //assumed: this address has to be send for a color change
-
-// Output enabled (OUT1-5, represented by lower 5 bits)
-#define BP1658CJ_ENABLE_OUTPUTS_ALL 0x1F
-
-// Current values: Bit 6 to 0 represent 30mA, 32mA, 16mA, 8mA, 4mA, 2mA, 1mA respectively
-#define BP1658CJ_10MA 0x0A // 0 0001010
-#define BP1658CJ_14MA 0x0E // 0 0001110
-#define BP1658CJ_15MA 0x0F // 0 0001111
-#define BP1658CJ_65MA 0x63 // 0 1100011
-#define BP1658CJ_90MA 0x7C // 0 1111100
+#define BP1658CJ_SUBADDR 0x23 //assumed: this address has to be send for a color change (never saw any different subadress)

--- a/src/driver/drv_bp1658cj.h
+++ b/src/driver/drv_bp1658cj.h
@@ -1,0 +1,19 @@
+
+// Thx to the work of https://github.com/arendst (Tasmota) for making the initial version of the driver
+
+// Layout: Bits B[7:8]=10 (address selection identification bits), B[5:6] sleep mode if set to 00, B[0:4] Address selection
+#define BP1658CJ_ADDR_OUT     0xB0  // Device Adress
+#define BP1658CJ_ADDR_SLEEP   0x80
+
+// Sub Addr
+#define BP1658CJ_SUBADDR 0x23 //assumed: this address has to be send for a color change
+
+// Output enabled (OUT1-5, represented by lower 5 bits)
+#define BP1658CJ_ENABLE_OUTPUTS_ALL 0x1F
+
+// Current values: Bit 6 to 0 represent 30mA, 32mA, 16mA, 8mA, 4mA, 2mA, 1mA respectively
+#define BP1658CJ_10MA 0x0A // 0 0001010
+#define BP1658CJ_14MA 0x0E // 0 0001110
+#define BP1658CJ_15MA 0x0F // 0 0001111
+#define BP1658CJ_65MA 0x63 // 0 1100011
+#define BP1658CJ_90MA 0x7C // 0 1111100

--- a/src/driver/drv_bp1658cj.h
+++ b/src/driver/drv_bp1658cj.h
@@ -1,8 +1,12 @@
 
 // Thx to the work of https://github.com/arendst (Tasmota) for making the initial version of the driver
+// This implemantation is heavily based on the BP5758D implemantation by openshwprojects
 
-#define BP1658CJ_ADDR_OUT     0xB0  //
-#define BP1658CJ_ADDR_SLEEP   0x80  // When this command and 00 for every channel is send the device goes to sleep --> was send by original firmware
+// Sadly I couldn't find any datasheet of this ic, so I sniffed the i2c protocol with a logic analyser
+// I've been testing the implemantation for a week now and it seems to be working without any issues.
 
-// Sub Addr
-#define BP1658CJ_SUBADDR 0x23 //assumed: this address has to be send for a color change (never saw any different subadress)
+#define BP1658CJ_ADDR_OUT     0xB0
+#define BP1658CJ_ADDR_SLEEP   0x80  // When this command + the subadress and 00 for every channel is send, the device goes to sleep. --> was send by original firmware
+
+// Sub Address
+#define BP1658CJ_SUBADDR      0x23  //assumed: this address has to be send for a color change (never saw any different subadress)

--- a/src/driver/drv_bp5758d.c
+++ b/src/driver/drv_bp5758d.c
@@ -11,7 +11,6 @@
 #include "../hal/hal_pins.h"
 
 #include "drv_bp5758d.h"
-#include "drv_1658cj.h"
 
 static int g_pin_clk = 26;
 static int g_pin_data = 24;

--- a/src/driver/drv_bp5758d.c
+++ b/src/driver/drv_bp5758d.c
@@ -11,6 +11,7 @@
 #include "../hal/hal_pins.h"
 
 #include "drv_bp5758d.h"
+#include "drv_1658cj.h"
 
 static int g_pin_clk = 26;
 static int g_pin_data = 24;
@@ -65,7 +66,7 @@ static void BP5758D_PreInit() {
 	BP5758D_Stop();
 
 	rtos_delay_milliseconds(BP5758D_DELAY);
-	
+
     // For it's init sequence, BP5758D just sets all fields
     BP5758D_Start(BP5758D_ADDR_SETUP);
     // Output enabled: enable all outputs since we're using a RGBCW light
@@ -111,7 +112,7 @@ void BP5758D_Write(byte *rgbcw) {
 	// Even though we could address changing channels only, in practice we observed that the lightbulb always sets all channels.
 	BP5758D_Start(BP5758D_ADDR_OUT1_GL);
 	// Brigtness values are transmitted as two bytes. The light-bulb accepts a 10-bit integer (0-1023) as an input value.
-	// The first 5bits of this input are transmitted in second byte, the second 5bits in the first byte.  
+	// The first 5bits of this input are transmitted in second byte, the second 5bits in the first byte.
 	BP5758D_WriteByte((uint8_t)(cur_col_10[0] & 0x1F));  //Red
 	BP5758D_WriteByte((uint8_t)(cur_col_10[0] >> 5));
 	BP5758D_WriteByte((uint8_t)(cur_col_10[1] & 0x1F)); //Green
@@ -171,10 +172,10 @@ static int BP5758D_RGBCW(const void *context, const char *cmd, const char *args,
 // This is how you uset RGB CW order:
 // BP5758D_Map 0 1 2 3 4
 // This is the order used on my polish Spectrum WOJ14415 bulb:
-// BP5758D_Map 2 1 0 4 3 
+// BP5758D_Map 2 1 0 4 3
 
 static int BP5758D_Map(const void *context, const char *cmd, const char *args, int flags){
-	
+
 	Tokenizer_TokenizeString(args);
 
 	if(Tokenizer_GetArgsCount()==0) {
@@ -233,7 +234,3 @@ void BP5758D_OnChannelChanged(int ch, int value) {
 	BP5758D_Write(col);
 #endif
 }
-
-
-
-

--- a/src/driver/drv_local.h
+++ b/src/driver/drv_local.h
@@ -27,6 +27,10 @@ void BP5758D_Init();
 void BP5758D_RunFrame();
 void BP5758D_OnChannelChanged(int ch, int value);
 
+void BP1658CJ_Init();
+void BP1658CJ_RunFrame();
+void BP1658CJ_OnChannelChanged(int ch, int value);
+
 void BL_ProcessUpdate(float voltage, float current, float power);
 void BL09XX_AppendInformationToHTTPIndexPage(http_request_t *request);
 bool DRV_IsRunning(const char *name);
@@ -34,4 +38,3 @@ bool DRV_IsRunning(const char *name);
 
 void TuyaMCU_Sensor_RunFrame();
 void TuyaMCU_Sensor_Init();
-

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -37,6 +37,7 @@ static driver_t g_drivers[] = {
 #endif
 	{ "SM2135", SM2135_Init, SM2135_RunFrame, NULL, NULL, NULL, SM2135_OnChannelChanged, false },
 	{ "BP5758D", BP5758D_Init, BP5758D_RunFrame, NULL, NULL, NULL, BP5758D_OnChannelChanged, false },
+	{ "BP1658CJ", BP1658CJ_Init, BP1658CJ_RunFrame, NULL, NULL, NULL, BP1658CJ_OnChannelChanged, false },
 	{ "tmSensor", TuyaMCU_Sensor_Init, TuyaMCU_Sensor_RunFrame, NULL, NULL, NULL, NULL, false },
 };
 
@@ -229,5 +230,3 @@ void DRV_AppendInformationToHTTPIndexPage(http_request_t *request) {
 	}
     hprintf128(request,", total %i</h5>",g_numDrivers);
 }
-
-

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -70,7 +70,7 @@ const char htmlBodyStart[] =
 	"<div id=\"main\">"
     "<h1>"
 	"<a target=\"_blank\" href=\"https://github.com/openshwprojects/OpenBK7231T_App/\">";
-const char htmlBodyStart2[] = 
+const char htmlBodyStart2[] =
     "</a></h1>";
 const char htmlBodyEnd[] = "</div></body></html>" ;
 
@@ -209,7 +209,7 @@ void http_html_start(http_request_t *request, const char *pagename) {
 	if (pagename) {
 		poststr(request, " - ");
 		poststr(request, pagename);
-	} 
+	}
 	poststr(request, "</title>");
 	poststr(request, htmlHeadMain);
 	poststr(request, htmlHeadStyle);
@@ -351,6 +351,8 @@ const char *htmlPinRoleNames[] = {
 	"SM2135CLK",
 	"BP5758D_DAT",
 	"BP5758D_CLK",
+  "BP1658CJ_DAT",
+	"BP1658CJ_CLK",
 	"PWM_n",
 	"error",
 	"error",
@@ -432,7 +434,7 @@ int postany(http_request_t *request, const char *str, int len){
 
 		rtos_delay_milliseconds(1);
 	}
-	
+
 	memcpy( request->reply+request->replylen, str, addlen );
 	request->replylen += addlen;
 	return (currentlen + addlen);

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -36,6 +36,9 @@ enum IORole {
 	IOR_BP5758D_DAT,
 	IOR_BP5758D_CLK,
 
+	IOR_BP1658CJ_DAT,
+	IOR_BP1658CJ_CLK,
+
 	IOR_PWM_n,
 
 	IOR_Total_Options,
@@ -96,7 +99,7 @@ typedef struct pinsState_s {
 
 
 // bit indexes (not values), so 0 1 2 3 4
-#define OBK_FLAG_MQTT_BROADCASTLEDPARAMSTOGETHER	0	
+#define OBK_FLAG_MQTT_BROADCASTLEDPARAMSTOGETHER	0
 #define OBK_FLAG_MQTT_BROADCASTLEDFINALCOLOR		1
 #define OBK_FLAG_MQTT_BROADCASTSELFSTATEPERMINUTE	2
 #define OBK_FLAG_LED_RAWCHANNELSMODE				3
@@ -253,4 +256,3 @@ void Setup_Device_BK7231N_KS_602_TOUCH();
 void Setup_Device_Enbrighten_WFD4103();
 void Setup_Device_Aubess_Mini_Smart_Switch_16A();
 #endif
-

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -143,7 +143,7 @@ void Main_OnWiFiStatusChange(int code){
         case WIFI_STA_CONNECTED:
 			g_bHasWiFiConnected = 1;
 			ADDLOGF_INFO("Main_OnWiFiStatusChange - WIFI_STA_CONNECTED\r\n");
-			
+
 			if(bSafeMode == 0 && strlen(CFG_DeviceGroups_GetName())>0){
 				ScheduleDriverStart("DGR",5);
 			}
@@ -454,6 +454,11 @@ void Main_Init()
 		if(PIN_FindPinIndexForRole(IOR_BP5758D_CLK,-1) != -1 && PIN_FindPinIndexForRole(IOR_BP5758D_DAT,-1) != -1) {
 #ifndef OBK_DISABLE_ALL_DRIVERS
 			DRV_StartDriver("BP5758D");
+#endif
+		}
+		if(PIN_FindPinIndexForRole(IOR_BP1658CJ_CLK,-1) != -1 && PIN_FindPinIndexForRole(IOR_BP1658CJ_DAT,-1) != -1) {
+#ifndef OBK_DISABLE_ALL_DRIVERS
+			DRV_StartDriver("BP1658CJ");
 #endif
 		}
 		if(PIN_FindPinIndexForRole(IOR_BL0937_CF,-1) != -1 && PIN_FindPinIndexForRole(IOR_BL0937_CF1,-1) != -1 && PIN_FindPinIndexForRole(IOR_BL0937_SEL,-1) != -1) {


### PR DESCRIPTION
I recently bought a [Hama GU10 RGBCW 5,5W Lamp](https://www.hama.com/00176598/hama-wlan-led-lampe-gu10-5-5w-rgbw-dimmbar-refl-fuer-sprach-app-steuerung#article-details) , which incorporates the tuya [WBLC5](https://developer.tuya.com/en/docs/iot/wblc5-module-datasheet?id=K9duilns1f3gi) module and a BP1658(CJ) I2C LED driver IC (sadly no datasheet found) at P24 (DAT) and P26 (CLK). 
The delay from the BP5758 was a bit to slow for this chip, so I used 10 nops as a delay. Maybe it could be improved there.