### PR TITLE
Defined USER_SW_VER

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -95,6 +95,10 @@ const char htmlFooterInfo[] =
         #define USER_SW_VER "BK7231N_Test"
     #elif defined(PLATFORM_BK7231T)
         #define USER_SW_VER "BK7231T_Test"
+	#elif defined(PLATFORM_W600)
+		#define USER_SW_VER "W600_Test"
+	#elif defined(PLATFORM_W800)
+		#define USER_SW_VER "W800_Test"
     #else
         #define USER_SW_VER "unknown"
     #endif


### PR DESCRIPTION
@openshwprojects 
I pushed in a some fixes into to get Linux build working (https://github.com/iprak/OpenW600).  This request jut has a small fix to assign test USER_SW_VER. I also verified that the img can now be uploaded via direct ota. 

I am not sure what is the process to change build actions to build the firmware officially. But you might want to test the build on your device first.