### PR TITLE
Fixed pins for W600 and W800

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ output/**
 **/*.d
 /custom.mk
 /.vs
+.vscode
+node_modules

--- a/src/hal/w800/hal_pins_w800.c
+++ b/src/hal/w800/hal_pins_w800.c
@@ -7,45 +7,59 @@
 
 typedef struct wmPin_s {
 	const char *name;
-	int code;
+	unsigned short code;
+	short pwm_channel;
 } wmPin_t;
 
-static wmPin_t g_pins[] = {
-	{"PA1",WM_IO_PA_01},
-	{"PA4",WM_IO_PA_04},
-	{"PA7",WM_IO_PA_07},
-	{"PB0",WM_IO_PB_00},
-	{"PB1",WM_IO_PB_01},
-	{"PB2",WM_IO_PB_02},
-	{"PB3",WM_IO_PB_03},
-	{"PB4",WM_IO_PB_04},
-	{"PB5",WM_IO_PB_05},
-	{"PB6",WM_IO_PB_06},
-	{"PB7",WM_IO_PB_07},
-	{"PB8",WM_IO_PB_08},
-	{"PB9",WM_IO_PB_09},
-	{"PB10",WM_IO_PB_10},
-	{"PB11",WM_IO_PB_11},
-	{"PB19",WM_IO_PB_19},
-	{"PB20",WM_IO_PB_20}
-};
-static int g_numPins = sizeof(g_pins)/sizeof(g_pins[0]);
+//NOTE: pwm_channel is defined based on demo/wm_pwm_demo.cs
 
-static int PIN_GetPWMIndexForPinIndex(int pin) {
-	if(pin == 6)
-		return 0;
-	if(pin == 7)
-		return 1;
-	if(pin == 8)
-		return 2;
-	if(pin == 9)
-		return 3;
-	if(pin == 24)
-		return 4;
-	if(pin == 26)
-		return 5;
-	return -1;
-}
+#if PLATFORM_W800
+
+static wmPin_t g_pins[] = {
+	{"PA1",WM_IO_PA_01, -1},
+	{"PA4",WM_IO_PA_04, -1},
+	{"PA7",WM_IO_PA_07, 4},
+	{"PB0",WM_IO_PB_00, 0},
+	{"PB1",WM_IO_PB_01, 1},
+	{"PB2",WM_IO_PB_02, 2},
+	{"PB3",WM_IO_PB_03, 3},
+	{"PB4",WM_IO_PB_04, -1},
+	{"PB5",WM_IO_PB_05, -1},
+	{"PB6",WM_IO_PB_06, -1},
+	{"PB7",WM_IO_PB_07, -1},
+	{"PB8",WM_IO_PB_08, -1},
+	{"PB9",WM_IO_PB_09, -1},
+	{"PB10",WM_IO_PB_10, -1},
+	{"PB11",WM_IO_PB_11, -1},
+	{"PB19",WM_IO_PB_19, -1},
+	{"PB20",WM_IO_PB_20, -1}
+};
+
+#else
+
+//W600 pinouts is based on W600-User Manual which lists pins for TW-02 and TW-03 modules.
+static wmPin_t g_pins[] = {
+	{"PA1",WM_IO_PA_01, -1},
+	{"PA4",WM_IO_PA_04, -1},
+	{"PA5",WM_IO_PA_05, -1},
+	{"PB8",WM_IO_PB_08, -1},
+	{"PB6",WM_IO_PB_06, -1},
+	{"PB7",WM_IO_PB_07, -1},
+	{"PB9",WM_IO_PB_09, -1},
+	{"PB10",WM_IO_PB_10, -1},
+	{"PB11",WM_IO_PB_11, -1},
+	{"PB12",WM_IO_PB_12, -1},
+	{"PB13",WM_IO_PB_13, -1},
+	{"PB14",WM_IO_PB_14, 4},
+	{"PB15",WM_IO_PB_15, 3},
+	{"PB16",WM_IO_PB_16, 2},
+	{"PB17",WM_IO_PB_17, 1},
+	{"PB18",WM_IO_PB_18, 0}
+};
+
+#endif
+
+static int g_numPins = sizeof(g_pins)/sizeof(g_pins[0]);
 
 static int IsPinIndexOk(int index){
 	if(index<0)
@@ -61,8 +75,10 @@ const char *HAL_PIN_GetPinNameAlias(int index) {
 }
 
 int HAL_PIN_CanThisPinBePWM(int index) {
-
-	return 1;
+	if(IsPinIndexOk(index)==0)
+		return 0;
+	
+	return g_pins[index].pwm_channel == -1 ? 0 : 1;
 }
 void HAL_PIN_SetOutputValue(int index, int iVal) {
 	int realCode ;

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -103,8 +103,6 @@ const char htmlFooterInfo[] =
 		#define USER_SW_VER "W600_Test"
 	#elif defined(PLATFORM_W800)
 		#define USER_SW_VER "W800_Test"
-	#elif defined(PLATFORM_BL602)
-		#define USER_SW_VER "BL602_Test"
     #else
         #define USER_SW_VER "unknown"
     #endif

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -101,7 +101,12 @@ const char *obktype = "BL602";
 const char * apppage2 = "';"
 "            var obktype = 'BL602';"
 "            var device = 'http://";
-#elif PLATFORM_W600 || PLATFORM_W800
+#elif PLATFORM_W600
+const char *obktype = "W600";
+const char * apppage2 = "';"
+"            var obktype = 'W600';"
+"            var device = 'http://";
+#elif PLATFORM_W800
 const char *obktype = "W800";
 const char * apppage2 = "';"
 "            var obktype = 'W800';"

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -69,7 +69,9 @@ enum ChannelType {
 #define PLATFORM_GPIO_MAX 24
 #elif PLATFORM_XR809
 #define PLATFORM_GPIO_MAX 13
-#elif defined(PLATFORM_W800) || defined(PLATFORM_W600)
+#elif PLATFORM_W600
+#define PLATFORM_GPIO_MAX 16
+#elif PLATFORM_W800
 #define PLATFORM_GPIO_MAX 17
 #else
 #define PLATFORM_GPIO_MAX 29


### PR DESCRIPTION
Fixes these things
* W800 configuration was allowing every pin to be PWM. Defined correct PWM pins for W600 and W800. There is no actual PWM implementation but at the least the pin choice would be correct now.
* Fixed PLATFORM_GPIO_MAX for W600.

I have now have my WiFi plug working and will soon submit a teardown.