### PR TITLE
added linear mapping function to map 0-255 to 0-1023

### DIFF
--- a/src/driver/drv_bp1658cj.c
+++ b/src/driver/drv_bp1658cj.c
@@ -83,10 +83,9 @@ void BP1658CJ_Write(byte *rgbcw) {
 	for(int i = 0; i < 5; i++){
 		// convert 0-255 to 0-1023
 		//cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
-    // Arduino mapping function
-    cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
+    cur_col_10[i] = MAP(rgbcw[g_channelOrder[i]], 0, 255, 0, 1023);
 	}
-
+  //ADDLOG_DEBUG(LOG_FEATURE_CMD, "Writing to Lamp (hex): #%02X%02X%02X%02X%02X", cur_col_10[0], cur_col_10[1], cur_col_10[2], cur_col_10[3], cur_col_10[4]);
 	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP1658CJ's sleep mode ([0x80] ).
 	if (cur_col_10[0]==0 && cur_col_10[1]==0 && cur_col_10[2]==0 && cur_col_10[3]==0 && cur_col_10[4]==0) {
 		BP1658CJ_Start(BP1658CJ_ADDR_SLEEP);

--- a/src/driver/drv_bp1658cj.c
+++ b/src/driver/drv_bp1658cj.c
@@ -82,7 +82,9 @@ void BP1658CJ_Write(byte *rgbcw) {
 
 	for(int i = 0; i < 5; i++){
 		// convert 0-255 to 0-1023
-		cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
+		//cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
+    // Arduino mapping function
+      cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
 	}
 
 	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP1658CJ's sleep mode ([0x80] ).

--- a/src/driver/drv_bp1658cj.c
+++ b/src/driver/drv_bp1658cj.c
@@ -84,7 +84,7 @@ void BP1658CJ_Write(byte *rgbcw) {
 		// convert 0-255 to 0-1023
 		//cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
     // Arduino mapping function
-      cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
+    cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
 	}
 
 	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP1658CJ's sleep mode ([0x80] ).

--- a/src/driver/drv_bp5758d.c
+++ b/src/driver/drv_bp5758d.c
@@ -102,7 +102,9 @@ void BP5758D_Write(byte *rgbcw) {
 
 	for(i = 0; i < 5; i++){
 		// convert 0-255 to 0-1023
-		cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
+		//cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
+		// Arduino mapping function
+      cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
 	}
 
 	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP5758d's sleep mode.
@@ -115,7 +117,7 @@ void BP5758D_Write(byte *rgbcw) {
 		BP5758D_Stop();
 		return;
 	}
-	
+
 	if(bIsSleeping) {
 		bIsSleeping = false;				//No need to run it every time a val gets changed
 		BP5758D_Start(BP5758D_ADDR_SETUP);		//Sleep mode gets disabled too since bits 5:6 get set to 01

--- a/src/driver/drv_bp5758d.c
+++ b/src/driver/drv_bp5758d.c
@@ -103,8 +103,8 @@ void BP5758D_Write(byte *rgbcw) {
 	for(i = 0; i < 5; i++){
 		// convert 0-255 to 0-1023
 		//cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
-		// Arduino mapping function
-    cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
+		cur_col_10[i] = MAP(rgbcw[g_channelOrder[i]], 0, 255, 0, 1023);
+
 	}
 
 	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP5758d's sleep mode.

--- a/src/driver/drv_bp5758d.c
+++ b/src/driver/drv_bp5758d.c
@@ -104,7 +104,7 @@ void BP5758D_Write(byte *rgbcw) {
 		// convert 0-255 to 0-1023
 		//cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
 		// Arduino mapping function
-      cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
+    cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
 	}
 
 	// If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP5758d's sleep mode.

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -290,3 +290,7 @@ int PingWatchDog_GetTotalReceived();
 
 int LWIP_GetMaxSockets();
 int LWIP_GetActiveSockets();
+
+// linear mapping function
+
+#define MAP(x, in_min, in_max, out_min, out_max) (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -291,6 +291,6 @@ int PingWatchDog_GetTotalReceived();
 int LWIP_GetMaxSockets();
 int LWIP_GetActiveSockets();
 
-// linear mapping function
+// linear mapping function --> https://www.arduino.cc/reference/en/language/functions/math/map/
 
 #define MAP(x, in_min, in_max, out_min, out_max) (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;


### PR DESCRIPTION
I noticed that the 8 to 10 bit conversion is just a simple multiplication by 4. 
```c
cur_col_10[i] = rgbcw[g_channelOrder[i]] * 4;
```
I now added a simple linear mapping function to improve the 8 to 10 bit mapping:
```c
// Arduino mapping function
cur_col_10[i] = (rgbcw[g_channelOrder[i]] - 0x00) * (0x3FF - 0x00) / (0xFF - 0x00) + 0x00;
```