### PR TITLE
Hass discovery/Json memory fixes

### DIFF
--- a/src/cJSON/cJSON.c
+++ b/src/cJSON/cJSON.c
@@ -259,6 +259,7 @@ CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
         if (!(item->type & cJSON_IsReference) && (item->child != NULL))
         {
             cJSON_Delete(item->child);
+            item->child = NULL;
         }
         if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL))
         {

--- a/src/httpserver/hass.h
+++ b/src/httpserver/hass.h
@@ -1,23 +1,35 @@
 
+#include "new_http.h"
 #include "../cJSON/cJSON.h"
+#include "../new_pins.h"
+#include "../mqtt/new_mqtt.h"
 
 typedef enum {
 	ENTITY_RELAY = 0,
     ENTITY_LIGHT = 1
 } ENTITY_TYPE;
 
+//unique_id is based on CFG_GetDeviceName() whose size is CGF_DEVICE_NAME_SIZE (see hass_populate_unique_id)
+#define HASS_UNIQUE_ID_SIZE     (CGF_DEVICE_NAME_SIZE + 1 + 5 + 1 + 4)
+
+//channel is based on unique_id (see hass_populate_device_config_channel)
+#define HASS_CHANNEL_SIZE       (HASS_UNIQUE_ID_SIZE + 32)
+
+//Size of JSON (1 less than MQTT queue holding)
+#define HASS_JSON_SIZE          (MQTT_PUBLISH_ITEM_VALUE_LENGTH - 1)
+
 /// @brief HomeAssistant device discovery information
 typedef struct HassDeviceInfo_s{
-    char *unique_id;
-    char *channel;
-    char *json;
+    char unique_id[HASS_UNIQUE_ID_SIZE];
+    char channel[HASS_CHANNEL_SIZE];
+    char json[HASS_JSON_SIZE];
+
     cJSON *root;
     cJSON *device;
     cJSON *ids;
 } HassDeviceInfo;
 
-char *hass_build_unique_id(ENTITY_TYPE type, int index);
-char *hass_build_unique_id(ENTITY_TYPE type, int index);
-char *hass_build_discovery_json(HassDeviceInfo *info);
+void hass_print_unique_id(http_request_t *request, const char *fmt, ENTITY_TYPE type, int index);
 HassDeviceInfo *hass_init_device_info(ENTITY_TYPE type, int index, char *payload_on, char *payload_off);
+char *hass_build_discovery_json(HassDeviceInfo *info);
 void hass_free_device_info(HassDeviceInfo *info);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -7,7 +7,6 @@
 #include "../cmnds/cmd_public.h"
 #include "../driver/drv_tuyaMCU.h"
 #include "../driver/drv_public.h"
-#include "../logging/logging.h"
 #include "../hal/hal_wifi.h"
 #include "../hal/hal_pins.h"
 #include "../hal/hal_flashConfig.h"
@@ -1325,10 +1324,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                     switchAdded=1;
                 }
 
-                uniq_id = hass_build_unique_id(ENTITY_RELAY,i);
-                hprintf128(request,"  - unique_id: \"%s\"\n",uniq_id);
-                os_free(uniq_id);
-
+                hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_RELAY,i);
                 hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);
@@ -1352,13 +1348,8 @@ int http_fn_ha_cfg(http_request_t *request) {
             switchAdded=1;
         }
 
-        uniq_id = hass_build_unique_id(ENTITY_LIGHT,i);
-        hprintf128(request,"  - unique_id: \"%s\"\n",uniq_id);
-        os_free(uniq_id);
-
+        hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT,i);
         hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
-
-
         hprintf128(request,"       rgb_command_template: \"{{ '#%02x%02x%02x0000' | format(red, green, blue)}}\"\n");
         hprintf128(request,"       rgb_state_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
         hprintf128(request,"       rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
@@ -1384,13 +1375,8 @@ int http_fn_ha_cfg(http_request_t *request) {
             switchAdded=1;
         }
 
-        uniq_id = hass_build_unique_id(ENTITY_LIGHT,i);
-        hprintf128(request,"  - unique_id: \"%s\"\n",uniq_id);
-        os_free(uniq_id);
-
+        hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT,i);
         hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
-
-
         hprintf128(request,"       rgb_command_template: \"{{ '#%02x%02x%02x0000' | format(red, green, blue)}}\"\n");
         hprintf128(request,"       rgb_state_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
         hprintf128(request,"       rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
@@ -1417,10 +1403,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                     lightAdded=1;
                 }
 
-                uniq_id = hass_build_unique_id(ENTITY_LIGHT,i);
-                hprintf128(request,"  - unique_id: \"%s\"\n",uniq_id);
-                os_free(uniq_id);
-
+                hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT,i);
                 hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);

--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -70,6 +70,7 @@ char *logfeaturenames[] = {
     "DGR:",// = 16
     "DDP:",// = 17
     "RAW:", // = 18 raw, without any prefix
+    "HASS:" // = 19
 };
 
 

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -76,7 +76,8 @@ typedef enum {
 	// user to print without any prefixes
 	LOG_FEATURE_RAW				= 18,
     // add in here - but also in names in logging.c
-    LOG_FEATURE_MAX             = 19,
+    LOG_FEATURE_HASS            = 19,
+    LOG_FEATURE_MAX             = 20,
 } log_features;
 
 #endif

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -61,6 +61,8 @@ This platform is not supported, error!
 #define BIT_TGL(PIN,N) (PIN ^=  (1<<N))
 #define BIT_CHECK(PIN,N) !!((PIN & (1<<N)))
 
+#define MIN(a,b)	(((a)<(b))?(a):(b))
+#define MAX(a,b)	(((a)>(b))?(a):(b))
 
 #if WINDOWS
 

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -119,6 +119,11 @@ typedef struct pinsState_s {
 
 #define OBK_TOTAL_FLAGS 13
 
+
+#define CGF_MQTT_CLIENT_ID_SIZE			64
+#define CGF_SHORT_DEVICE_NAME_SIZE		32
+#define CGF_DEVICE_NAME_SIZE			64
+
 //
 // Main config structure (less than 2KB)
 //
@@ -143,7 +148,7 @@ typedef struct mainConfig_s {
 	char wifi_pass[64];
 	// MQTT information for Home Assistant
 	char mqtt_host[256];
-	char mqtt_clientId[64];
+	char mqtt_clientId[CGF_MQTT_CLIENT_ID_SIZE];
 	char mqtt_userName[64];
 	char mqtt_pass[128];
 	int mqtt_port;
@@ -152,8 +157,8 @@ typedef struct mainConfig_s {
 	// TODO?
 	byte mac[6];
 	// TODO?
-	char shortDeviceName[32];
-	char longDeviceName[64];
+	char shortDeviceName[CGF_SHORT_DEVICE_NAME_SIZE];
+	char longDeviceName[CGF_DEVICE_NAME_SIZE];
 	pinsState_t pins;
 	short startChannelValues[CHANNEL_MAX];
 	int dgr_sendFlags;


### PR DESCRIPTION
Various fixes which were crippling W600 device.
* Fixed cJSON_Delete to nuke child nodes after they have been deleted.  cJSON_Delete recurses to clean up children but was not setting them to NULL. The caller (hass.c) was doing cleanup on child nodes in a NULL check and that caused crashes .. but only in W600.
* Defined constants for various configuration fields and converted discovery structure to use fixed size array based on those constants. This got rid of some malloc/free operations.
* Added logging for HASS.
* Discovery payload was always 1/0 and not the passed values which might be problem later.

This seems to resolve HASS discovery crashes on W600. The MQTT buffers in LWIP definitely helped as well.
