### PR TITLE
Hass discovery support for  RGB

### DIFF
--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -259,6 +259,23 @@ int LED_GetMode() {
 	return g_lightMode;
 }
 
+const char *GetLightModeStr(int mode) {
+	if(mode == Light_All)
+		return "all";
+	if(mode == Light_Temperature)
+		return "cw";
+	if(mode == Light_RGB)
+		return "rgb";
+	return "er";
+}
+void SET_LightMode(int newMode) {
+	if(g_lightMode != newMode) {
+        ADDLOG_INFO(LOG_FEATURE_CMD, "Changing LightMode from %s to %s",
+			GetLightModeStr(g_lightMode),
+			GetLightModeStr(newMode));
+		g_lightMode = newMode;
+	}
+}
 OBK_Publish_Result LED_SendCurrentLightMode() {
 
 	if(g_lightMode == Light_Temperature) {
@@ -291,7 +308,8 @@ void LED_SetTemperature(int tmpInteger, bool bApply) {
 	baseColors[4] = (255.0f) * f;
 
 	if(bApply) {
-		g_lightMode = Light_Temperature;
+		// set g_lightMode
+		SET_LightMode(Light_Temperature);
 		sendTemperatureChange();
 		apply_smart_light();
 	}
@@ -393,7 +411,7 @@ static int dimmer(const void *context, const char *cmd, const char *args, int cm
 	//return 0;
 }
 void LED_SetFinalRGB(byte r, byte g, byte b) {
-	g_lightMode = Light_RGB;
+	SET_LightMode(Light_RGB);
 
 	baseColors[0] = r;
 	baseColors[1] = g;
@@ -425,9 +443,9 @@ int LED_SetBaseColor(const void *context, const char *cmd, const char *args, int
 				c++;
 
 			if(bAll) {
-				g_lightMode = Light_All;
+				SET_LightMode(Light_All);
 			} else {
-				g_lightMode = Light_RGB;
+				SET_LightMode(Light_RGB);
 			}
 
 			g_numBaseColors = 0;
@@ -581,7 +599,7 @@ void NewLED_RestoreSavedStateIfNeeded() {
 		byte rgb[3];
 		byte mod;
 		HAL_FlashVars_ReadLED(&mod, &brig, &tmp, rgb);
-		g_lightMode = mod;
+		SET_LightMode(mod);
 		g_brightness = brig * g_cfg_brightnessMult;
 		LED_SetTemperature(tmp,0);
 		baseColors[0] = rgb[0];

--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -587,7 +587,9 @@ void NewLED_RestoreSavedStateIfNeeded() {
 		apply_smart_light();
 	} else {
 		// set, but do not apply (force a refresh)
-		LED_SetTemperature(led_temperature_current,0);
+		// NOW REMOVED - because users might want to force both C and W channels to 100% without using temperature calculation....
+		// FIXME - is this correct?
+		//LED_SetTemperature(led_temperature_current,0);
 	}
 
 	// "cmnd/obk8D38570E/led_dimmer_get""

--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -560,6 +560,9 @@ static int setHue(const void *context, const char *cmd, const char *args, int cm
 }
 
 void NewLED_InitCommands(){
+	// set, but do not apply (force a refresh)
+	LED_SetTemperature(led_temperature_current,0);
+
     CMD_RegisterCommand("led_dimmer", "", dimmer, "set output dimmer 0..100", NULL);
     CMD_RegisterCommand("led_enableAll", "", enableAll, "qqqq", NULL);
     CMD_RegisterCommand("led_basecolor_rgb", "", basecolor_rgb, "set PWN color using #RRGGBB", NULL);
@@ -586,10 +589,6 @@ void NewLED_RestoreSavedStateIfNeeded() {
 		baseColors[2] = rgb[2];
 		apply_smart_light();
 	} else {
-		// set, but do not apply (force a refresh)
-		// NOW REMOVED - because users might want to force both C and W channels to 100% without using temperature calculation....
-		// FIXME - is this correct?
-		//LED_SetTemperature(led_temperature_current,0);
 	}
 
 	// "cmnd/obk8D38570E/led_dimmer_get""

--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -70,7 +70,7 @@ float g_cfg_brightnessMult = 0.01f;
 //in homeassistant/util/color.py as HASS_COLOR_MIN and HASS_COLOR_MAX).
 float led_temperature_min = HASS_TEMPERATURE_MIN;
 float led_temperature_max = HASS_TEMPERATURE_MAX;
-float led_temperature_current = 0;
+float led_temperature_current = HASS_TEMPERATURE_MIN;
 
 
 int isCWMode() {
@@ -586,8 +586,8 @@ void NewLED_RestoreSavedStateIfNeeded() {
 		baseColors[2] = rgb[2];
 		apply_smart_light();
 	} else {
-		// set, but do not apply
-		LED_SetTemperature(250,0);
+		// set, but do not apply (force a refresh)
+		LED_SetTemperature(led_temperature_current,0);
 	}
 
 	// "cmnd/obk8D38570E/led_dimmer_get""

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -170,7 +170,8 @@ HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index){
         case ENTITY_LIGHT_RGB:
             info = hass_init_device_info(type, index, "1", "0");
 
-            cJSON_AddStringToObject(info->root, "rgb_cmd_tpl","{{'#%02x%02x%02x0000'|format(red, green, blue)}}");  //rgb_command_template
+            cJSON_AddStringToObject(info->root, "rgb_cmd_tpl","{{ '#%02x%02x%02x0000' | format(red, green, blue) }}");  //rgb_command_template
+            cJSON_AddStringToObject(info->root, "rgb_val_tpl","{{ value[1:3] | int(base=16) }},{{ value[3:5] | int(base=16) }},{{ value[5:7] | int(base=16) }}");  //rgb_value_template
 
             sprintf(g_hassBuffer,"%s/led_basecolor_rgb/get",clientId);
             cJSON_AddStringToObject(info->root, "rgb_stat_t", g_hassBuffer); //rgb_state_topic
@@ -191,7 +192,7 @@ HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index){
 
             if (type == ENTITY_LIGHT_RGBCW){
                 sprintf(g_hassBuffer,"cmnd/%s/led_temperature",clientId);
-                cJSON_AddStringToObject(info->root, "clr_temp_cmd_t", g_hassBuffer); //color_temp_command_topic
+                cJSON_AddStringToObject(info->root, "clr_temp_cmd_t", g_hassBuffer);    //color_temp_command_topic
                 sprintf(g_hassBuffer,"%s/led_temperature/get",clientId);
                 cJSON_AddStringToObject(info->root, "clr_temp_stat_t", g_hassBuffer);    //color_temp_state_topic
             }

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -177,6 +177,8 @@ HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index){
             sprintf(g_hassBuffer,"cmnd/%s/led_basecolor_rgb",clientId);
             cJSON_AddStringToObject(info->root, "rgb_cmd_t", g_hassBuffer);  //rgb_command_topic
 
+            sprintf(g_hassBuffer,"%s/led_enableAll/get",clientId);
+            cJSON_AddStringToObject(info->root, STATE_TOPIC_KEY, g_hassBuffer);  //state_topic
             sprintf(g_hassBuffer,"cmnd/%s/led_enableAll",clientId);
             cJSON_AddStringToObject(info->root, COMMAND_TOPIC_KEY, g_hassBuffer);  //command_topic
 

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -119,9 +119,12 @@ void hass_populate_common(cJSON *root, ENTITY_TYPE type, int index, char *unique
     //A device can have both relay and PWM and they would need to have separate names.
     switch(type){
         case ENTITY_LIGHT_PWM:
+            sprintf(tmp,"%s light %i",CFG_GetShortDeviceName(),index);
+            break;
         case ENTITY_LIGHT_RGB:
         case ENTITY_LIGHT_RGBCW:
-            sprintf(tmp,"%s light %i",CFG_GetShortDeviceName(),index);
+            //There can only be one RGB so we can skip including index in the name
+            sprintf(tmp,"%s light",CFG_GetShortDeviceName());
             break;
         case ENTITY_RELAY:
             //state_topic and command_topic are only for relay

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -25,10 +25,13 @@ Abbreviated node names - https://www.home-assistant.io/docs/mqtt/discovery/
 
 */
 
+//Buffer for populates values with cJSON_Add* calls
+//We are values based on CFG_GetShortDeviceName and clientId so it needs to be bigger than them. +64 for light/switch/etc.
+static char g_hassBuffer[CGF_MQTT_CLIENT_ID_SIZE + 64];
 
 /// @brief Populates HomeAssistant unique id for the entity.
 /// @param type Entity type
-/// @param index Entity index
+/// @param index Entity index (Ignored for RGB)
 /// @param uniq_id Array to populate (should be of size HASS_UNIQUE_ID_SIZE)
 void hass_populate_unique_id(ENTITY_TYPE type, int index, char *uniq_id){
     //https://developers.home-assistant.io/docs/entity_registry_index/#unique-id-requirements
@@ -103,56 +106,9 @@ cJSON *hass_build_device_node(cJSON *ids) {
     return dev;
 }
 
-/// @brief Populates common values for HomeAssistant device discovery.
-/// @param root 
-/// @param type Entity type 
-/// @param index 
-/// @param unique_id 
-/// @param payload_on 
-/// @param payload_off 
-void hass_populate_common(cJSON *root, ENTITY_TYPE type, int index, char *unique_id, char *payload_on, char *payload_off){
-    const char *clientId = CFG_GetMQTTClientId();
-    
-    //We are stuffing CFG_GetShortDeviceName and clientId into tmp so it needs to be bigger than them. +16 for light/switch/etc.
-    char tmp[CGF_MQTT_CLIENT_ID_SIZE + 16];
-    
-    //A device can have both relay and PWM and they would need to have separate names.
-    switch(type){
-        case ENTITY_LIGHT_PWM:
-            sprintf(tmp,"%s light %i",CFG_GetShortDeviceName(),index);
-            break;
-        case ENTITY_LIGHT_RGB:
-        case ENTITY_LIGHT_RGBCW:
-            //There can only be one RGB so we can skip including index in the name
-            sprintf(tmp,"%s light",CFG_GetShortDeviceName());
-            break;
-        case ENTITY_RELAY:
-            //state_topic and command_topic are only for relay
-            sprintf(tmp,"%s/%i/get",clientId,index);
-            cJSON_AddStringToObject(root, "stat_t", tmp);   //state_topic
-
-            sprintf(tmp,"%s/%i/set",clientId,index);
-            cJSON_AddStringToObject(root, "cmd_t", tmp);    //command_topic
-            
-            sprintf(tmp,"%s switch %i",CFG_GetShortDeviceName(),index);
-            break;
-        case ENTITY_SENSOR:
-            addLogAdv(LOG_ERROR, LOG_FEATURE_HASS, "ENTITY_SENSOR not yet supported");
-    }
-    
-    cJSON_AddStringToObject(root, "name", tmp);
-
-    sprintf(tmp,"%s/connected",clientId);
-    cJSON_AddStringToObject(root, "avty_t", tmp);   //availability_topic
-
-    cJSON_AddStringToObject(root, "pl_on", payload_on);    //payload_on
-    cJSON_AddStringToObject(root, "pl_off", payload_off);   //payload_off
-    cJSON_AddStringToObject(root, "uniq_id", unique_id);  //unique_id
-}
-
-/// @brief Initializes HomeAssistant device discovery storage.
+/// @brief Initializes HomeAssistant device discovery storage with common values.
 /// @param type 
-/// @param index 
+/// @param index Ignored for RGB
 /// @param payload_on 
 /// @param payload_off 
 /// @return 
@@ -169,11 +125,32 @@ HassDeviceInfo *hass_init_device_info(ENTITY_TYPE type, int index, char *payload
     cJSON_AddItemToArray(info->ids, cJSON_CreateString(CFG_GetDeviceName()));
 
     info->device = hass_build_device_node(info->ids);
-    info->root = cJSON_CreateObject();
 
+    info->root = cJSON_CreateObject();
     cJSON_AddItemToObject(info->root, "dev", info->device);    //device
     
-    hass_populate_common(info->root, type, index, info->unique_id, payload_on, payload_off);
+    switch(type){
+        case ENTITY_LIGHT_PWM:
+        case ENTITY_RELAY:
+            sprintf(g_hassBuffer,"%s %i",CFG_GetShortDeviceName(),index);
+            break;
+        case ENTITY_LIGHT_RGB:
+        case ENTITY_LIGHT_RGBCW:
+            //There can only be one RGB so we can skip including index in the name
+            sprintf(g_hassBuffer,"%s",CFG_GetShortDeviceName());
+            break;
+        case ENTITY_SENSOR:
+            addLogAdv(LOG_ERROR, LOG_FEATURE_HASS, "ENTITY_SENSOR not yet supported");
+    }
+    cJSON_AddStringToObject(info->root, "name", g_hassBuffer); 
+
+    sprintf(g_hassBuffer,"%s/connected",CFG_GetMQTTClientId());
+    cJSON_AddStringToObject(info->root, "avty_t", g_hassBuffer);   //availability_topic, `online` value is broadcasted
+
+    cJSON_AddStringToObject(info->root, "pl_on", payload_on);    //payload_on
+    cJSON_AddStringToObject(info->root, "pl_off", payload_off);   //payload_off
+    cJSON_AddStringToObject(info->root, "uniq_id", info->unique_id);  //unique_id
+
     addLogAdv(LOG_DEBUG, LOG_FEATURE_HASS, "root=%p", info->root);
     return info;
 }
@@ -182,12 +159,23 @@ HassDeviceInfo *hass_init_device_info(ENTITY_TYPE type, int index, char *payload
 /// @param index
 /// @return 
 HassDeviceInfo *hass_init_relay_device_info(int index){
-    return hass_init_device_info(ENTITY_RELAY, index, "1", "0");
+    const char *clientId = CFG_GetMQTTClientId();
+
+    HassDeviceInfo *info = hass_init_device_info(ENTITY_RELAY, index, "1", "0");
+    cJSON_AddNumberToObject(info->root, "qos", 1);
+
+    sprintf(g_hassBuffer,"%s/%i/get",clientId,index);
+    cJSON_AddStringToObject(info->root, "stat_t", g_hassBuffer);   //state_topic
+
+    sprintf(g_hassBuffer,"%s/%i/set",clientId,index);
+    cJSON_AddStringToObject(info->root, "cmd_t", g_hassBuffer);    //command_topic
+
+    return info;
 }
 
 /// @brief Initializes HomeAssistant light device discovery storage.
 /// @param type 
-/// @param index
+/// @param index Ignored for RGB
 /// @return 
 HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index){
     char tmp[CGF_MQTT_CLIENT_ID_SIZE + 64];  //Used to generate values based on CFG_GetMQTTClientId
@@ -199,30 +187,31 @@ HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index){
         case ENTITY_LIGHT_RGB:
             info = hass_init_device_info(type, index, "1", "0");
 
-            cJSON_AddStringToObject(info->root, "rgb_cmd_tpl","{{'#%02x%02x%02x0000'|format(red, green, blue)}}");
+            cJSON_AddStringToObject(info->root, "rgb_cmd_tpl","{{'#%02x%02x%02x0000'|format(red, green, blue)}}");  //rgb_command_template
 
             sprintf(tmp,"cmnd/%s/led_basecolor_rgb",clientId);
-            cJSON_AddStringToObject(info->root, "rgb_stat_t", tmp);
+            cJSON_AddStringToObject(info->root, "rgb_stat_t", tmp); //rgb_state_topic
 
             sprintf(tmp,"cmnd/%s/led_basecolor_rgb",clientId);
-            cJSON_AddStringToObject(info->root, "rgb_cmd_t", tmp);
+            cJSON_AddStringToObject(info->root, "rgb_cmd_t", tmp);  //rgb_command_topic
 
             sprintf(tmp,"cmnd/%s/led_enableAll",clientId);
-            cJSON_AddStringToObject(info->root, "cmd_t", tmp);
+            cJSON_AddStringToObject(info->root, "cmd_t", tmp);  //command_topic
 
             sprintf(tmp,"cmnd/%s/led_dimmer",clientId);
-            cJSON_AddStringToObject(info->root, "bri_cmd_t", tmp);
-            cJSON_AddNumberToObject(info->root, "bri_scl", 100);
-            cJSON_AddStringToObject(info->root, "bri_val_tpl", "{{value_json.Dimmer}}");
+            cJSON_AddStringToObject(info->root, "bri_cmd_t", tmp);  //brightness_command_topic
+
+            cJSON_AddNumberToObject(info->root, "bri_scl", 100);    //brightness_scale
+            cJSON_AddStringToObject(info->root, "bri_val_tpl", "{{value_json.Dimmer}}");    //brightness_value_template
 
             if (type == ENTITY_LIGHT_RGBCW){
                 sprintf(tmp,"cmnd/%s/led_temperature",clientId);
-                cJSON_AddStringToObject(info->root, "clr_temp_cmd_t", tmp);
+                cJSON_AddStringToObject(info->root, "clr_temp_cmd_t", tmp); //color_temp_command_topic
 
                 sprintf(tmp,"cmnd/%s/ctr",clientId);
-                cJSON_AddStringToObject(info->root, "clr_temp_stat_t", tmp);
+                cJSON_AddStringToObject(info->root, "clr_temp_stat_t", tmp);    //color_temp_state_topic
                 
-                cJSON_AddStringToObject(info->root, "clr_temp_val_tpl", "{{value_json.CT}}");
+                cJSON_AddStringToObject(info->root, "clr_temp_val_tpl", "{{value_json.CT}}");   //color_temp_value_template
             }
 
             break;
@@ -231,11 +220,18 @@ HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index){
             info = hass_init_device_info(type, index, "99", "0");
             cJSON_AddStringToObject(info->root, "on_cmd_type", "brightness"); //on_command_type
             cJSON_AddNumberToObject(info->root, "bri_scl", 99);   //brightness_scale
-            cJSON_AddNumberToObject(info->root, "bri_scl", 99);   //brightness_scale
             cJSON_AddBoolToObject(info->root, "opt", cJSON_True);   //optimistic
+            cJSON_AddNumberToObject(info->root, "qos", 1);
 
             sprintf(tmp,"%s/%i/set",clientId,index);
             cJSON_AddStringToObject(info->root, "bri_cmd_t", tmp);    //brightness_command_topic
+
+            sprintf(g_hassBuffer,"%s/%i/get",clientId,index);
+            cJSON_AddStringToObject(info->root, "stat_t", g_hassBuffer);   //state_topic
+
+            sprintf(g_hassBuffer,"%s/%i/set",clientId,index);
+            cJSON_AddStringToObject(info->root, "cmd_t", g_hassBuffer);    //command_topic
+
             break;
         
         default:

--- a/src/httpserver/hass.h
+++ b/src/httpserver/hass.h
@@ -6,10 +6,15 @@
 
 typedef enum {
 	ENTITY_RELAY = 0,
-    ENTITY_LIGHT = 1
+    ENTITY_LIGHT_PWM = 1,
+    ENTITY_LIGHT_RGB = 2,
+    ENTITY_LIGHT_RGBCW = 3,
+    ENTITY_SENSOR = 4,
 } ENTITY_TYPE;
 
-//unique_id is based on CFG_GetDeviceName() whose size is CGF_DEVICE_NAME_SIZE (see hass_populate_unique_id)
+//unique_id is defined in hass_populate_unique_id and is based on CFG_GetDeviceName() whose size is CGF_DEVICE_NAME_SIZE.
+//Sample unique_id would be deviceName_entityType_index.
+//Currently supported entityType is `relay` or `light` - 5 char.
 #define HASS_UNIQUE_ID_SIZE     (CGF_DEVICE_NAME_SIZE + 1 + 5 + 1 + 4)
 
 //channel is based on unique_id (see hass_populate_device_config_channel)
@@ -30,6 +35,7 @@ typedef struct HassDeviceInfo_s{
 } HassDeviceInfo;
 
 void hass_print_unique_id(http_request_t *request, const char *fmt, ENTITY_TYPE type, int index);
-HassDeviceInfo *hass_init_device_info(ENTITY_TYPE type, int index, char *payload_on, char *payload_off);
+HassDeviceInfo *hass_init_relay_device_info(int index);
+HassDeviceInfo *hass_init_light_device_info(ENTITY_TYPE type, int index);
 char *hass_build_discovery_json(HassDeviceInfo *info);
 void hass_free_device_info(HassDeviceInfo *info);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1294,7 +1294,6 @@ int http_fn_ha_cfg(http_request_t *request) {
     const char *clientId;
     int i;
     char mqttAdded = 0;
-    char *uniq_id;
     char switchAdded = 0;
     char lightAdded = 0;
 	int bLedDriverChipRunning;

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1333,7 +1333,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                 }
 
                 hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_RELAY,i);
-                hprintf128(request,"    name: \"%s relay %i\"\n",shortDeviceName,i);
+                hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);
                 poststr(request,   "    qos: 1\n");
@@ -1387,8 +1387,8 @@ int http_fn_ha_cfg(http_request_t *request) {
 
         hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_RGB,i);
         hprintf128(request,"    name: \"%s\"\n",shortDeviceName);
-        hprintf128(request,"       rgb_command_template: \"{{ '#%02x%02x%02x0000' | format(red, green, blue)}}\"\n");
-        hprintf128(request,"       rgb_state_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
+        hprintf128(request,"       rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
+        hprintf128(request,"       rgb_state_topic: \"%s/led_basecolor_rgb/get\"\n",clientId);
         hprintf128(request,"       rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
         hprintf128(request,"       command_topic: \"cmnd/%s/led_enableAll\"\n",clientId);
         hprintf128(request,"       availability_topic: \"%s/connected\"\n",clientId);
@@ -1396,10 +1396,7 @@ int http_fn_ha_cfg(http_request_t *request) {
         hprintf128(request,"       payload_off: 0\n");
         hprintf128(request,"       brightness_command_topic: \"cmnd/%s/led_dimmer\"\n",clientId);
         hprintf128(request,"       brightness_scale: 100\n");
-        hprintf128(request,"       brightness_value_template: \"{{ value_json.Dimmer }}\"\n");
-        //hprintf128(request,"       color_temp_command_topic: \"cmnd/%s/led_temperature\"\n",clientId);
-        //hprintf128(request,"       color_temp_state_topic: \"cmnd/%s/ctr\"\n",clientId);
-        //hprintf128(request,"       color_temp_value_template: \"{{ value_json.CT }}\"\n");
+
 	} else if(pwmCount > 0) {
                 
         for(i = 0; i < CHANNEL_MAX; i++) {
@@ -1414,7 +1411,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                 }
 
                 hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_PWM,i);
-                hprintf128(request,"    name: \"%s light %i\"\n",shortDeviceName,i);
+                hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);
                 hprintf128(request,"    brightness_command_topic: \"%s/%i/set\"\n",clientId,i);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1386,20 +1386,20 @@ int http_fn_ha_cfg(http_request_t *request) {
         }
 
         hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_RGB,i);
-        hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
-        hprintf128(request,"    rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
-        hprintf128(request,"    rgb_value_template: \"{{ value[1:3] | int(base=16) }},{{ value[3:5] | int(base=16) }},{{ value[5:7] | int(base=16) }}\"\n");
-        hprintf128(request,"    rgb_state_topic: \"%s/led_basecolor_rgb/get\"\n",clientId);
-        hprintf128(request,"    rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
-        hprintf128(request,"    command_topic: \"cmnd/%s/led_enableAll\"\n",clientId);
-        hprintf128(request,"    state_topic: \"%s/led_enableAll/get\"\n",clientId);
-        hprintf128(request,"    availability_topic: \"%s/connected\"\n",clientId);
-        hprintf128(request,"    payload_on: 1\n");
-        hprintf128(request,"    payload_off: 0\n");
-        hprintf128(request,"    brightness_command_topic: \"cmnd/%s/led_dimmer\"\n",clientId);
-        hprintf128(request,"    brightness_scale: 100\n");
-        hprintf128(request,"    #brightness_value_template: \"{{ value }}\"\n");
-
+        hprintf128(request,"    name: \"%s\"\n",shortDeviceName);
+        hprintf128(request,"       rgb_command_template: \"{{ '#%02x%02x%02x0000' | format(red, green, blue)}}\"\n");
+        hprintf128(request,"       rgb_state_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
+        hprintf128(request,"       rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
+        hprintf128(request,"       command_topic: \"cmnd/%s/led_enableAll\"\n",clientId);
+        hprintf128(request,"       availability_topic: \"%s/connected\"\n",clientId);
+        hprintf128(request,"       payload_on: 1\n");
+        hprintf128(request,"       payload_off: 0\n");
+        hprintf128(request,"       brightness_command_topic: \"cmnd/%s/led_dimmer\"\n",clientId);
+        hprintf128(request,"       brightness_scale: 100\n");
+        hprintf128(request,"       brightness_value_template: \"{{ value_json.Dimmer }}\"\n");
+        //hprintf128(request,"       color_temp_command_topic: \"cmnd/%s/led_temperature\"\n",clientId);
+        //hprintf128(request,"       color_temp_state_topic: \"cmnd/%s/ctr\"\n",clientId);
+        //hprintf128(request,"       color_temp_value_template: \"{{ value_json.CT }}\"\n");
 	} else if(pwmCount > 0) {
                 
         for(i = 0; i < CHANNEL_MAX; i++) {

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1387,15 +1387,18 @@ int http_fn_ha_cfg(http_request_t *request) {
 
         hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_RGB,i);
         hprintf128(request,"    name: \"%s\"\n",shortDeviceName);
-        hprintf128(request,"       rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
-        hprintf128(request,"       rgb_state_topic: \"%s/led_basecolor_rgb/get\"\n",clientId);
-        hprintf128(request,"       rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
-        hprintf128(request,"       command_topic: \"cmnd/%s/led_enableAll\"\n",clientId);
-        hprintf128(request,"       availability_topic: \"%s/connected\"\n",clientId);
-        hprintf128(request,"       payload_on: 1\n");
-        hprintf128(request,"       payload_off: 0\n");
-        hprintf128(request,"       brightness_command_topic: \"cmnd/%s/led_dimmer\"\n",clientId);
-        hprintf128(request,"       brightness_scale: 100\n");
+        hprintf128(request,"    rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
+        hprintf128(request,"    rgb_value_template: \"{{ value[1:3] | int(base=16) }},{{ value[3:5] | int(base=16) }},{{ value[5:7] | int(base=16) }}\"\n");
+        hprintf128(request,"    rgb_state_topic: \"%s/led_basecolor_rgb/get\"\n",clientId);
+        hprintf128(request,"    rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n",clientId);
+        hprintf128(request,"    command_topic: \"cmnd/%s/led_enableAll\"\n",clientId);
+        hprintf128(request,"    state_topic: \"%s/led_enableAll/get\"\n",clientId);
+        hprintf128(request,"    availability_topic: \"%s/connected\"\n",clientId);
+        hprintf128(request,"    payload_on: 1\n");
+        hprintf128(request,"    payload_off: 0\n");
+        hprintf128(request,"    brightness_command_topic: \"cmnd/%s/led_dimmer\"\n",clientId);
+        hprintf128(request,"    brightness_scale: 100\n");
+        hprintf128(request,"    #brightness_value_template: \"{{ value }}\"\n");
 
 	} else if(pwmCount > 0) {
                 

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1333,7 +1333,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                 }
 
                 hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_RELAY,i);
-                hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
+                hprintf128(request,"    name: \"%s relay %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);
                 poststr(request,   "    qos: 1\n");
@@ -1414,7 +1414,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                 }
 
                 hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_PWM,i);
-                hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
+                hprintf128(request,"    name: \"%s light %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);
                 hprintf128(request,"    brightness_command_topic: \"%s/%i/set\"\n",clientId,i);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1226,9 +1226,16 @@ int http_fn_ha_discovery(http_request_t *request) {
     char topic[32];
     int relayCount = 0;
     int pwmCount = 0;
+    char bLedDriverChipRunning;
 
     http_setup(request, httpMimeTypeText);
     get_Relay_PWM_Count(&relayCount, &pwmCount);
+
+#ifndef OBK_DISABLE_ALL_DRIVERS
+	bLedDriverChipRunning = DRV_IsRunning("SM2135") || DRV_IsRunning("BP5758D");
+#else
+	bLedDriverChipRunning = 0;
+#endif
 
     if ((relayCount == 0) && (pwmCount == 0)) {
         poststr(request, NULL);
@@ -1247,27 +1254,29 @@ int http_fn_ha_discovery(http_request_t *request) {
     if(relayCount > 0) {
         for(i = 0; i < CHANNEL_MAX; i++) {
             if(h_isChannelRelay(i)) {
-                HassDeviceInfo *dev_info = hass_init_device_info(ENTITY_RELAY, i, "1", "0");
+                HassDeviceInfo *dev_info = hass_init_relay_device_info(i);
                 MQTT_QueuePublish(topic, dev_info->channel, hass_build_discovery_json(dev_info), OBK_PUBLISH_FLAG_RETAIN);
                 hass_free_device_info(dev_info);
             }
         }
     }
 
-    if(pwmCount > 0) {
-        char tmp[64];
-        const char *shortDeviceName = CFG_GetShortDeviceName();
-
+    if (pwmCount == 5 || bLedDriverChipRunning) {
+        // Enable + RGB control + CW control
+        HassDeviceInfo *dev_info = hass_init_light_device_info(ENTITY_LIGHT_RGBCW, -1);
+        MQTT_QueuePublish(topic, dev_info->channel, hass_build_discovery_json(dev_info), OBK_PUBLISH_FLAG_RETAIN);
+        hass_free_device_info(dev_info);
+    }
+    else if (pwmCount == 3) {
+        // Enable + RGB control
+        HassDeviceInfo *dev_info = hass_init_light_device_info(ENTITY_LIGHT_RGB, -1);
+        MQTT_QueuePublish(topic, dev_info->channel, hass_build_discovery_json(dev_info), OBK_PUBLISH_FLAG_RETAIN);
+        hass_free_device_info(dev_info);
+    }
+    else if(pwmCount > 0) {
         for(i = 0; i < CHANNEL_MAX; i++) {
             if(h_isChannelPWM(i)) {
-                HassDeviceInfo *dev_info = hass_init_device_info(ENTITY_LIGHT, i, "99", "0");
-
-                cJSON_AddStringToObject(dev_info->root, "on_cmd_type", "brightness"); //on_command_type
-                cJSON_AddNumberToObject(dev_info->root, "bri_scl", 99);   //brightness_scale
-
-                sprintf(tmp,"%s/%i/set",shortDeviceName,i);
-                cJSON_AddStringToObject(dev_info->root, "bri_cmd_t", tmp);    //brightness_command_topic
-
+                HassDeviceInfo *dev_info = hass_init_light_device_info(ENTITY_LIGHT_PWM, i);
                 MQTT_QueuePublish(topic, dev_info->channel, hass_build_discovery_json(dev_info), OBK_PUBLISH_FLAG_RETAIN);
                 hass_free_device_info(dev_info);
             }
@@ -1348,7 +1357,7 @@ int http_fn_ha_cfg(http_request_t *request) {
             switchAdded=1;
         }
 
-        hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT,i);
+        hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_RGBCW,i);
         hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
         hprintf128(request,"    rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
         hprintf128(request,"    rgb_value_template: \"{{ value[1:3] | int(base=16) }},{{ value[3:5] | int(base=16) }},{{ value[5:7] | int(base=16) }}\"\n");
@@ -1377,7 +1386,7 @@ int http_fn_ha_cfg(http_request_t *request) {
             switchAdded=1;
         }
 
-        hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT,i);
+        hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_RGB,i);
         hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
         hprintf128(request,"    rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
         hprintf128(request,"    rgb_value_template: \"{{ value[1:3] | int(base=16) }},{{ value[3:5] | int(base=16) }},{{ value[5:7] | int(base=16) }}\"\n");
@@ -1405,7 +1414,7 @@ int http_fn_ha_cfg(http_request_t *request) {
                     lightAdded=1;
                 }
 
-                hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT,i);
+                hass_print_unique_id(request,"  - unique_id: \"%s\"\n", ENTITY_LIGHT_PWM,i);
                 hprintf128(request,"    name: \"%s %i\"\n",shortDeviceName,i);
                 hprintf128(request,"    state_topic: \"%s/%i/get\"\n",clientId,i);
                 hprintf128(request,"    command_topic: \"%s/%i/set\"\n",clientId,i);

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -1159,7 +1159,8 @@ void MQTT_QueuePublish(char *topic, char *channel, char *value, int flags){
   if ((strlen(topic) > MQTT_PUBLISH_ITEM_TOPIC_LENGTH) ||
     (strlen(channel) > MQTT_PUBLISH_ITEM_CHANNEL_LENGTH) ||
     (strlen(value) > MQTT_PUBLISH_ITEM_VALUE_LENGTH)){
-    addLogAdv(LOG_ERROR,LOG_FEATURE_MQTT,"Unable to queue! Topic, channel or value exceeds size limit\r\n");
+    addLogAdv(LOG_ERROR,LOG_FEATURE_MQTT,"Unable to queue! Topic (%i), channel (%i) or value (%i) exceeds size limit\r\n", 
+      strlen(topic), strlen(channel), strlen(value));
     return;
   }
 

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -976,8 +976,16 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx)
       break;
   }
   
-	if(CHANNEL_IsInUse(idx)) {
-		 MQTT_ChannelPublish(g_publishItemIndex, OBK_PUBLISH_FLAG_MUTEX_SILENT);
+	// if LED driver is active, do not publish raw channel values
+	if(LED_IsRunningDriver() == false && idx >= 0) {
+		// This is because raw channels are like PWM values, RGBCW has 5 raw channels
+		// (unless it has I2C LED driver)
+		// We do not need raw values for RGBCW lights (or RGB, etc)
+		// because we are using led_basecolor_rgb, led_dimmer, led_enableAll, etc
+		// NOTE: negative indexes are not channels - they are special values
+		if(CHANNEL_IsInUse(idx)) {
+			 MQTT_ChannelPublish(g_publishItemIndex, OBK_PUBLISH_FLAG_MUTEX_SILENT);
+		}
 	}
 	return OBK_PUBLISH_WAS_NOT_REQUIRED; // didnt publish
 }

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -520,8 +520,7 @@ static OBK_Publish_Result MQTT_PublishTopicToClient(mqtt_client_t *client, const
   if (pub_topic != NULL)
   {
     sprintf(pub_topic, "%s/%s%s", sTopic, sChannel, (appendGet == true ? "/get" : ""));
-    addLogAdv(LOG_INFO,LOG_FEATURE_MQTT,"Publishing to %s retain=%i",pub_topic, retain);
-    addLogAdv(LOG_INFO,LOG_FEATURE_MQTT,"Published '%s' \n", sVal);
+    addLogAdv(LOG_INFO,LOG_FEATURE_MQTT,"Publishing val %s to %s retain=%i\n",sVal,pub_topic, retain);
 
     err = mqtt_publish(client, pub_topic, sVal, strlen(sVal), qos, retain, mqtt_pub_request_cb, 0);
     os_free(pub_topic);

--- a/src/mqtt/new_mqtt.h
+++ b/src/mqtt/new_mqtt.h
@@ -42,7 +42,7 @@ typedef struct mqtt_request_tag {
 
 #define MQTT_PUBLISH_ITEM_TOPIC_LENGTH    64
 #define MQTT_PUBLISH_ITEM_CHANNEL_LENGTH  64
-#define MQTT_PUBLISH_ITEM_VALUE_LENGTH    480
+#define MQTT_PUBLISH_ITEM_VALUE_LENGTH    768
 
 /// @brief Publish queue item
 typedef struct MqttPublishItem

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -61,8 +61,13 @@ This platform is not supported, error!
 #define BIT_TGL(PIN,N) (PIN ^=  (1<<N))
 #define BIT_CHECK(PIN,N) !!((PIN & (1<<N)))
 
+#ifndef MIN
 #define MIN(a,b)	(((a)<(b))?(a):(b))
+#endif
+
+#ifndef MAX
 #define MAX(a,b)	(((a)>(b))?(a):(b))
+#endif
 
 #if WINDOWS
 


### PR DESCRIPTION
This is not done yet but I wanted to get feedback.

The discovery additions for RGB are based on `http_fn_ha_cfg`.

Changes
* Relay and PWM names now include `relay` or `light` to differentiate between them e.g. `w600CD2185A3 relay 1`. 
* RGB name does not need to include `index`. There should be only one RGB entity since that will only happen if all 5 PWMs were used or external driver was being used, right? 
* The hass config was appending 64 due to the relay loop before it. This has been fixed as well.

Issues
* Currently, PWM and relay have the same state_topic/command_topic (`w600Test/1/set`) which won't work. Instead, should it be  `w600Test/relay_1/set`? To avoid breaking existing settings, `w600Test/1/set` can still drive the relay.
* RGB: I think the topics are incorrect, shouldn't they start with `clientId` and not with `cmnd` ?
* HomeAssistant doesn't like rgb_command_template `hprintf128(request,"       rgb_command_template: \"{{ '#%02x%02x%02x0000' | format(red, green, blue)}}\"\n");` and throws

```
2022-10-05 06:05:16.093 ERROR (MainThread) [homeassistant.util.logging] Exception in rgb_received when handling msg on 'cmnd/w600Test/led_basecolor_rgb': '#ff80ff0000'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/mqtt/debug_info.py", line 47, in wrapper
    msg_callback(msg)
  File "/usr/src/homeassistant/homeassistant/components/mqtt/light/schema_basic.py", line 490, in rgb_received
    rgb = _rgbx_received(
  File "/usr/src/homeassistant/homeassistant/components/mqtt/light/schema_basic.py", line 477, in _rgbx_received
    color = tuple(int(val) for val in payload.split(","))
  File "/usr/src/homeassistant/homeassistant/components/mqtt/light/schema_basic.py", line 477, in <genexpr>
    color = tuple(int(val) for val in payload.split(","))
ValueError: invalid literal for int() with base 10: '#ff80ff0000'
```