### PR TITLE
Update BL602 build info

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,6 +38,24 @@ Checkout [this repository](https://github.com/openshwprojects/OpenBK7231T_App) t
 Run ./build_oxr_sharedapp.sh
 
 
+# Building for BL602
+Get the SDK repo:
+https://github.com/openshwprojects/OpenBL602
+Clone it to a folder, e.g. `OpenBL602/`
+
+Clone the [app](https://github.com/openshwprojects/OpenBK7231T_App) repo into `OpenBL602/customer_app/bl602_sharedApp/bl602_sharedApp/shared` (such that the `.git` folder is placed in the `shared` folder).
+
+On Windows, install [MSys2](https://www.msys2.org/) and open a Msys2 terminal. Install `make` using `pacman -S make`.
+Create a copy of the `OpenBL602/toolchain/riscv/MSYS` folder and rename it to `OpenBL602/toolchain/riscv/MINGW64`.
+
+Open a Msys2 terminal and browse to the `OpenBL602/customer_app/bl602_sharedApp` folder.
+
+Build using:
+`./genromap`
+
+The output binaries can be found at `OpenBL602/customer_app/bl602_sharedApp/build_out/bl602_sharedApp.bin`.
+
+
 # Building for W800/W801
 
 To build for W800, you need our W800 SDK fork:


### PR DESCRIPTION
Elaborate on necessary steps to make the build process easier for new users and contributors. It might be possible to build using Cygwin as well, but that fails on a missing `<sdk>/toolchain/riscv/CYGWIN` directory. Using Msys2, the `<sdk>/toolchain/riscv/MSYS` directory can be copied and renamed as described. This is probably something that should be changed in the SDK repo, but as far as the building information goes, this at least allows people to compile binaries without having to figure out these steps.