### PR TITLE
feat: migrate W600 SDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/openshwprojects/OpenW800.git
 [submodule "sdk/OpenW600"]
 	path = sdk/OpenW600
-	url = https://github.com/iprak/OpenW600.git
+	url = https://github.com/openshwprojects/OpenW600.git


### PR DESCRIPTION
Here's a PR for migrating W600 SDK to the @openshwprojects fork if you wanted. Both repos are at same commit currently so no other changes should be required.