### PR TITLE
Mqtt failure reason

### DIFF
--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -200,6 +200,21 @@ int MQTT_GetConnectResult(void)
 	return mqtt_connect_result;
 }
 
+//Based on mqtt_connection_status_t and https://www.nongnu.org/lwip/2_1_x/group__mqtt.html
+const char* get_callback_error(int reason) {
+	switch (reason)
+	{
+	case MQTT_CONNECT_REFUSED_PROTOCOL_VERSION: return "Refused protocol version";
+	case MQTT_CONNECT_REFUSED_IDENTIFIER: return "Refused identifier";
+	case MQTT_CONNECT_REFUSED_SERVER: return "Refused server";
+	case MQTT_CONNECT_REFUSED_USERNAME_PASS: return "Refused user credentials";
+	case MQTT_CONNECT_REFUSED_NOT_AUTHORIZED_: return "Refused not authorized";
+	case MQTT_CONNECT_DISCONNECTED: return "Disconnected";
+	case MQTT_CONNECT_TIMEOUT: return "Timeout";
+	}
+	return "";
+}
+
 const char* get_error_name(int err)
 {
 	switch (err)
@@ -724,7 +739,7 @@ static void mqtt_connection_cb(mqtt_client_t* client, void* arg, mqtt_connection
 		//        1);
 	}
 	else {
-		addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "mqtt_connection_cb: Disconnected, reason: %d\n", status);
+		addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "mqtt_connection_cb: Disconnected, reason: %d(%s)\n", status, get_callback_error(status));
 	}
 }
 
@@ -1247,4 +1262,11 @@ OBK_Publish_Result PublishQueuedItems() {
 	}
 
 	return result;
+}
+
+
+/// @brief Is MQTT sub system ready and connected?
+/// @return 
+bool MQTT_ready() {
+	return mqtt_client && mqtt_client_is_connected(mqtt_client);
 }

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -749,7 +749,7 @@ static void MQTT_do_connect(mqtt_client_t* client)
 	int mqtt_port;
 	int res;
 	struct hostent* hostEntry;
-	char will_topic[32];
+	char will_topic[CGF_MQTT_CLIENT_ID_SIZE + 16];
 
 	mqtt_host = CFG_GetMQTTHost();
 
@@ -777,7 +777,7 @@ static void MQTT_do_connect(mqtt_client_t* client)
 	mqtt_client_info.client_pass = mqtt_pass;
 	mqtt_client_info.client_user = mqtt_userName;
 
-	sprintf(will_topic, "%s/connected", CFG_GetMQTTClientId());
+	sprintf(will_topic, "%s/connected", mqtt_clientID);
 	mqtt_client_info.will_topic = will_topic;
 	mqtt_client_info.will_msg = "offline";
 	mqtt_client_info.will_retain = true,
@@ -917,8 +917,8 @@ OBK_Publish_Result MQTT_PublishCommand(const void* context, const char* cmd, con
 // called from user_main
 void MQTT_init()
 {
-	char cbtopicbase[64];
-	char cbtopicsub[64];
+	char cbtopicbase[CGF_MQTT_CLIENT_ID_SIZE + 16];
+	char cbtopicsub[CGF_MQTT_CLIENT_ID_SIZE + 16];
 	const char* clientId;
 
 	clientId = CFG_GetMQTTClientId();

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -1267,6 +1267,6 @@ OBK_Publish_Result PublishQueuedItems() {
 
 /// @brief Is MQTT sub system ready and connected?
 /// @return 
-bool MQTT_ready() {
+bool MQTT_IsReady() {
 	return mqtt_client && mqtt_client_is_connected(mqtt_client);
 }

--- a/src/mqtt/new_mqtt.h
+++ b/src/mqtt/new_mqtt.h
@@ -86,7 +86,6 @@ OBK_Publish_Result MQTT_ChannelChangeCallback(int channel, int iVal);
 void MQTT_PublishOnlyDeviceChannelsIfPossible();
 void MQTT_QueuePublish(char* topic, char* channel, char* value, int flags);
 OBK_Publish_Result MQTT_Publish(char* sTopic, char* sChannel, char* value, int flags);
+bool MQTT_ready();
 
 #endif // __NEW_MQTT_H__
-
-

--- a/src/mqtt/new_mqtt.h
+++ b/src/mqtt/new_mqtt.h
@@ -86,6 +86,6 @@ OBK_Publish_Result MQTT_ChannelChangeCallback(int channel, int iVal);
 void MQTT_PublishOnlyDeviceChannelsIfPossible();
 void MQTT_QueuePublish(char* topic, char* channel, char* value, int flags);
 OBK_Publish_Result MQTT_Publish(char* sTopic, char* sChannel, char* value, int flags);
-bool MQTT_ready();
+bool MQTT_IsReady();
 
 #endif // __NEW_MQTT_H__

--- a/src/mqtt/new_mqtt.h
+++ b/src/mqtt/new_mqtt.h
@@ -18,7 +18,7 @@ extern mqtt_client_t* mqtt_client;
 
 //void mqtt_example_init(void);
 //void example_do_connect(mqtt_client_t *client);
-void example_publish(mqtt_client_t *client, int channel, int iVal);
+void example_publish(mqtt_client_t* client, int channel, int iVal);
 void MQTT_init();
 int MQTT_RunEverySecondUpdate();
 
@@ -27,7 +27,7 @@ enum OBK_Publish_Result_e {
 	OBK_PUBLISH_MUTEX_FAIL,
 	OBK_PUBLISH_WAS_DISCONNECTED,
 	OBK_PUBLISH_WAS_NOT_REQUIRED,
-    OBK_PUBLISH_MEM_FAIL,
+	OBK_PUBLISH_MEM_FAIL,
 };
 
 #define OBK_PUBLISH_FLAG_MUTEX_SILENT	1
@@ -35,9 +35,9 @@ enum OBK_Publish_Result_e {
 
 // ability to register callbacks for MQTT data
 typedef struct mqtt_request_tag {
-    const unsigned char *received; // note: NOT terminated, may be binary
-    int receivedLen;
-    char topic[128];
+	const unsigned char* received; // note: NOT terminated, may be binary
+	int receivedLen;
+	char topic[128];
 } mqtt_request_t;
 
 #define MQTT_PUBLISH_ITEM_TOPIC_LENGTH    64
@@ -47,11 +47,11 @@ typedef struct mqtt_request_tag {
 /// @brief Publish queue item
 typedef struct MqttPublishItem
 {
-  char topic[MQTT_PUBLISH_ITEM_TOPIC_LENGTH];
-  char channel[MQTT_PUBLISH_ITEM_CHANNEL_LENGTH];
-  char value[MQTT_PUBLISH_ITEM_VALUE_LENGTH];
-  int flags;
-  struct MqttPublishItem *next;
+	char topic[MQTT_PUBLISH_ITEM_TOPIC_LENGTH];
+	char channel[MQTT_PUBLISH_ITEM_CHANNEL_LENGTH];
+	char value[MQTT_PUBLISH_ITEM_VALUE_LENGTH];
+	int flags;
+	struct MqttPublishItem* next;
 } MqttPublishItem_t;
 
 // Count of queued items published at once.
@@ -61,31 +61,31 @@ typedef struct MqttPublishItem
 // callback function for mqtt.
 // return 0 to allow the incoming topic/data to be processed by others/channel set.
 // return 1 to 'eat the packet and terminate further processing.
-typedef int (*mqtt_callback_fn)(mqtt_request_t *request);
+typedef int (*mqtt_callback_fn)(mqtt_request_t* request);
 
 // topics must be unique (i.e. you can't have /about and /aboutme or /about/me)
 // ALL topics currently must start with main device topic root.
 // ID is unique and non-zero - so that callbacks can be replaced....
 int MQTT_GetConnectEvents(void);
-const char *get_error_name(int err);
+const char* get_error_name(int err);
 int MQTT_GetConnectResult(void);
-char *MQTT_GetStatusMessage(void);
+char* MQTT_GetStatusMessage(void);
 int MQTT_GetPublishEventCounter(void);
 int MQTT_GetPublishErrorCounter(void);
 int MQTT_GetReceivedEventCounter(void);
 
-int MQTT_RegisterCallback( const char *basetopic, const char *subscriptiontopic, int ID, mqtt_callback_fn callback);
+int MQTT_RegisterCallback(const char* basetopic, const char* subscriptiontopic, int ID, mqtt_callback_fn callback);
 int MQTT_RemoveCallback(int ID);
 
-void MQTT_GetStats(int *outUsed, int *outMax, int *outFreeMem);
+void MQTT_GetStats(int* outUsed, int* outMax, int* outFreeMem);
 
-OBK_Publish_Result MQTT_PublishMain_StringFloat(const char *sChannel, float f);
-OBK_Publish_Result MQTT_PublishMain_StringInt(const char *sChannel, int val);
-OBK_Publish_Result MQTT_PublishMain_StringString(const char *sChannel, const char *valueStr, int flags);
+OBK_Publish_Result MQTT_PublishMain_StringFloat(const char* sChannel, float f);
+OBK_Publish_Result MQTT_PublishMain_StringInt(const char* sChannel, int val);
+OBK_Publish_Result MQTT_PublishMain_StringString(const char* sChannel, const char* valueStr, int flags);
 OBK_Publish_Result MQTT_ChannelChangeCallback(int channel, int iVal);
 void MQTT_PublishOnlyDeviceChannelsIfPossible();
-void MQTT_QueuePublish(char *topic, char *channel, char *value, int flags);
-OBK_Publish_Result MQTT_Publish(char *sTopic, char *sChannel, char *value, int flags);
+void MQTT_QueuePublish(char* topic, char* channel, char* value, int flags);
+OBK_Publish_Result MQTT_Publish(char* sTopic, char* sChannel, char* value, int flags);
 
 #endif // __NEW_MQTT_H__
 


### PR DESCRIPTION
* Ensures that fields based on `CFG_GetMQTTClientId()` have more space than 64 which is what is the size of `mqtt_clientId`.
* Also added `MQTT_ready` for future use.
* Added MQTT failure reasons.
![image](https://user-images.githubusercontent.com/6459774/195982888-b6a4594f-65eb-44b5-acc2-13d0c2063820.png)
