### PR TITLE
chore: new built-in device for Deta GPO

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -92,7 +92,8 @@ template_t g_templates[] = {
 	{ Setup_Device_Enbrighten_WFD4103, "Enbrighten WFD4103 WiFi Switch BK7231T WB2S"} ,
 	{ Setup_Device_Zemismart_Light_Switch_KS_811_3, "Zemismart Light Switch (Neutral Optional) KS_811_3"} ,
 	{ Setup_Device_TeslaSmartPlus_TSL_SPL_1, "Tesla Smart Plug. Model: (TSL-SPL-1)"},
-	{ Setup_Device_Calex_900011_1_WB2S, "Calex Smart Power Plug 900011.1"}
+	{ Setup_Device_Calex_900011_1_WB2S, "Calex Smart Power Plug 900011.1"},
+	{ Setup_Device_BK7231T_WB2S_6920HA_CSE7766, "[BK7231T][WB2S] DETA Smart Double Touch Power Point With Dual USB and Power Monitoring (6920HA)"}
 
 };
 

--- a/src/new_builtin_devices.c
+++ b/src/new_builtin_devices.c
@@ -930,3 +930,31 @@ void Setup_Device_Calex_900011_1_WB2S(){
 
 	CFG_Save_SetupTimer();
 }
+
+// Deta Grid Connect Smart Double Touch Power Point With Dual USB (6920HA)
+// https://www.bunnings.com.au/deta-grid-connect-smart-double-touch-power-point-with-dual-usb_p0172780
+void Setup_Device_BK7231T_WB2S_6920HA_CSE7766() {
+
+	CFG_ClearPins();
+	// Relay 1
+	PIN_SetPinRoleForPinIndex(6, IOR_Relay);
+	PIN_SetPinChannelForPinIndex(6, 1);
+	// Button 1
+	PIN_SetPinRoleForPinIndex(7, IOR_Button);
+	PIN_SetPinChannelForPinIndex(7, 1);
+
+	// LED
+	PIN_SetPinRoleForPinIndex(8, IOR_LED_WIFI_n);
+	PIN_SetPinChannelForPinIndex(8, 1);
+
+	// Button 2
+	PIN_SetPinRoleForPinIndex(24, IOR_Button);
+	PIN_SetPinChannelForPinIndex(24, 2);
+	// Relay 2
+	PIN_SetPinRoleForPinIndex(26, IOR_Relay);
+	PIN_SetPinChannelForPinIndex(26, 2);
+
+	CFG_SetShortStartupCommand_AndExecuteNow("backlog startDriver CSE7766; VREF 383160; IREF 16520; PREF 10444800;");
+
+	CFG_Save_SetupTimer();
+}

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -271,5 +271,6 @@ void Setup_Device_Aubess_Mini_Smart_Switch_16A();
 void Setup_Device_Zemismart_Light_Switch_KS_811_3();
 void Setup_Device_TeslaSmartPlus_TSL_SPL_1();
 void Setup_Device_Calex_900011_1_WB2S();
+void Setup_Device_BK7231T_WB2S_6920HA_CSE7766();
 
 #endif


### PR DESCRIPTION
Device template for power monitoring edition of the DETA dual GPO with USB ports (https://www.bunnings.com.au/deta-grid-connect-smart-double-touch-power-point-with-dual-usb_p0172780)

Enables buttons linked to relays, WiFi LED and starts CSE7766 driver for power monitoring.