### PR TITLE
Discovery check power driver correctly

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -615,5 +615,5 @@ const char pageScript[] = "<script type='text/javascript'>var firstTime,lastTime
 //region_end pageScript
 
 //region_start ha_discovery_script
-const char ha_discovery_script[] = "<script type='text/javascript'>function send_ha_disc(){var e=new XMLHttpRequest;e.open(\"GET\",\"/ha_discovery?prefix=\"+document.getElementById(\"ha_disc_topic\").value,!1),e.onload=function(){200===e.status?alert(\"MQTT discovery queued\"):404===e.status&&alert(\"Error invoking ha_discovery\")},e.onerror=function(){alert(\"Error invoking ha_discovery\")},e.send()}</script>";
+const char ha_discovery_script[] = "<script type='text/javascript'>function send_ha_disc(){var e=new XMLHttpRequest;e.open(\"GET\",\"/ha_discovery?prefix=\"+document.getElementById(\"ha_disc_topic\").value,!1),e.onload=function(){200===e.status?alert(e.responseText):404===e.status&&alert(\"Error invoking ha_discovery\")},e.onerror=function(){alert(\"Error invoking ha_discovery\")},e.send()}</script>";
 //region_end ha_discovery_script

--- a/src/httpserver/script_ha_discovery.js
+++ b/src/httpserver/script_ha_discovery.js
@@ -9,7 +9,7 @@ function send_ha_disc() {
   );
   xhr.onload = function () {
     if (xhr.status === 200) {
-      alert("MQTT discovery queued");
+      alert(xhr.responseText);
     } else if (xhr.status === 404) {
       alert("Error invoking ha_discovery");
     }


### PR DESCRIPTION
* Fixed incorrect quit when device has only power measurement driver running and has no relay/PWM channels.
* Changed client script to show message sent from device,
![image](https://user-images.githubusercontent.com/6459774/196032792-64dd4734-c31f-4643-9b92-12d6259b8822.png)
![image](https://user-images.githubusercontent.com/6459774/196032941-9f68b4ad-bcb9-49a0-a521-c63d5ea0d829.png)
![image](https://user-images.githubusercontent.com/6459774/196032992-8c1a6338-925d-4c3f-8ae4-16e586dd0be4.png)
