### PR TITLE
Discovery / publish initial values

### DIFF
--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -1248,7 +1248,6 @@ OBK_Publish_Result PublishQueuedItems() {
 
 	int count = 0;
 	MqttPublishItem_t* head = g_MqttPublishQueueHead;
-	char* command;
 
 	//The next actionable item might not be at the front. The queue size is limited to MQTT_QUEUED_ITEMS_PUBLISHED_AT_ONCE
 	//so this traversal is fast.

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -884,16 +884,12 @@ OBK_Publish_Result MQTT_ChannelPublish(int channel, int flags)
 }
 // This console command will trigger a publish of all used variables (channels and extra stuff)
 OBK_Publish_Result MQTT_PublishAll(const void* context, const char* cmd, const char* args, int cmdFlags) {
-
-	MQTT_PublishWholeDeviceState_Internal(false);
-
+	MQTT_PublishWholeDeviceState_Internal(true);
 	return 1;// TODO make return values consistent for all console commands
 }
 // This console command will trigger a publish of runtime variables
 OBK_Publish_Result MQTT_PublishChannels(const void* context, const char* cmd, const char* args, int cmdFlags) {
-
-	MQTT_PublishWholeDeviceState_Internal(true);
-
+	MQTT_PublishOnlyDeviceChannelsIfPossible();
 	return 1;// TODO make return values consistent for all console commands
 }
 OBK_Publish_Result MQTT_PublishCommand(const void* context, const char* cmd, const char* args, int cmdFlags) {

--- a/src/mqtt/new_mqtt.h
+++ b/src/mqtt/new_mqtt.h
@@ -49,7 +49,13 @@ typedef struct MqttPublishItem
 	char value[MQTT_PUBLISH_ITEM_VALUE_LENGTH];
 	int flags;
 	struct MqttPublishItem* next;
+	const char* command;
 } MqttPublishItem_t;
+
+#define MQTT_COMMAND_PUBLISH			"publish"
+#define MQTT_COMMAND_PUBLISH_ALL		"publishAll"
+#define MQTT_COMMAND_PUBLISH_CHANNELS	"publishChannels"
+
 
 // Count of queued items published at once.
 #define MQTT_QUEUED_ITEMS_PUBLISHED_AT_ONCE	3
@@ -82,6 +88,7 @@ OBK_Publish_Result MQTT_PublishMain_StringString(const char* sChannel, const cha
 OBK_Publish_Result MQTT_ChannelChangeCallback(int channel, int iVal);
 void MQTT_PublishOnlyDeviceChannelsIfPossible();
 void MQTT_QueuePublish(char* topic, char* channel, char* value, int flags);
+void MQTT_QueuePublishWithCommand(char* topic, char* channel, char* value, int flags, const char* command);
 OBK_Publish_Result MQTT_Publish(char* sTopic, char* sChannel, char* value, int flags);
 bool MQTT_IsReady();
 


### PR DESCRIPTION
This PR address the issue of devices initially appearing unavailable. The MQTT publish for discovery has been adjusted to allow executing a command at the end, the command being `publishChannels`.

MQTT_PublishAll and MQTT_PublishChannels were reversed and have been addressed as well.

This should close https://github.com/openshwprojects/OpenBK7231T_App/issues/252 as well.