### PR TITLE
Malloctest

### DIFF
--- a/src/cmnds/cmd_eventHandlers.c
+++ b/src/cmnds/cmd_eventHandlers.c
@@ -252,6 +252,9 @@ void EventHandlers_AddEventHandler_Integer(byte eventCode, int type, int require
 	ev->eventCode = eventCode;
 	ev->requiredArgument = requiredArgument;
 	ev->requiredArgument2 = requiredArgument2;
+
+	ev->next = g_eventHandlers;
+	g_eventHandlers = ev;
 }
 
 void EventHandlers_AddEventHandler_String(byte eventCode, int type, const char *requiredArgument, const char *commandToRun)
@@ -265,6 +268,9 @@ void EventHandlers_AddEventHandler_String(byte eventCode, int type, const char *
 	ev->eventCode = eventCode;
 	ev->requiredArgument = 0;
 	ev->requiredArgument2 = 0;
+
+	ev->next = g_eventHandlers;
+	g_eventHandlers = ev;
 }
 
 void EventHandlers_FireEvent2(byte eventCode, int argument, int argument2) {

--- a/src/cmnds/cmd_eventHandlers.c
+++ b/src/cmnds/cmd_eventHandlers.c
@@ -246,22 +246,9 @@ void EventHandlers_AddEventHandler_Integer(byte eventCode, int type, int require
 	eventHandler_t *ev = malloc(sizeof(eventHandler_t));
 	memset(ev,0,sizeof(eventHandler_t));
 
-	// only re-allocate and pre-pend if we did not find it
-	if (!ev){
-		ev = (eventHandler_t *) malloc(sizeof(eventHandler_t));
-		ev->next = g_eventHandlers;
-		g_eventHandlers = ev;
-		ADDLOG_INFO(LOG_FEATURE_EVENT, "EventHandlers_AddEventHandler_Integer: new event %s", commandToRun);
-	} else {
-		ADDLOG_INFO(LOG_FEATURE_EVENT, "EventHandlers_AddEventHandler_Integer: replace event %s", commandToRun);
-	}
-
 	ev->requiredArgumentText = NULL;
 	ev->eventType = type;
-	if (strcmp(ev->command, commandToRun)){
-		free(ev->command);
-		ev->command = test_strdup(commandToRun);
-	}
+	ev->command = test_strdup(commandToRun);
 	ev->eventCode = eventCode;
 	ev->requiredArgument = requiredArgument;
 	ev->requiredArgument2 = requiredArgument2;
@@ -272,22 +259,9 @@ void EventHandlers_AddEventHandler_String(byte eventCode, int type, const char *
 	eventHandler_t *ev = malloc(sizeof(eventHandler_t));
 	memset(ev,0,sizeof(eventHandler_t));
 
-	// only re-allocate and pre-pend if we did not find it
-	if (!ev){
-		ev = (eventHandler_t *) malloc(sizeof(eventHandler_t));
-		ev->next = g_eventHandlers;
-		g_eventHandlers = ev;
-		ADDLOG_INFO(LOG_FEATURE_EVENT, "EventHandlers_AddEventHandler_String: new event %s", commandToRun);
-	} else {
-		ADDLOG_INFO(LOG_FEATURE_EVENT, "EventHandlers_AddEventHandler_String: replace event %s", commandToRun);
-	}
-
 	ev->requiredArgumentText = test_strdup(requiredArgument);
 	ev->eventType = type;
-	if (strcmp(ev->command, commandToRun)){
-		free(ev->command);
-		ev->command = test_strdup(commandToRun);
-	}
+	ev->command = test_strdup(commandToRun);
 	ev->eventCode = eventCode;
 	ev->requiredArgument = 0;
 	ev->requiredArgument2 = 0;

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -32,13 +32,39 @@ static int generateHashValue(const char *fname) {
 
 command_t *g_commands[HASH_SIZE] = { NULL };
 
+static int callme(int calls){
+	//char test[200];
+	rtos_delay_milliseconds(40);
+	calls++;
+	//memset(test, 0, 200);
+	//char *test2 = malloc(100);
+	ADDLOG_INFO(LOG_FEATURE_CMD, " recurse %d", calls);
+	if (calls < 10){
+		callme(calls);
+	}
+	//free(test2);
+	return 0;
+}
+
 static int CMD_SimonTest(const void *context, const char *cmd, const char *args, int cmdFlags){
-	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_SimonTest: ir test routine");
+
 
 #ifdef PLATFORM_BK7231T
-	// anything
-#endif
 
+	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_SimonTest: starting");
+	char *test = malloc(4000);
+
+	callme(0);
+
+	if (test){
+		memset(test, 0xaa, 4000);
+		free(test);
+	} else {
+		ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_SimonTest: #####MALLOC FAILE####");
+
+	}
+	//rtos_delay_milliseconds(500);
+#endif
 	
 	return 1;
 }

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -57,6 +57,7 @@ static int CMD_SimonTest(const void *context, const char *cmd, const char *args,
 
 #ifdef PLATFORM_BK7231T
 	logStack("CMD_SimonTest");
+	mallocTest();
 	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_SimonTest: starting stackvarsize %d", sizeof(StackType_t));
 
 	char *test = malloc(4000);

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -5,6 +5,7 @@
 #include <ctype.h>
 #include "cmd_local.h"
 #include "../driver/drv_ir.h"
+#include "../memory/memtest.h"
 
 #ifdef BK_LITTLEFS
 	#include "../littlefs/our_lfs.h"
@@ -32,8 +33,12 @@ static int generateHashValue(const char *fname) {
 
 command_t *g_commands[HASH_SIZE] = { NULL };
 
+
+
+
 static int callme(int calls){
-	//char test[200];
+#ifdef PLATFORM_BK7231T
+	logStack("callme");
 	rtos_delay_milliseconds(40);
 	calls++;
 	//memset(test, 0, 200);
@@ -43,6 +48,7 @@ static int callme(int calls){
 		callme(calls);
 	}
 	//free(test2);
+#endif	
 	return 0;
 }
 
@@ -50,8 +56,9 @@ static int CMD_SimonTest(const void *context, const char *cmd, const char *args,
 
 
 #ifdef PLATFORM_BK7231T
+	logStack("CMD_SimonTest");
+	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_SimonTest: starting stackvarsize %d", sizeof(StackType_t));
 
-	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_SimonTest: starting");
 	char *test = malloc(4000);
 
 	callme(0);

--- a/src/cmnds/cmd_tasmota.c
+++ b/src/cmnds/cmd_tasmota.c
@@ -184,7 +184,7 @@ static int cmnd_lfsexec(const void * context, const char *cmd, const char *args,
 #ifdef BK_LITTLEFS
 	ADDLOG_DEBUG(LOG_FEATURE_CMD, "exec %s", args);
 	if (lfs_present()){
-		lfs_file_t *file = os_malloc(sizeof(lfs_file_t));
+		lfs_file_t *file = malloc(sizeof(lfs_file_t));
 		if (file){
 			int lfsres;
 			char line[256];
@@ -220,7 +220,7 @@ static int cmnd_lfsexec(const void * context, const char *cmd, const char *args,
 			} else {
 				ADDLOG_ERROR(LOG_FEATURE_CMD, "no file %s err %d", fname, lfsres);
 			}
-			os_free(file);
+			free(file);
 			file = NULL;
 		}
 	} else {

--- a/src/cmnds/cmd_tcp.c
+++ b/src/cmnds/cmd_tcp.c
@@ -124,7 +124,7 @@ void CMD_StartTCPCommandLine()
     err = rtos_create_thread( &g_cmd_thread, 6,
 									"CMD_server",
 									(beken_thread_function_t)CMD_ServerThread,
-									0x800,
+									0x1000,
 									(beken_thread_arg_t)0 );
     if(err != kNoErr)
     {

--- a/src/cmnds/cmd_test.c
+++ b/src/cmnds/cmd_test.c
@@ -43,17 +43,17 @@ static int addcmd(const void * context, const char *cmd, const char *args, int c
         }
 
         if (cmds[index]){
-            os_free(cmds[index]);
+            free(cmds[index]);
         }
         if (names[index]){
-            os_free(names[index]);
+            free(names[index]);
         }
-        cmds[index] = os_malloc(strlen(args)+1);
+        cmds[index] = malloc(strlen(args)+1);
 
         strcpy(cmds[index], args);
         //len =
 		get_cmd(args, cmd, 32, 1);
-        names[index] = os_malloc(strlen(cmd)+1);
+        names[index] = malloc(strlen(cmd)+1);
         strcpy(names[index], cmd);
 		ADDLOG_ERROR(LOG_FEATURE_CMD, "cmd %d set to %s", index, cmd);
 
@@ -83,7 +83,7 @@ static int testMallocFree(const void * context, const char *cmd, const char *arg
 
 		msg = malloc(ra1);
 		memset(msg,rand()%255,ra1);
-		os_free(msg);
+		free(msg);
 	}
 
 	ADDLOG_INFO(LOG_FEATURE_CMD, "Malloc has been tested! Total calls %i, reps now %i",totalCalls,repeats);
@@ -115,7 +115,7 @@ static int testRealloc(const void * context, const char *cmd, const char *args, 
 			msg = realloc(msg,ra1);
 		}
 
-		os_free(msg);
+		free(msg);
 	}
 
 	ADDLOG_INFO(LOG_FEATURE_CMD, "Realloc has been tested! Total calls %i, reps now %i",totalCalls,repeats);
@@ -165,7 +165,7 @@ static int testJSON(const void * context, const char *cmd, const char *args, int
 
 		msg = cJSON_Print(root);
 		cJSON_Delete(root);
-		os_free(msg);
+		free(msg);
 	}
 
 	ADDLOG_INFO(LOG_FEATURE_CMD, "testJSON has been tested! Total calls %i, reps now %i",totalCalls,repeats);

--- a/src/cmnds/cmd_tokenizer.c
+++ b/src/cmnds/cmd_tokenizer.c
@@ -76,7 +76,7 @@ void Tokenizer_TokenizeString(const char *s) {
 		return;
 	}
 
-	while(isWhiteSpace(*s)) {
+	while((*s) && isWhiteSpace(*s)) {
 		s++;
 	}
 
@@ -84,7 +84,7 @@ void Tokenizer_TokenizeString(const char *s) {
 		return;
 	}
 
-	strcpy(g_buffer,s);
+	strncpy(g_buffer,s, 500);
 	p = g_buffer;
 	g_args[g_numArgs] = p;
 	g_argsFrom[g_numArgs] = (s+(p-g_buffer));

--- a/src/cmnds/cmd_tokenizer.c
+++ b/src/cmnds/cmd_tokenizer.c
@@ -84,7 +84,7 @@ void Tokenizer_TokenizeString(const char *s) {
 		return;
 	}
 
-	strncpy(g_buffer,s, 500);
+	strcpy_safe(g_buffer,s, MAX_CMD_LEN);
 	p = g_buffer;
 	g_args[g_numArgs] = p;
 	g_argsFrom[g_numArgs] = (s+(p-g_buffer));

--- a/src/driver/drv_bl_shared.c
+++ b/src/driver/drv_bl_shared.c
@@ -192,7 +192,7 @@ int BL09XX_SetupEnergyStatistic(const void *context, const char *cmd, const char
         {
             /* upgrade sample count, free memory */
             if (energyCounterMinutes != NULL)
-                os_free(energyCounterMinutes);
+                free(energyCounterMinutes);
             energyCounterMinutes = NULL;
             energyCounterSampleCount = sample_count;
         }
@@ -208,7 +208,7 @@ int BL09XX_SetupEnergyStatistic(const void *context, const char *cmd, const char
         if (energyCounterMinutes == NULL)
         {
             /* allocate new memeory */
-            energyCounterMinutes = (float*)os_malloc(sample_count*sizeof(float));
+            energyCounterMinutes = (float*)malloc(sample_count*sizeof(float));
             if (energyCounterMinutes != NULL)
             {
                 memset(energyCounterMinutes, 0, energyCounterSampleCount*sizeof(float));
@@ -224,7 +224,7 @@ int BL09XX_SetupEnergyStatistic(const void *context, const char *cmd, const char
         energyCounterStatsEnable = false;
         if (energyCounterMinutes != NULL)
         {
-            os_free(energyCounterMinutes);
+            free(energyCounterMinutes);
             energyCounterMinutes = NULL;
         }
         energyCounterSampleCount = sample_count;
@@ -292,7 +292,7 @@ void BL_ProcessUpdate(float voltage, float current, float power)
 
                 MQTT_PublishMain_StringString(counter_mqttNames[2], msg, 0);
                 stat_updatesSent++;
-                os_free(msg);
+                free(msg);
             }
 
             if (energyCounterMinutes != NULL)
@@ -379,7 +379,7 @@ void BL_Shared_Init()
     {
         if (energyCounterMinutes == NULL)
         {
-            energyCounterMinutes = (float*)os_malloc(energyCounterSampleCount*sizeof(float));
+            energyCounterMinutes = (float*)malloc(energyCounterSampleCount*sizeof(float));
         }
         if (energyCounterMinutes != NULL)
         {

--- a/src/hal/bk7231/hal_main_bk7231.c
+++ b/src/hal/bk7231/hal_main_bk7231.c
@@ -42,7 +42,7 @@ void user_main(void)
 // That's because Free is defined to os_free. It would be better to fix it elsewhere
 void Free(void* ptr)
 {
-    os_free(ptr);
+    free(ptr);
 }
 
 

--- a/src/hal/bk7231/hal_wifi_bk7231.c
+++ b/src/hal/bk7231/hal_wifi_bk7231.c
@@ -66,31 +66,34 @@ const char* HAL_GetMACStr(char* macstr)
 	return macstr;
 }
 
-void print_security_type(int type) {
+const char *get_security_type(int type) {
+	const char *t
 	switch (type)
 	{
 	case SECURITY_TYPE_NONE:
-		bk_printf("OPEN\r\n");
+		t = "OPEN";
 		break;
 	case SECURITY_TYPE_WEP:
-		bk_printf("WEP\r\n");
+		t = "WEP";
 		break;
 	case SECURITY_TYPE_WPA_TKIP:
-		bk_printf("TKIP\r\n");
+		t = "TKIP";
 		break;
 	case SECURITY_TYPE_WPA2_AES:
-		bk_printf("CCMP\r\n");
+		t = "CCMP";
 		break;
 	case SECURITY_TYPE_WPA2_MIXED:
-		bk_printf("MIXED\r\n");
+		t = "MIXED";
 		break;
 	case SECURITY_TYPE_AUTO:
-		bk_printf("AUTO\r\n");
+		t = "AUTO";
 		break;
 	default:
-		bk_printf("Error\r\n");
+		t = "Error";
 		break;
 	}
+
+	return t;
 }
 
 void HAL_PrintNetworkInfo()
@@ -110,9 +113,11 @@ void HAL_PrintNetworkInfo()
 	network_InitTypeDef_ap_st ap_info;
 	char ssid[33] = { 0 };
 #if CFG_IEEE80211N
-	bk_printf("sta: %d, softap: %d, b/g/n\r\n", sta_ip_is_start(), uap_ip_is_start());
+	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, 
+		"sta: %d, softap: %d, b/g/n\r\n", sta_ip_is_start(), uap_ip_is_start());
 #else
-	bk_printf("sta: %d, softap: %d, b/g\r\n", sta_ip_is_start(), uap_ip_is_start());
+	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, 
+		"sta: %d, softap: %d, b/g\r\n", sta_ip_is_start(), uap_ip_is_start());
 #endif
 
 	if (sta_ip_is_start())
@@ -121,10 +126,11 @@ void HAL_PrintNetworkInfo()
 		bk_wlan_get_link_status(&linkStatus);
 		memcpy(ssid, linkStatus.ssid, 32);
 
-		char* fmt = "sta:rssi=%d,ssid=%s,bssid=" MACSTR ",channel=%d,cipher_type:";
-		bk_printf(fmt,
-			linkStatus.wifi_strength, ssid, MAC2STR(linkStatus.bssid), linkStatus.channel);
-		print_security_type(bk_sta_cipher_type());
+		char* fmt = "sta:rssi=%d,ssid=%s,bssid=" MACSTR ",channel=%d,cipher_type:%s";
+		addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, 
+			fmt,
+			linkStatus.wifi_strength, ssid, MAC2STR(linkStatus.bssid), linkStatus.channel,
+			get_security_type(bk_sta_cipher_type()));
 	}
 
 	if (uap_ip_is_start())
@@ -132,9 +138,9 @@ void HAL_PrintNetworkInfo()
 		os_memset(&ap_info, 0x0, sizeof(network_InitTypeDef_ap_st));
 		bk_wlan_ap_para_info_get(&ap_info);
 		memcpy(ssid, ap_info.wifi_ssid, 32);
-		bk_printf("softap:ssid=%s,channel=%d,dhcp=%d,cipher_type:",
-			ssid, ap_info.channel, ap_info.dhcp_mode);
-		print_security_type(ap_info.security);
+		addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, 
+			"softap:ssid=%s,channel=%d,dhcp=%d,cipher_type:%s",
+			ssid, ap_info.channel, ap_info.dhcp_mode, get_security_type(ap_info.security));
 		addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "ip=%s,gate=%s,mask=%s,dns=%s\r\n",
 			ap_info.local_ip_addr,
 			ap_info.gateway_ip_addr,

--- a/src/hal/bk7231/hal_wifi_bk7231.c
+++ b/src/hal/bk7231/hal_wifi_bk7231.c
@@ -67,7 +67,7 @@ const char* HAL_GetMACStr(char* macstr)
 }
 
 const char *get_security_type(int type) {
-	const char *t
+	const char *t = "Error";
 	switch (type)
 	{
 	case SECURITY_TYPE_NONE:
@@ -87,9 +87,6 @@ const char *get_security_type(int type) {
 		break;
 	case SECURITY_TYPE_AUTO:
 		t = "AUTO";
-		break;
-	default:
-		t = "Error";
 		break;
 	}
 

--- a/src/httpclient/http_client.c
+++ b/src/httpclient/http_client.c
@@ -288,21 +288,21 @@ int httpclient_send_header(httpclient_t *client, const char *url, int method, ht
     int port;
     int rc = SUCCESS_RETURN;
 
-    if (NULL == (host = (char *)os_malloc(HTTPCLIENT_MAX_HOST_LEN))) {
+    if (NULL == (host = (char *)malloc(HTTPCLIENT_MAX_HOST_LEN))) {
         ADDLOG_ERROR(LOG_FEATURE_HTTP_CLIENT, "not enough memory");
         return FAIL_RETURN;
     }
-    if (NULL == (path = (char *)os_malloc(HTTPCLIENT_MAX_HOST_LEN))) {
+    if (NULL == (path = (char *)malloc(HTTPCLIENT_MAX_HOST_LEN))) {
         ADDLOG_ERROR(LOG_FEATURE_HTTP_CLIENT, "not enough memory");
         rc = FAIL_RETURN;
         goto GO_ERR_3;
     }
-    if (NULL == (send_buf = (char *)os_malloc(HTTPCLIENT_SEND_BUF_SIZE))) {
+    if (NULL == (send_buf = (char *)malloc(HTTPCLIENT_SEND_BUF_SIZE))) {
         ADDLOG_ERROR(LOG_FEATURE_HTTP_CLIENT, "not enough memory");
         rc = FAIL_RETURN;
         goto GO_ERR_2;
     }
-    if (NULL == (buf = (char *)os_malloc(HTTPCLIENT_SEND_BUF_SIZE))) {
+    if (NULL == (buf = (char *)malloc(HTTPCLIENT_SEND_BUF_SIZE))) {
         ADDLOG_ERROR(LOG_FEATURE_HTTP_CLIENT, "not enough memory");
         rc = FAIL_RETURN;
         goto GO_ERR_1;
@@ -378,13 +378,13 @@ int httpclient_send_header(httpclient_t *client, const char *url, int method, ht
         rc = ERROR_HTTP_CONN;
     }
 GO_ERR:
-    os_free(buf);
+    free(buf);
 GO_ERR_1:
-    os_free(send_buf);
+    free(send_buf);
 GO_ERR_2:
-    os_free(path);
+    free(path);
 GO_ERR_3:
-    os_free(host);
+    free(host);
     return rc;//SUCCESS_RETURN;
 }
 
@@ -609,7 +609,7 @@ int httpclient_retrieve_content_old(httpclient_t *client, char *data, int len, u
         #endif
 
 
-        b_data =  os_malloc((TCP_LEN_MAX+1) * sizeof(char));
+        b_data =  malloc((TCP_LEN_MAX+1) * sizeof(char));
         //bk_http_ptr->do_data = 1;
         //bk_http_ptr->http_total = readLen - len;
         do {
@@ -625,7 +625,7 @@ int httpclient_retrieve_content_old(httpclient_t *client, char *data, int len, u
                 client_data->response_buf[client_data->response_buf_len - 1] = '\0';
                 client_data->response_buf_filled = client_data->response_buf_len - 1;
                 client_data->retrieve_len -= (client_data->response_buf_len - 1 - count);
-                os_free(b_data);
+                free(b_data);
                 b_data = NULL;
                 return HTTP_RETRIEVE_MORE_DATA;
             }
@@ -647,7 +647,7 @@ int httpclient_retrieve_content_old(httpclient_t *client, char *data, int len, u
 
                 ret = httpclient_recv(client, b_data, 1, max_len, &len, iotx_time_left(&timer));
                 if (ret == ERROR_HTTP_CONN) {
-                    os_free(b_data);
+                    free(b_data);
                     b_data = NULL;
                     return ret;
                 }
@@ -655,7 +655,7 @@ int httpclient_retrieve_content_old(httpclient_t *client, char *data, int len, u
         } while (readLen);
 
         //bk_http_ptr->do_data = 0;
-        os_free(b_data);
+        free(b_data);
         b_data = NULL;
 
         if (client_data->is_chunked) {

--- a/src/httpclient/http_client.c
+++ b/src/httpclient/http_client.c
@@ -1134,7 +1134,7 @@ int HTTPClient_Async_SendGeneric(httprequest_t *request){
     err = rtos_create_thread( NULL, BEKEN_APPLICATION_PRIORITY,
 									"httprequest",
 									(beken_thread_function_t)httprequest_thread,
-									0x800,
+									0x1000,
 									(beken_thread_arg_t)request );
     if(err != kNoErr)
     {

--- a/src/httpclient/http_client.h
+++ b/src/httpclient/http_client.h
@@ -111,7 +111,7 @@ typedef struct httprequest_t_tag{
  * @return           .
  * @par              HTTPClient_Async_SendGeneric Post Example
  * @code
- *                   httprequest_t *request = os_malloc(sizeof(httprequest_t));
+ *                   httprequest_t *request = malloc(sizeof(httprequest_t));
  *                   // NOTE: these MUST persist
  *                   char *url = "https://api.mediatek.com/mcs/v2/devices/D0n2yhrl/datapoints.csv";
  *                   char *header = "deviceKey:FZoo0S07CpwUHcrt\r\n";

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -110,7 +110,7 @@ cJSON* hass_build_device_node(cJSON* ids) {
 /// @param payload_off The payload that represents disabled state. This is not added for ENTITY_SENSOR.
 /// @return 
 HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, char* payload_on, char* payload_off) {
-	HassDeviceInfo* info = os_malloc(sizeof(HassDeviceInfo));
+	HassDeviceInfo* info = malloc(sizeof(HassDeviceInfo));
 	addLogAdv(LOG_INFO, LOG_FEATURE_HASS, "hass_init_device_info=%p", info);
 
 	hass_populate_unique_id(type, index, info->unique_id);
@@ -285,5 +285,5 @@ void hass_free_device_info(HassDeviceInfo* info) {
 		cJSON_Delete(info->root);
 	}
 
-	os_free(info);
+	free(info);
 }

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1286,8 +1286,8 @@ int http_fn_ha_discovery(http_request_t* request) {
 	}
 
 	struct cJSON_Hooks hooks;
-	hooks.malloc_fn = os_malloc;
-	hooks.free_fn = os_free;
+	hooks.malloc_fn = malloc;
+	hooks.free_fn = free;
 	cJSON_InitHooks(&hooks);
 
 	if (relayCount > 0) {

--- a/src/httpserver/http_tcp_server.c
+++ b/src/httpserver/http_tcp_server.c
@@ -81,7 +81,7 @@ static void tcp_client_thread(beken_thread_arg_t arg)
 			store = malloc(sizeof(TCP_CLIENT_STORE));
 			if (!store){
 				ADDLOG_ERROR(LOG_FEATURE_HTTP, "TCP Client failed to malloc buffer");
-				return;
+				goto exit;
 			}
 			memset(store, 0, sizeof(TCP_CLIENT_STORE));
 			store->inuse = 1;
@@ -96,11 +96,14 @@ static void tcp_client_thread(beken_thread_arg_t arg)
 			store = tcpClientStores[i];
 			memset(store, 0, sizeof(TCP_CLIENT_STORE));
 			store->inuse = 1;
-			reply = store->replyBuffer;
-			buf = store->incomingBuffer;
 			ADDLOG_INFO(LOG_FEATURE_HTTP, "TCP Client use store %d/%d", i, tcpClientStoreCount);
 			break;
 		}
+	}
+
+	if(store){
+		reply = store->replyBuffer;
+		buf = store->incomingBuffer;
 	}
 
 	//reply = (char*)malloc(replyBufferSize);

--- a/src/httpserver/http_tcp_server.c
+++ b/src/httpserver/http_tcp_server.c
@@ -35,7 +35,7 @@ void HTTPServer_Start()
 	err = rtos_create_thread(&g_http_thread, BEKEN_APPLICATION_PRIORITY,
 		"TCP_server",
 		(beken_thread_function_t)tcp_server_thread,
-		0x800,
+		0x1000,
 		(beken_thread_arg_t)0);
 	if (err != kNoErr)
 	{
@@ -227,7 +227,7 @@ static void tcp_server_thread(beken_thread_arg_t arg)
 					rtos_create_thread(NULL, BEKEN_APPLICATION_PRIORITY,
 						"HTTP Client",
 						(beken_thread_function_t)tcp_client_thread,
-						0x800,
+						0x1600,
 						(beken_thread_arg_t)client_fd)
 
 #endif
@@ -359,7 +359,7 @@ void HTTPServer_Start()
 	err = rtos_create_thread(&g_http_thread, BEKEN_APPLICATION_PRIORITY,
 		"TCP_server",
 		(beken_thread_function_t)tcp_server_thread,
-		0x800,
+		0x1000,
 		(beken_thread_arg_t)0);
 	if (err != kNoErr)
 	{

--- a/src/httpserver/http_tcp_server.c
+++ b/src/httpserver/http_tcp_server.c
@@ -273,8 +273,8 @@ static void tcp_server_thread(beken_thread_arg_t arg)
 
 	err = listen(tcp_listen_fd, 0);
 
-	reply = (char*)os_malloc(REPLY_BUFFER_SIZE);
-	buf = (char*)os_malloc(INCOMING_BUFFER_SIZE);
+	reply = (char*)malloc(REPLY_BUFFER_SIZE);
+	buf = (char*)malloc(INCOMING_BUFFER_SIZE);
 
 	while (1)
 	{

--- a/src/httpserver/http_tcp_server.c
+++ b/src/httpserver/http_tcp_server.c
@@ -87,7 +87,7 @@ static void tcp_client_thread(beken_thread_arg_t arg)
 			store->inuse = 1;
 			tcpClientStores[i] = store;
 			tcpClientStoreCount = i+1;
-			ADDLOG_INFO(LOG_FEATURE_HTTP, "TCP Client allocate store %d/%d", i, tcpClientStoreCount);
+			ADDLOG_INFO(LOG_FEATURE_HTTP, "TCP Client allocate store %d/%d", i+1, tcpClientStoreCount);
 			break;
 		}
 
@@ -96,7 +96,7 @@ static void tcp_client_thread(beken_thread_arg_t arg)
 			store = tcpClientStores[i];
 			memset(store, 0, sizeof(TCP_CLIENT_STORE));
 			store->inuse = 1;
-			ADDLOG_INFO(LOG_FEATURE_HTTP, "TCP Client use store %d/%d", i, tcpClientStoreCount);
+//			ADDLOG_INFO(LOG_FEATURE_HTTP, "TCP Client use store %d/%d", i, tcpClientStoreCount);
 			break;
 		}
 	}

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -104,13 +104,13 @@ int HTTP_RegisterCallback(const char* url, int method, http_callback_fn callback
 	if (numCallbacks >= MAX_HTTP_CALLBACKS) {
 		return -4;
 	}
-	callbacks[numCallbacks] = (http_callback_t*)os_malloc(sizeof(http_callback_t));
+	callbacks[numCallbacks] = (http_callback_t*)malloc(sizeof(http_callback_t));
 	if (!callbacks[numCallbacks]) {
 		return -2;
 	}
-	callbacks[numCallbacks]->url = (char*)os_malloc(strlen(url) + 1);
+	callbacks[numCallbacks]->url = (char*)malloc(strlen(url) + 1);
 	if (!callbacks[numCallbacks]->url) {
-		os_free(callbacks[numCallbacks]);
+		free(callbacks[numCallbacks]);
 		return -3;
 	}
 	strcpy(callbacks[numCallbacks]->url, url);

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -326,10 +326,10 @@ static int http_rest_get_lfs_file(http_request_t* request) {
 		return 0;
 	}
 
-	fpath = os_malloc(strlen(request->url) - strlen("api/lfs/") + 1);
+	fpath = malloc(strlen(request->url) - strlen("api/lfs/") + 1);
 
-	buff = os_malloc(1024);
-	file = os_malloc(sizeof(lfs_file_t));
+	buff = malloc(1024);
+	file = malloc(sizeof(lfs_file_t));
 	memset(file, 0, sizeof(lfs_file_t));
 
 	strcpy(fpath, request->url + strlen("api/lfs/"));
@@ -340,7 +340,7 @@ static int http_rest_get_lfs_file(http_request_t* request) {
 	if (lfsres == -21) {
 		lfs_dir_t* dir;
 		ADDLOG_DEBUG(LOG_FEATURE_API, "%s is a folder", fpath);
-		dir = os_malloc(sizeof(lfs_dir_t));
+		dir = malloc(sizeof(lfs_dir_t));
 		os_memset(dir, 0, sizeof(*dir));
 		// if the thing is a folder.
 		lfsres = lfs_dir_open(&lfs, dir, fpath);
@@ -376,11 +376,11 @@ static int http_rest_get_lfs_file(http_request_t* request) {
 			hprintf128(request, "]}");
 
 			lfs_dir_close(&lfs, dir);
-			if (dir) os_free(dir);
+			if (dir) free(dir);
 			dir = NULL;
 		}
 		else {
-			if (dir) os_free(dir);
+			if (dir) free(dir);
 			dir = NULL;
 			request->responseCode = HTTP_RESPONSE_NOT_FOUND;
 			http_setup(request, httpMimeTypeJson);
@@ -436,9 +436,9 @@ static int http_rest_get_lfs_file(http_request_t* request) {
 		}
 	}
 	poststr(request, NULL);
-	if (fpath) os_free(fpath);
-	if (file) os_free(file);
-	if (buff) os_free(buff);
+	if (fpath) free(fpath);
+	if (file) free(file);
+	if (buff) free(buff);
 	return 0;
 }
 
@@ -455,8 +455,8 @@ static int http_rest_post_lfs_file(http_request_t* request) {
 	// create if it does not exist
 	init_lfs(1);
 
-	fpath = os_malloc(strlen(request->url) - strlen("api/lfs/") + 1);
-	file = os_malloc(sizeof(lfs_file_t));
+	fpath = malloc(strlen(request->url) - strlen("api/lfs/") + 1);
+	file = malloc(sizeof(lfs_file_t));
 	memset(file, 0, sizeof(lfs_file_t));
 
 	strcpy(fpath, request->url + strlen("api/lfs/"));
@@ -465,7 +465,7 @@ static int http_rest_post_lfs_file(http_request_t* request) {
 	folder = strchr(fpath, '/');
 	if (folder) {
 		int folderlen = folder - fpath;
-		folder = os_malloc(folderlen + 1);
+		folder = malloc(folderlen + 1);
 		strncpy(folder, fpath, folderlen);
 		folder[folderlen] = 0;
 		ADDLOG_DEBUG(LOG_FEATURE_API, "file is in folder %s try to create", folder);
@@ -531,9 +531,9 @@ static int http_rest_post_lfs_file(http_request_t* request) {
 	}
 exit:
 	poststr(request, NULL);
-	if (folder) os_free(folder);
-	if (file) os_free(file);
-	if (fpath) os_free(fpath);
+	if (folder) free(folder);
+	if (file) free(file);
+	if (fpath) free(fpath);
 	return 0;
 }
 
@@ -645,10 +645,10 @@ static int http_rest_post_logconfig(http_request_t* request) {
 
 	//https://github.com/zserge/jsmn/blob/master/example/simple.c
 	//jsmn_parser p;
-	jsmn_parser* p = os_malloc(sizeof(jsmn_parser));
+	jsmn_parser* p = malloc(sizeof(jsmn_parser));
 	//jsmntok_t t[128]; /* We expect no more than 128 tokens */
 #define TOKEN_COUNT 128
-	jsmntok_t* t = os_malloc(sizeof(jsmntok_t) * TOKEN_COUNT);
+	jsmntok_t* t = malloc(sizeof(jsmntok_t) * TOKEN_COUNT);
 	char* json_str = request->bodystart;
 	int json_len = strlen(json_str);
 
@@ -661,8 +661,8 @@ static int http_rest_post_logconfig(http_request_t* request) {
 	if (r < 0) {
 		ADDLOG_ERROR(LOG_FEATURE_API, "Failed to parse JSON: %d", r);
 		poststr(request, NULL);
-		os_free(p);
-		os_free(t);
+		free(p);
+		free(t);
 		return 0;
 	}
 
@@ -670,8 +670,8 @@ static int http_rest_post_logconfig(http_request_t* request) {
 	if (r < 1 || t[0].type != JSMN_OBJECT) {
 		ADDLOG_ERROR(LOG_FEATURE_API, "Object expected", r);
 		poststr(request, NULL);
-		os_free(p);
-		os_free(t);
+		free(p);
+		free(t);
 		return 0;
 	}
 
@@ -705,8 +705,8 @@ static int http_rest_post_logconfig(http_request_t* request) {
 	}
 
 	poststr(request, NULL);
-	os_free(p);
-	os_free(t);
+	free(p);
+	free(t);
 	return 0;
 }
 
@@ -740,10 +740,10 @@ static int http_rest_post_pins(http_request_t* request) {
 
 	//https://github.com/zserge/jsmn/blob/master/example/simple.c
 	//jsmn_parser p;
-	jsmn_parser* p = os_malloc(sizeof(jsmn_parser));
+	jsmn_parser* p = malloc(sizeof(jsmn_parser));
 	//jsmntok_t t[128]; /* We expect no more than 128 tokens */
 #define TOKEN_COUNT 128
-	jsmntok_t* t = os_malloc(sizeof(jsmntok_t) * TOKEN_COUNT);
+	jsmntok_t* t = malloc(sizeof(jsmntok_t) * TOKEN_COUNT);
 	char* json_str = request->bodystart;
 	int json_len = strlen(json_str);
 
@@ -755,8 +755,8 @@ static int http_rest_post_pins(http_request_t* request) {
 	if (r < 0) {
 		ADDLOG_ERROR(LOG_FEATURE_API, "Failed to parse JSON: %d", r);
 		sprintf(tmp, "Failed to parse JSON: %d\n", r);
-		os_free(p);
-		os_free(t);
+		free(p);
+		free(t);
 		return http_rest_error(request, 400, tmp);
 	}
 
@@ -764,8 +764,8 @@ static int http_rest_post_pins(http_request_t* request) {
 	if (r < 1 || t[0].type != JSMN_OBJECT) {
 		ADDLOG_ERROR(LOG_FEATURE_API, "Object expected", r);
 		sprintf(tmp, "Object expected\n");
-		os_free(p);
-		os_free(t);
+		free(p);
+		free(t);
 		return http_rest_error(request, 400, tmp);
 	}
 
@@ -846,8 +846,8 @@ static int http_rest_post_pins(http_request_t* request) {
 		ADDLOG_DEBUG(LOG_FEATURE_API, "Changed %d - saved to flash", iChanged);
 	}
 
-	os_free(p);
-	os_free(t);
+	free(p);
+	free(t);
 	return http_rest_error(request, 200, "OK");
 	return 0;
 }
@@ -958,7 +958,7 @@ static int http_rest_get_flash(http_request_t* request, int startaddr, int len) 
 		return http_rest_error(request, -1, "requested flash read out of range");
 	}
 
-	buffer = os_malloc(1024);
+	buffer = malloc(1024);
 
 	http_setup(request, httpMimeTypeBinary);
 	while (len) {
@@ -1099,10 +1099,10 @@ static int http_rest_post_channels(http_request_t* request) {
 
 	//https://github.com/zserge/jsmn/blob/master/example/simple.c
 	//jsmn_parser p;
-	jsmn_parser* p = os_malloc(sizeof(jsmn_parser));
+	jsmn_parser* p = malloc(sizeof(jsmn_parser));
 	//jsmntok_t t[128]; /* We expect no more than 128 tokens */
 #define TOKEN_COUNT 128
-	jsmntok_t* t = os_malloc(sizeof(jsmntok_t) * TOKEN_COUNT);
+	jsmntok_t* t = malloc(sizeof(jsmntok_t) * TOKEN_COUNT);
 	char* json_str = request->bodystart;
 	int json_len = strlen(json_str);
 
@@ -1114,8 +1114,8 @@ static int http_rest_post_channels(http_request_t* request) {
 	if (r < 0) {
 		ADDLOG_ERROR(LOG_FEATURE_API, "Failed to parse JSON: %d", r);
 		sprintf(tmp, "Failed to parse JSON: %d\n", r);
-		os_free(p);
-		os_free(t);
+		free(p);
+		free(t);
 		return http_rest_error(request, 400, tmp);
 	}
 
@@ -1123,8 +1123,8 @@ static int http_rest_post_channels(http_request_t* request) {
 	if (r < 1 || t[0].type != JSMN_ARRAY) {
 		ADDLOG_ERROR(LOG_FEATURE_API, "Array expected", r);
 		sprintf(tmp, "Object expected\n");
-		os_free(p);
-		os_free(t);
+		free(p);
+		free(t);
 		return http_rest_error(request, 400, tmp);
 	}
 
@@ -1138,8 +1138,8 @@ static int http_rest_post_channels(http_request_t* request) {
 			chanval);
 	}
 
-	os_free(p);
-	os_free(t);
+	free(p);
+	free(t);
 	return http_rest_error(request, 200, "OK");
 	return 0;
 }

--- a/src/littlefs/lfs_util.h
+++ b/src/littlefs/lfs_util.h
@@ -221,7 +221,7 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 // Note, memory must be 64-bit aligned
 static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
-    return os_malloc(size);
+    return malloc(size);
 #else
     (void)size;
     return NULL;
@@ -231,7 +231,7 @@ static inline void *lfs_malloc(size_t size) {
 // Deallocate memory, only used if buffers are not provided to littlefs
 static inline void lfs_free(void *p) {
 #ifndef LFS_NO_MALLOC
-    os_free(p);
+    free(p);
 #else
     (void)p;
 #endif

--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -103,7 +103,7 @@ void addLogAdv(int level, int feature, const char *fmt, ...)
         return;
     }
 
-    tmp = (char*)os_malloc(tmp_len);
+    tmp = (char*)malloc(tmp_len);
     if (tmp != NULL)
     {
         memset(tmp, 0, tmp_len);
@@ -128,7 +128,7 @@ void addLogAdv(int level, int feature, const char *fmt, ...)
 
         printf(tmp);
         printf("\r\n");
-        os_free(tmp);
+        free(tmp);
     }
 }
 #else // from WINDOWS
@@ -164,7 +164,7 @@ void addLogAdv(int level, int feature, const char *fmt, ...)
     taken = xSemaphoreTake( g_mutex, 100 );
     if (taken == pdTRUE) 
     {
-        tmp = (char*)os_malloc(tmp_len);
+        tmp = (char*)malloc(tmp_len);
         if (tmp != NULL)
         {
             memset(tmp, 0, tmp_len);

--- a/src/memory/memtest.c
+++ b/src/memory/memtest.c
@@ -32,22 +32,179 @@ int getMallocSize(void *ptr) {
 void logStack(const char *name){
 	GETSTACK // macro which get a C variable SP and stacksize from memtest.h.
 	int stacktotalsize = getMallocSize((void *)pxCurrentTCB->pxStack);
-    uint8_t *stackstart = pxCurrentTCB->pxStack;
+    uint8_t *stackstart = (uint8_t *)pxCurrentTCB->pxStack;
     uint8_t *stackend = stackstart + stacktotalsize;
     int used = ((uint32_t)stackend) - SP;
 
 	ADDLOG_INFO(LOG_FEATURE_CMD, "%s:Stack: base:0x%08X use: %d/%d bytes", name, (uint32_t)pxCurrentTCB->pxStack, used, stacktotalsize);
 }
 
-void getStack(uint32_t* pTotal, uint32_t* pUsed){
+int getStack(uint32_t* pTotal, uint32_t* pUsed){
 	GETSTACK // macro which get a C variable SP and stacksize from memtest.h.
 	int stacktotalsize = getMallocSize((void *)pxCurrentTCB->pxStack);
-    uint8_t *stackstart = pxCurrentTCB->pxStack;
+    uint8_t *stackstart = (uint8_t *)pxCurrentTCB->pxStack;
     uint8_t *stackend = stackstart + stacktotalsize;
     int used = ((uint32_t)stackend) - SP;
     if (pUsed) *pUsed = used;
     if (pTotal) *pTotal = stacktotalsize;
     return 0;
+}
+
+uint8_t *ucHeap;
+extern unsigned char _empty_ram;
+
+#define HEAP_START_ADDRESS    (void*)&_empty_ram
+#define HEAP_END_ADDRESS      (void*)(0x00400000 + 256 * 1024)
+
+void mallocTest(){
+    if (!ucHeap) return;
+    size_t uxAddress = (size_t)ucHeap;
+	if( ( uxAddress & portBYTE_ALIGNMENT_MASK ) != 0 )
+	{
+		uxAddress += ( portBYTE_ALIGNMENT - 1 );
+		uxAddress &= ~( ( size_t ) portBYTE_ALIGNMENT_MASK );
+	}
+
+	uint8_t *pucAlignedHeap = ( uint8_t * ) uxAddress;
+	BlockLink_t *pxBlock = (BlockLink_t *)pucAlignedHeap;
+    uint8_t *pucHeapEnd = HEAP_END_ADDRESS;
+	BlockLink_t *pxFirstFree = NULL;
+	BlockLink_t *pxLastFree = NULL;
+
+    // walk all blocks noting if allocated or not
+    int maxblocks = 5000;
+    int countAllocated = 0;
+    int countFree = 0;
+    int totalmalloc = 0;
+    int mallocfree = 0;
+    int mallocused = 0;
+    int largestfree = 0;
+    int smallestfree = 0x80000000;
+
+	vTaskSuspendAll();
+
+    while (pxBlock && maxblocks){
+        maxblocks--;
+        int size = pxBlock->xBlockSize & ~xBlockAllocatedBit;
+
+        if (size == 0){
+            break;
+        }
+
+        if (pxBlock->xBlockSize & xBlockAllocatedBit){
+            countAllocated++;
+            mallocused += size;
+        } else {
+            if (!pxFirstFree){
+                pxFirstFree = pxBlock;
+            }
+            countFree++;
+            mallocfree += size;
+            if (largestfree < size - sizeof(BlockLink_t)){
+                largestfree = size - sizeof(BlockLink_t);
+            }
+            if (smallestfree > size - sizeof(BlockLink_t)){
+                smallestfree = size - sizeof(BlockLink_t);
+            }
+        }
+        totalmalloc += size;
+
+        if (pxBlock->pxNextFreeBlock){
+            if ((uint32_t)pxBlock->pxNextFreeBlock < (uint32_t)pucAlignedHeap){
+                ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: badblock next ptr 0x%08X",
+                    (uint32_t)pxBlock->pxNextFreeBlock);
+                break;
+            }
+            if ((uint32_t)pxBlock->pxNextFreeBlock >= (uint32_t)pucHeapEnd){
+                ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: badblock next ptr 0x%08X",
+                    (uint32_t)pxBlock->pxNextFreeBlock);
+                break;
+            }
+        }
+
+        pxBlock = (BlockLink_t *)((( uint8_t * )pxBlock) + size);
+
+        if ((uint32_t)pxBlock >= (uint32_t)pucHeapEnd){
+            ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: next off end 0x%08X",
+                (uint32_t)pxBlock);
+            break;
+        }
+
+    }
+
+
+    int countFree2 = 0;
+    int countAlloc2 = 0;
+    int mallocfree2 = 0;
+    int maxblocks2 = 5000;
+
+    while(pxFirstFree && maxblocks){
+        maxblocks2--;
+        int size = pxFirstFree->xBlockSize & ~xBlockAllocatedBit;
+        if (size == 0){
+            break;
+        }
+
+        if (pxFirstFree->xBlockSize & xBlockAllocatedBit){
+            countAlloc2++;
+        } else {
+            countFree2++;
+        }
+        mallocfree2 += size;
+        pxLastFree = pxFirstFree;
+        pxFirstFree = pxFirstFree->pxNextFreeBlock;
+    }
+
+    ( void ) xTaskResumeAll();
+
+
+    if (!maxblocks){
+        ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: #### got to maxblocks 5000!");
+    }
+
+    if (!maxblocks2){
+        ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: #### FreeList got to maxblocks 5000!");
+    }
+
+    if((mallocfree != mallocfree2) || (countFree != countFree2)){
+        ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: #### Freelist mismatch! count:%d != %d",
+            countFree, countFree2
+        );
+    }
+    if(countAlloc2){
+        ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: #### Freelist contains allocated blocks! count:%d",
+            countAlloc2
+        );
+    }
+
+    // last block in free list should always be pxEnd with zero size
+    if(pxFirstFree != pxBlock){
+        ADDLOG_INFO(LOG_FEATURE_CMD, "MallocDiag: #### Freelist lastbloack mismatch! %0x08X != %0x08X",
+            pxFirstFree, pxBlock
+        );
+    }
+
+	ADDLOG_INFO(LOG_FEATURE_CMD, 
+        "MallocDiag: First:0x%08X Last:0x%08X Scansize:0x%08X Expected: 0x%08X(%d)",
+        (uint32_t)pucAlignedHeap, (uint32_t)pxBlock,
+        ((uint32_t)pxBlock + sizeof(BlockLink_t)) - (uint32_t)pucAlignedHeap,
+        ((uint32_t)HEAP_END_ADDRESS - (uint32_t)HEAP_START_ADDRESS),
+        ((uint32_t)HEAP_END_ADDRESS - (uint32_t)HEAP_START_ADDRESS)
+        );
+
+    if ( (((uint32_t)pxBlock + sizeof(BlockLink_t)) - (uint32_t)pucAlignedHeap) != 
+         ((uint32_t)HEAP_END_ADDRESS - (uint32_t)HEAP_START_ADDRESS) ){
+        ADDLOG_ERROR(LOG_FEATURE_CMD, "MallocDiag: Scan incomplete?");
+    }
+
+	ADDLOG_INFO(LOG_FEATURE_CMD, 
+        "MallocDiag: AllocCount:%d FreeCount:%d total:0x%08X used: 0x%08X largestfree: 0x%08x smallestfree: 0x%08X",
+        countAllocated, countFree,
+        totalmalloc, mallocused,
+        largestfree, smallestfree
+        );
+
+
 }
 
 
@@ -57,12 +214,13 @@ int getMallocSize(void *ptr){
     return -1;
 }
 void logStack(const char *name){
-
 }
-void getStack(uint32_t* pTotal, uint32_t* pUsed){
+int getStack(uint32_t* pTotal, uint32_t* pUsed){
     if (pUsed) *pUsed = 0;
     if (pTotal) *pTotal = 0;
     return -1;
+}
+void mallocTest(){
 }
 
 #endif

--- a/src/memory/memtest.c
+++ b/src/memory/memtest.c
@@ -1,0 +1,68 @@
+#include "include.h"
+#include "arm_arch.h"
+#include "sys_rtos.h"
+
+#include "../memory/memtest.h"
+#include "../logging/logging.h"
+
+
+#ifdef PLATFORM_BK7231T
+
+static const size_t xHeapStructSize	= ( sizeof( BlockLink_t ) + ( ( size_t ) ( portBYTE_ALIGNMENT - 1 ) ) ) & ~( ( size_t ) portBYTE_ALIGNMENT_MASK );
+static size_t xBlockAllocatedBit = (1<<31);
+
+int getMallocSize(void *ptr) {
+	uint8_t *puc;
+	BlockLink_t *pxLink;
+	int presize, datasize;
+
+    if (!ptr){
+        return -2;
+    }
+
+    puc = ( uint8_t * ) ptr;
+
+    puc -= xHeapStructSize;
+	pxLink = ( void * ) puc;
+	presize = (pxLink->xBlockSize & ~xBlockAllocatedBit);
+	datasize = presize - xHeapStructSize;
+    return datasize;
+}
+
+void logStack(const char *name){
+	GETSTACK // macro which get a C variable SP and stacksize from memtest.h.
+	int stacktotalsize = getMallocSize((void *)pxCurrentTCB->pxStack);
+    uint8_t *stackstart = pxCurrentTCB->pxStack;
+    uint8_t *stackend = stackstart + stacktotalsize;
+    int used = ((uint32_t)stackend) - SP;
+
+	ADDLOG_INFO(LOG_FEATURE_CMD, "%s:Stack: base:0x%08X use: %d/%d bytes", name, (uint32_t)pxCurrentTCB->pxStack, used, stacktotalsize);
+}
+
+void getStack(uint32_t* pTotal, uint32_t* pUsed){
+	GETSTACK // macro which get a C variable SP and stacksize from memtest.h.
+	int stacktotalsize = getMallocSize((void *)pxCurrentTCB->pxStack);
+    uint8_t *stackstart = pxCurrentTCB->pxStack;
+    uint8_t *stackend = stackstart + stacktotalsize;
+    int used = ((uint32_t)stackend) - SP;
+    if (pUsed) *pUsed = used;
+    if (pTotal) *pTotal = stacktotalsize;
+    return 0;
+}
+
+
+#else 
+int getMallocSize(void *ptr){
+    // unsupported
+    return -1;
+}
+void logStack(const char *name){
+
+}
+void getStack(uint32_t* pTotal, uint32_t* pUsed){
+    if (pUsed) *pUsed = 0;
+    if (pTotal) *pTotal = 0;
+    return -1;
+}
+
+#endif

--- a/src/memory/memtest.h
+++ b/src/memory/memtest.h
@@ -1,0 +1,128 @@
+/////////////////////////////////////////////////////////////////////
+// Duplicate some structures from freeRTOS so we can acces sthem
+// These are purely for testing!!!!
+
+// read the number of bytes allocated to this ptr if malloced
+extern int getMallocSize(void *ptr);
+// log the stack use and total size for the current task.
+void logStack(const char *name);
+// get total stack size and used in BYTES
+void getStack(uint32_t* pTotal, uint32_t* pUsed);
+
+#ifdef PLATFORM_BK7231T
+
+
+/*
+ * Task control block.  A task control block (TCB) is allocated for each task,
+ * and stores task state information, including a pointer to the task's context
+ * (the task's run time environment, including register values)
+ */
+typedef struct tskTaskControlBlock
+{
+	volatile StackType_t	*pxTopOfStack;	/*< Points to the location of the last item placed on the tasks stack.  THIS MUST BE THE FIRST MEMBER OF THE TCB STRUCT. */
+
+	#if ( portUSING_MPU_WRAPPERS == 1 )
+		xMPU_SETTINGS	xMPUSettings;		/*< The MPU settings are defined as part of the port layer.  THIS MUST BE THE SECOND MEMBER OF THE TCB STRUCT. */
+	#endif
+
+	ListItem_t			xStateListItem;	/*< The list that the state list item of a task is reference from denotes the state of that task (Ready, Blocked, Suspended ). */
+	ListItem_t			xEventListItem;		/*< Used to reference a task from an event list. */
+	UBaseType_t			uxPriority;			/*< The priority of the task.  0 is the lowest priority. */
+	StackType_t			*pxStack;			/*< Points to the start of the stack. */
+	char				pcTaskName[ configMAX_TASK_NAME_LEN ];/*< Descriptive name given to the task when created.  Facilitates debugging only. */ /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+	#if ( portSTACK_GROWTH > 0 )
+		StackType_t		*pxEndOfStack;		/*< Points to the end of the stack on architectures where the stack grows up from low memory. */
+	#endif
+
+	#if ( portCRITICAL_NESTING_IN_TCB == 1 )
+		UBaseType_t		uxCriticalNesting;	/*< Holds the critical section nesting depth for ports that do not maintain their own count in the port layer. */
+	#endif
+
+	#if ( configUSE_TRACE_FACILITY == 1 )
+		UBaseType_t		uxTCBNumber;		/*< Stores a number that increments each time a TCB is created.  It allows debuggers to determine when a task has been deleted and then recreated. */
+		UBaseType_t		uxTaskNumber;		/*< Stores a number specifically for use by third party trace code. */
+	#endif
+
+	#if ( configUSE_MUTEXES == 1 )
+		UBaseType_t		uxBasePriority;		/*< The priority last assigned to the task - used by the priority inheritance mechanism. */
+		UBaseType_t		uxMutexesHeld;
+	#endif
+
+	#if ( configUSE_APPLICATION_TASK_TAG == 1 )
+		TaskHookFunction_t pxTaskTag;
+	#endif
+
+	#if( configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0 )
+		void *pvThreadLocalStoragePointers[ configNUM_THREAD_LOCAL_STORAGE_POINTERS ];
+	#endif
+
+	#if( configGENERATE_RUN_TIME_STATS == 1 )
+		uint32_t		ulRunTimeCounter;	/*< Stores the amount of time the task has spent in the Running state. */
+	#endif
+
+	#if ( configUSE_NEWLIB_REENTRANT == 1 )
+		/* Allocate a Newlib reent structure that is specific to this task.
+		Note Newlib support has been included by popular demand, but is not
+		used by the FreeRTOS maintainers themselves.  FreeRTOS is not
+		responsible for resulting newlib operation.  User must be familiar with
+		newlib and must provide system-wide implementations of the necessary
+		stubs. Be warned that (at the time of writing) the current newlib design
+		implements a system-wide malloc() that must be provided with locks. */
+		struct	_reent xNewLib_reent;
+	#endif
+
+	#if( configUSE_TASK_NOTIFICATIONS == 1 )
+		volatile uint32_t ulNotifiedValue;
+		volatile uint8_t ucNotifyState;
+	#endif
+
+	/* See the comments above the definition of
+	tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE. */
+	#if( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0 )
+		uint8_t	ucStaticallyAllocated; 		/*< Set to pdTRUE if the task is a statically allocated to ensure no attempt is made to free the memory. */
+	#endif
+
+	#if( INCLUDE_xTaskAbortDelay == 1 )
+		uint8_t ucDelayAborted;
+	#endif
+
+} tskTCB;
+
+/* The old tskTCB name is maintained above then typedefed to the new TCB_t name
+below to enable the use of older kernel aware debuggers. */
+typedef tskTCB TCB_t;
+
+/*lint -e956 A manual analysis and inspection has been used to determine which
+static variables must be declared volatile. */
+
+extern PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB;
+
+
+// from heap_4.c
+typedef struct A_BLOCK_LINK
+{
+	struct A_BLOCK_LINK *pxNextFreeBlock;	/*<< The next free block in the list. */
+	size_t xBlockSize;						/*<< The size of the free block. */
+} BlockLink_t;
+
+// read the SP and the current stacksize
+#define GETSTACK \
+	register uint32_t SP = 0; \
+	__asm volatile ("mov %0, sp\n\t" : "=r" ( SP )	); \
+	uint32_t stacksize = SP - (uint32_t)pxCurrentTCB->pxStack;
+
+// read the caller address for a fucntion
+#define GETCALLERADDR \
+    register uint32_t calleraddr; \
+    __asm volatile ("MOV %0, LR\n" : "=r" (calleraddr) ); 
+
+
+#else 
+// non-beken
+#define GETSTACK \
+	uint32_t SP = 0; \
+	uint32_t stacksize = 0;
+#endif
+
+

--- a/src/memory/memtest.h
+++ b/src/memory/memtest.h
@@ -7,7 +7,9 @@ extern int getMallocSize(void *ptr);
 // log the stack use and total size for the current task.
 void logStack(const char *name);
 // get total stack size and used in BYTES
-void getStack(uint32_t* pTotal, uint32_t* pUsed);
+int getStack(uint32_t* pTotal, uint32_t* pUsed);
+void mallocTest();
+
 
 #ifdef PLATFORM_BK7231T
 
@@ -106,23 +108,26 @@ typedef struct A_BLOCK_LINK
 	size_t xBlockSize;						/*<< The size of the free block. */
 } BlockLink_t;
 
-// read the SP and the current stacksize
+// read the SP
 #define GETSTACK \
 	register uint32_t SP = 0; \
-	__asm volatile ("mov %0, sp\n\t" : "=r" ( SP )	); \
-	uint32_t stacksize = SP - (uint32_t)pxCurrentTCB->pxStack;
+	__asm volatile ("mov %0, sp\n\t" : "=r" ( SP )	);
 
 // read the caller address for a fucntion
 #define GETCALLERADDR \
-    register uint32_t calleraddr; \
+    register uint32_t calleraddr = 0; \
     __asm volatile ("MOV %0, LR\n" : "=r" (calleraddr) ); 
 
 
 #else 
+
 // non-beken
 #define GETSTACK \
-	uint32_t SP = 0; \
-	uint32_t stacksize = 0;
+	uint32_t SP = 0;
+
+#define GETCALLERADDR \
+    register uint32_t calleraddr = 0;
+
 #endif
 
 

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -295,7 +295,7 @@ int MQTT_RegisterCallback(const char* basetopic, const char* subscriptiontopic, 
 		return -4;
 	}
 	if (!callbacks[index]) {
-		callbacks[index] = (mqtt_callback_t*)os_malloc(sizeof(mqtt_callback_t));
+		callbacks[index] = (mqtt_callback_t*)malloc(sizeof(mqtt_callback_t));
 		if (callbacks[index] != 0) {
 			memset(callbacks[index], 0, sizeof(mqtt_callback_t));
 		}
@@ -305,11 +305,11 @@ int MQTT_RegisterCallback(const char* basetopic, const char* subscriptiontopic, 
 	}
 	if (!callbacks[index]->topic || strcmp(callbacks[index]->topic, basetopic)) {
 		if (callbacks[index]->topic) {
-			os_free(callbacks[index]->topic);
+			free(callbacks[index]->topic);
 		}
-		callbacks[index]->topic = (char*)os_malloc(strlen(basetopic) + 1);
+		callbacks[index]->topic = (char*)malloc(strlen(basetopic) + 1);
 		if (!callbacks[index]->topic) {
-			os_free(callbacks[index]);
+			free(callbacks[index]);
 			return -3;
 		}
 		strcpy(callbacks[index]->topic, basetopic);
@@ -317,13 +317,13 @@ int MQTT_RegisterCallback(const char* basetopic, const char* subscriptiontopic, 
 
 	if (!callbacks[index]->subscriptionTopic || strcmp(callbacks[index]->subscriptionTopic, subscriptiontopic)) {
 		if (callbacks[index]->subscriptionTopic) {
-			os_free(callbacks[index]->subscriptionTopic);
+			free(callbacks[index]->subscriptionTopic);
 		}
-		callbacks[index]->subscriptionTopic = (char*)os_malloc(strlen(subscriptiontopic) + 1);
+		callbacks[index]->subscriptionTopic = (char*)malloc(strlen(subscriptiontopic) + 1);
 		callbacks[index]->subscriptionTopic[0] = '\0';
 		if (!callbacks[index]->subscriptionTopic) {
-			os_free(callbacks[index]->topic);
-			os_free(callbacks[index]);
+			free(callbacks[index]->topic);
+			free(callbacks[index]);
 			return -3;
 		}
 
@@ -362,14 +362,14 @@ int MQTT_RemoveCallback(int ID) {
 		if (callbacks[index]) {
 			if (callbacks[index]->ID == ID) {
 				if (callbacks[index]->topic) {
-					os_free(callbacks[index]->topic);
+					free(callbacks[index]->topic);
 					callbacks[index]->topic = NULL;
 				}
 				if (callbacks[index]->subscriptionTopic) {
-					os_free(callbacks[index]->subscriptionTopic);
+					free(callbacks[index]->subscriptionTopic);
 					callbacks[index]->subscriptionTopic = NULL;
 				}
-				os_free(callbacks[index]);
+				free(callbacks[index]);
 				callbacks[index] = NULL;
 				mqtt_reconnect = 8;
 				return 1;
@@ -543,14 +543,14 @@ static OBK_Publish_Result MQTT_PublishTopicToClient(mqtt_client_t* client, const
 
 	g_timeSinceLastMQTTPublish = 0;
 
-	char* pub_topic = (char*)os_malloc(strlen(sTopic) + 1 + strlen(sChannel) + 5 + 1); //5 for /get
+	char* pub_topic = (char*)malloc(strlen(sTopic) + 1 + strlen(sChannel) + 5 + 1); //5 for /get
 	if (pub_topic != NULL)
 	{
 		sprintf(pub_topic, "%s/%s%s", sTopic, sChannel, (appendGet == true ? "/get" : ""));
 		addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "Publishing val %s to %s retain=%i\n", sVal, pub_topic, retain);
 
 		err = mqtt_publish(client, pub_topic, sVal, strlen(sVal), qos, retain, mqtt_pub_request_cb, 0);
-		os_free(pub_topic);
+		free(pub_topic);
 
 		if (err != ERR_OK)
 		{
@@ -1207,14 +1207,14 @@ void MQTT_QueuePublishWithCommand(char* topic, char* channel, char* value, int f
 	MqttPublishItem_t* newItem;
 
 	if (g_MqttPublishQueueHead == NULL) {
-		g_MqttPublishQueueHead = newItem = os_malloc(sizeof(MqttPublishItem_t));
+		g_MqttPublishQueueHead = newItem = malloc(sizeof(MqttPublishItem_t));
 		newItem->next = NULL;
 	}
 	else {
 		newItem = find_queue_reusable_item(g_MqttPublishQueueHead);
 
 		if (newItem == NULL) {
-			newItem = os_malloc(sizeof(MqttPublishItem_t));
+			newItem = malloc(sizeof(MqttPublishItem_t));
 			newItem->next = NULL;
 			get_queue_tail(g_MqttPublishQueueHead)->next = newItem; //Append new item
 		}

--- a/src/ota/ota.c
+++ b/src/ota/ota.c
@@ -32,7 +32,7 @@ int init_ota(unsigned int startaddr){
             addLogAdv(LOG_INFO, LOG_FEATURE_OTA,"aborting OTS, sector already non-null\n");
             return 0;
         }
-        sector = os_malloc(SECTOR_SIZE);
+        sector = malloc(SECTOR_SIZE);
         sectorlen = 0;
         addr = startaddr;
         addLogAdv(LOG_INFO, LOG_FEATURE_OTA,"init OTA, startaddr 0x%x\n", startaddr);
@@ -54,7 +54,7 @@ void close_ota(){
     }
     addLogAdv(LOG_INFO, LOG_FEATURE_OTA,"close OTA, addr 0x%x\n", addr);
 
-    os_free(sector);
+    free(sector);
     sector = (void *)0;
 	  flash_protection_op(FLASH_XTX_16M_SR_WRITE_ENABLE, FLASH_UNPROTECT_LAST_BLOCK);
 }
@@ -139,7 +139,7 @@ int myhttpclientcallback(httprequest_t* request){
   //rtos_delay_milliseconds(500);
 
   if (request->state == 2){
-    //os_free(client_data->response_buf);
+    //free(client_data->response_buf);
     client_data->response_buf = (void*)0;
     client_data->response_buf_len = 0;
   }
@@ -173,7 +173,7 @@ void otarequest(const char *urlin){
   httpclient_data_t *client_data = &request->client_data;
 
   if (http_buf == (void *)0){
-    http_buf = os_malloc(BUF_SIZE+1);
+    http_buf = malloc(BUF_SIZE+1);
     if (http_buf == (void *)0) {
         addLogAdv(LOG_INFO, LOG_FEATURE_OTA,"startrequest Malloc failed.\r\n");
         return;


### PR DESCRIPTION
replace ALL os_malloc() with malloc()
replace ALL os_free() with free()
Add memory/memtest.c with routines to check stack and malloc area (T only)
TCP client thread buffers allocated when needed and KEPT.  Reused on client calls.
MQTT - use 50 bytes of stack for topic if short enough.
Thread stack size changes - we need to analyse thread requirements better (use memtest!!!)
