### PR TITLE
bk_timer driver is already intiialised.  Re-initialising kills N, so …

### DIFF
--- a/src/driver/drv_ir.cpp
+++ b/src/driver/drv_ir.cpp
@@ -138,10 +138,28 @@ void timerConfigForReceive() {
     };
     //GLOBAL_INT_DECLARATION();
 
-	ADDLOG_INFO(LOG_FEATURE_IR, (char *)"ir timer init");
-    bk_timer_init();
-	ADDLOG_INFO(LOG_FEATURE_IR, (char *)"ir timer init done");
+
     UINT32 res;
+    // test what error we get with an invalid command
+    res = sddev_control((char *)TIMER_DEV_NAME, -1, nullptr);
+
+    if (res == 1){
+    	ADDLOG_INFO(LOG_FEATURE_IR, (char *)"bk_timer already initialised");
+    } else {
+    	ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"bk_timer driver not initialised?");
+        if ((int)res == -5){
+            ADDLOG_INFO(LOG_FEATURE_IR, (char *)"bk_timer sddev not found - not initialised?");
+            return;
+        }
+        return;
+    }
+
+
+	//ADDLOG_INFO(LOG_FEATURE_IR, (char *)"ir timer init");
+    // do not need to do this
+    //bk_timer_init();
+	//ADDLOG_INFO(LOG_FEATURE_IR, (char *)"ir timer init done");
+	ADDLOG_INFO(LOG_FEATURE_IR, (char *)"will ir timer setup %u", res);
     res = sddev_control((char *)TIMER_DEV_NAME, CMD_TIMER_INIT_PARAM_US, &params);
 	ADDLOG_INFO(LOG_FEATURE_IR, (char *)"ir timer setup %u", res);
     res = sddev_control((char *)TIMER_DEV_NAME, CMD_TIMER_UNIT_ENABLE, &ir_chan);

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -58,7 +58,8 @@ static int g_saveCfgAfter = 0;
 static int g_startPingWatchDogAfter = 0;
 
 // not really <time>, but rather a loop count, but it doesn't really matter much
-static int g_timeSinceLastPingReply = 0;
+// start disabled.
+static int g_timeSinceLastPingReply = -1;
 // was it ran?
 static int g_bPingWatchDogStarted = 0;
 


### PR DESCRIPTION
…is probably also very bad on T
Tested on N.
N now does RX and recognises it's own TX.