### PR TITLE
Fixed rgb template value

### DIFF
--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -192,7 +192,7 @@ HassDeviceInfo* hass_init_light_device_info(ENTITY_TYPE type) {
 	case ENTITY_LIGHT_RGBCW:
 	case ENTITY_LIGHT_RGB:
 		cJSON_AddStringToObject(info->root, "rgb_cmd_tpl", "{{'#%02x%02x%02x0000'|format(red,green,blue)}}");  //rgb_command_template
-		cJSON_AddStringToObject(info->root, "rgb_val_tpl", "{{value[1:3]|int(base=16)}},{{value[3:5]|int(base=16)}},{{value[5:7]|int(base=16)}}");  //rgb_value_template
+		cJSON_AddStringToObject(info->root, "rgb_val_tpl", "{{ value[0:2]|int(base=16) }},{{ value[2:4]|int(base=16) }},{{ value[4:6]|int(base=16) }}");  //rgb_value_template
 
 		cJSON_AddStringToObject(info->root, "rgb_stat_t", "~/led_basecolor_rgb/get"); //rgb_state_topic
 		sprintf(g_hassBuffer, "cmnd/%s/led_basecolor_rgb", clientId);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1388,7 +1388,7 @@ int http_fn_ha_discovery(http_request_t* request) {
 
 void http_generate_rgb_cfg(http_request_t* request, const char* clientId) {
 	hprintf255(request, "    rgb_command_template: \"{{ '#%%02x%%02x%%02x0000' | format(red, green, blue)}}\"\n");
-	hprintf255(request, "    rgb_value_template: \"{{ value[1:3] | int(base=16) }},{{ value[3:5] | int(base=16) }},{{ value[5:7] | int(base=16) }}\"\n");
+	hprintf255(request, "    rgb_value_template: \"{{ value[0:2]|int(base=16) }},{{ value[2:4]|int(base=16) }},{{ value[4:6]|int(base=16) }}\"\n");
 	hprintf255(request, "    rgb_state_topic: \"%s/led_basecolor_rgb/get\"\n", clientId);
 	hprintf255(request, "    rgb_command_topic: \"cmnd/%s/led_basecolor_rgb\"\n", clientId);
 	hprintf255(request, "    command_topic: \"cmnd/%s/led_enableAll\"\n", clientId);


### PR DESCRIPTION
This should resolve the color issue mentioned in https://github.com/openshwprojects/OpenBK7231T_App/issues/408

The rgb template is based on @openshwprojects comment here https://www.elektroda.com/rtvforum/topic3880540.html#20044837.

I tested it with 5 PWM setup and confirmed that it works with latest Hass.