### PR TITLE
added src/jsmn since it is no longer pulled from sdk

### DIFF
--- a/bouffalo.mk
+++ b/bouffalo.mk
@@ -14,7 +14,7 @@ COMPONENT_SRCS :=
 COMPONENT_OBJS := $(patsubst %.c,%.o, $(COMPONENT_SRCS))
 COMPONENT_OBJS := $(patsubst %.S,%.o, $(COMPONENT_OBJS))
 
-COMPONENT_SRCDIRS := src/ src/httpserver/ src/cmnds/ src/logging/ src/hal/bl602/ src/mqtt/ src/cJSON src/driver src/devicegroups src/bitmessage
+COMPONENT_SRCDIRS := src/ src/jsmn src/httpserver/ src/cmnds/ src/logging/ src/hal/bl602/ src/mqtt/ src/cJSON src/driver src/devicegroups src/bitmessage
 
 
 


### PR DESCRIPTION
I changed sdk to not include aws jsmn which was being used instead of your jsmn (they are the same but it could lead to problems later). This means your app needs to include the functions.