### PR TITLE
fix: setChannel should parse the client

### DIFF
--- a/src/mqtt/new_mqtt.h
+++ b/src/mqtt/new_mqtt.h
@@ -69,6 +69,8 @@ typedef struct MqttPublishItem
 #define MQTT_COMMAND_PUBLISH_CHANNELS	"publishChannels"
 #define MQTT_COMMAND_PUBLISH_BENCHMARK  "publishBenchmark"
 
+// Maximum length to log data parameters
+#define MQTT_MAX_DATA_LOG_LENGTH					12
 
 // Count of queued items published at once.
 #define MQTT_QUEUED_ITEMS_PUBLISHED_AT_ONCE	3


### PR DESCRIPTION
If the mqtt client contains a '/', setChannel will fail to find the channel because it will stop at the first '/'.

This PR fixes setChannel to scan the client name instead, so it correctly skips over client. 

A new function `MQTT_RemoveClientFromTopic` is added, which skips over the topic.
In addition, the parsing in `channelSet` is greatly simplified, and and unnecessary copies are removed.

Fixes #515