### PR TITLE
Add Exponential Brightness

### DIFF
--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -11,6 +11,7 @@
 #include "cmd_local.h"
 #include "../mqtt/new_mqtt.h"
 #include "../cJSON/cJSON.h"
+#include <math.h>
 #ifdef BK_LITTLEFS
 	#include "../littlefs/our_lfs.h"
 #endif
@@ -372,7 +373,7 @@ void apply_smart_light() {
 						expo_factor  = 74.115f;
 						expo_offset -=  0.013f;
 					}
-					final = raw * (pow(expo_base, g_brightness * expo_factor) / expo_factor + expo_offset);
+					final = raw * (powf(expo_base, g_brightness * expo_factor) / expo_factor + expo_offset);
 				}
 			}
 			if(g_lightMode == Light_Temperature) {


### PR DESCRIPTION
Make brightness exponential. Exponential mode can be set with command led_expoMode <0..4>:
0 = Off
1 = 1% min brightness with moderate exponential
2 = 1% min brightness with full exponential (default)
3 = 0.1% min brightness with moderate exponential
4 = 0.1% min brightness with full exponential
The mode can be set at startup by the "Change startup command text" Config command.
Modes 3 & 4 will not be very useful yet since minimum brightness is currently limited to 1%.