### PR TITLE
Powerlogging

### DIFF
--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -18,7 +18,7 @@
 
 
 //According to your need to modify the constants.
-#define PIN_TMR_DURATION      5 // Delay (in ms) between button scan iterations
+#define PIN_TMR_DURATION      25 // Delay (in ms) between button scan iterations
 //#define BTN_DEBOUNCE_TICKS    3	//MAX 8
 #define BTN_DEBOUNCE_MS    		15	//MAX 8*5
 


### PR DESCRIPTION
goes with SDK mods to log powersave

Increases quicktick onterval to 25ms - 5ms interval completely prevents PS.

Note: you will NOT get PS without the logging changes....