### PR TITLE
Prepare gpi interrupt

### DIFF
--- a/src/hal/bk7231/hal_main_bk7231.c
+++ b/src/hal/bk7231/hal_main_bk7231.c
@@ -1,6 +1,7 @@
 
 #include "../../new_common.h"
 #include "../../logging/logging.h"
+#include "../../quicktick.h"
 
 
 #include "../../beken378/app/config/param_config.h"
@@ -8,8 +9,18 @@
 
 // main timer tick every 1s
 beken_timer_t g_main_timer_1s;
-beken2_timer_t g_mqtt_timer_oneshot;
+// 1ms oneshot timer - effectively a pended function, but overridable.
+beken2_timer_t g_timer_oneshot;
+// oneshot timer at quicktick interval
+beken2_timer_t g_quick_timer_oneshot;
 
+// fwd declaration
+void trigger_quick_oneshot(uint32_t type);
+
+// from new_mqtt.c
+extern int MQTT_process_received();
+// from new_pins.c
+extern void PIN_ticks(void *param);
 
 #if PLATFORM_BK7231T
 
@@ -50,14 +61,113 @@ OSStatus OBK_rtos_callback_in_timer_thread( PendedFunction_t xFunctionToPend, vo
   return kNoErr;
 }
 
-extern int MQTT_process_received();
-void MQTT_process_received_timer(void *a, void*b){
-  MQTT_process_received();
+
+// bitfield values for g_timer_triggers
+#define ONESHOT_MQTT_PROCESS 1
+#define ONESHOT_BUTTON_PROCESS 2
+
+// this is a bitfield for oneshot timer requests
+uint32_t g_timer_triggers = 0;
+uint32_t g_quick_timer_triggers = 0;
+
+
+
+// OBK_timer_cb cmd values
+#define OBK_DEFER_BUTTON_POLL 0
+
+// our timer thread callback - extend for multiple options,
+// e.g. pins called back from GPIO level interrupt.
+// this function is PENDED below.
+void OBK_timer_cb(void *a, uint32_t cmd){
+  switch (cmd){
+    case OBK_DEFER_BUTTON_POLL:
+      trigger_quick_oneshot(ONESHOT_BUTTON_PROCESS);
+      break;
+  }
 }
 
-void MQTT_TriggerRead(){
+// NOTE: defer to a DIFFERENT function in timer thread, 
+// else **** we can't set the timer from within itself... ****
+void OBK_TriggerButtonPoll(){
   OSStatus err;
-  err = rtos_start_oneshot_timer(&g_mqtt_timer_oneshot);
+  // note the 100 is ms to wait if timer queue full, NOT delay to function call.
+  err = OBK_rtos_callback_in_timer_thread( OBK_timer_cb, NULL, OBK_DEFER_BUTTON_POLL, 100);
+}
+
+
+void process_oneshot_timer(void *a, void*b){
+  // if mqtt process incomming data requested
+  if (g_timer_triggers & ONESHOT_MQTT_PROCESS){
+    MQTT_process_received();
+    g_timer_triggers &= ~ONESHOT_MQTT_PROCESS;
+  }
+
+  if (g_timer_triggers & ONESHOT_BUTTON_PROCESS){
+    //MQTT_process_received();
+    // 1 means it's a trigger/interrupt
+    PIN_ticks((void *)1);
+    g_timer_triggers &= ~ONESHOT_BUTTON_PROCESS;
+  }
+}
+
+void process_quick_oneshot_timer(void *a, void*b){
+  if (g_quick_timer_triggers & ONESHOT_BUTTON_PROCESS){
+    //MQTT_process_received();
+    // 1 means it's a trigger/interrupt
+    PIN_ticks((void *)0);
+    g_quick_timer_triggers &= ~ONESHOT_BUTTON_PROCESS;
+  }
+}
+
+
+// NOTE: this one RESETS the timer if the timer is pending.
+// so many calls will result in delayed firing.
+void trigger_oneshot(uint32_t type){
+  OSStatus err;
+  // note that we want (type) to be processed
+  g_timer_triggers |= type;
+  // will start or reset the oneshot timer.
+  // the timer should fire 1ms after this call.
+  // if two calls are made before the timer fires, it will fire ONCE
+  // 1ms after the last call....
+  // the timer calls process_oneshot_timer
+  err = rtos_start_oneshot_timer(&g_timer_oneshot);
+}
+
+// NOTE: this one only triggers the timer if it's not already pending.
+// so many calls will result undelayed firing.
+// i.e. the timer will fire 50ms after the FIRST call when the timer is not pending
+void trigger_quick_oneshot(uint32_t type){
+  OSStatus err;
+  int fire = 1;
+  if (g_quick_timer_triggers) fire = 0;
+  // note that we watn MQTT input to be processed
+  g_quick_timer_triggers |= type;
+  // will start or reset the oneshot timer.
+  // the timer should fire 1ms after this call.
+  // if two calls are made before the timer fires, it will fire ONCE
+  // 1ms after the last call....
+  // the timer calls process_oneshot_timer
+  if (fire) err = rtos_start_oneshot_timer(&g_quick_timer_oneshot);
+}
+
+
+// these functions should (are) safe to call from ISR or task.
+// they use the above functions
+
+// basically, 'read mqtt as soon as possible'
+void MQTT_TriggerRead(){
+  trigger_oneshot(ONESHOT_MQTT_PROCESS);
+}
+
+// basically, 'read buttons as soon as possible'
+void BUTTON_TriggerRead(){
+  trigger_oneshot(ONESHOT_BUTTON_PROCESS);
+}
+
+// basically, 'read buttons in quick tick period' - ~25ms
+void BUTTON_TriggerRead_quick(){
+  OBK_TriggerButtonPoll();
 }
 
 
@@ -77,12 +187,22 @@ void user_main(void)
   ASSERT(kNoErr == err);
 	ADDLOGF_DEBUG("started timer\r\n");
 
-  // initialise a one-shot timer, triggered by MQTT_TriggerRead()
-  err = rtos_init_oneshot_timer(&g_mqtt_timer_oneshot,
+  // initialise a one-shot timer, triggered by MQTT_TriggerRead() and others
+  err = rtos_init_oneshot_timer(&g_timer_oneshot,
                         1,
-                        MQTT_process_received_timer,
+                        process_oneshot_timer,
                         (void *)0,
                         (void *)0);
+  ASSERT(kNoErr == err);
+
+  err = rtos_init_oneshot_timer(&g_quick_timer_oneshot,
+                        QUICK_TMR_DURATION,
+                        process_quick_oneshot_timer,
+                        (void *)0,
+                        (void *)0);
+  ASSERT(kNoErr == err);
+
+	ADDLOGF_DEBUG("initialised oneshot timers");
 }
 
 #if PLATFORM_BK7231N

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -17,6 +17,11 @@
 #include "hal/hal_pins.h"
 #include "hal/hal_adc.h"
 
+#ifdef PLATFORM_BEKEN
+#include <gpio_pub.h>
+#include "driver/drv_ir.h"
+#endif
+
 
 //According to your need to modify the constants.
 #define PIN_TMR_DURATION      QUICK_TMR_DURATION // Delay (in ms) between button scan iterations
@@ -83,11 +88,91 @@ static byte g_timesUp[PLATFORM_GPIO_MAX];
 static byte g_lastValidState[PLATFORM_GPIO_MAX];
 
 
+// a bitfield indicating which GPI are inputs.
+// could be used to control edge triggered interrupts...
+/*  @param  gpio_index_map:The gpio bitmap which set 1 enable wakeup deep sleep.
+ *              gpio_index_map is hex and every bits is map to gpio0-gpio31.
+ *          gpio_edge_map:The gpio edge bitmap for wakeup gpios,
+ *              gpio_edge_map is hex and every bits is map to gpio0-gpio31.
+ *              0:rising,1:falling.
+ */
+// these map directly to void bk_enter_deep_sleep(UINT32 gpio_index_map,UINT32 gpio_edge_map);
+uint32_t g_gpio_index_map = 0;
+uint32_t g_gpio_edge_map = 0; // note: 0->rising, 1->falling
+
+void setGPIActive(int index, int active, int falling){
+	if (active){
+		g_gpio_index_map |= (1<<index);
+	} else {
+		g_gpio_index_map &= ~(1<<index);
+	}
+	if (falling){
+		g_gpio_edge_map |= (1<<index);
+	} else {
+		g_gpio_edge_map &= ~(1<<index);
+	}
+}
+
+
+#ifdef PLATFORM_BEKEN
+#ifdef BEKEN_PIN_GPI_INTERRUPTS
+	// TODO: EXAMPLE of edge based interrupt handling
+	// NOT YET ENABLED
+
+	// this will be from hal_bk....
+	// causes button read.
+	extern void BUTTON_TriggerRead();
+
+
+	// NOTE: ISR!!!!
+	// triggers one-shot timer to fire in 1ms
+	// from hal_main_bk7231.c
+	// THIS IS AN ISR.
+	void PIN_IntHandler(unsigned char index){
+		BUTTON_TriggerRead();
+	}
+
+	// this will be from hal_bk....
+	// ensures that we will get called in 50ms or less.
+	extern void BUTTON_TriggerRead_quick();
+
+	// called in PIN_ticks to carry on polling for 20 polls after last button is active
+	void PIN_TriggerPoll(){
+		BUTTON_TriggerRead_quick();
+	}
+#endif
+#endif
+
+
 void PIN_SetupPins() {
 	int i;
 	for(i = 0; i < PLATFORM_GPIO_MAX; i++) {
 		PIN_SetPinRoleForPinIndex(i,g_cfg.pins.roles[i]);
 	}
+
+#ifdef PLATFORM_BEKEN
+#ifdef BEKEN_PIN_GPI_INTERRUPTS
+	// TODO: EXAMPLE of edge based interrupt handling
+	// NOT YET ENABLED
+	for (int i = 0; i < 32; i++){
+		if (g_gpio_index_map & (1<<i)){
+			UINT32 mode = GPIO_INT_LEVEL_RISING;
+			if (g_gpio_edge_map & (1<<i)){
+				mode = GPIO_INT_LEVEL_FALLING;
+			}
+			if (g_cfg.pins.roles[i] == IOR_IRRecv){
+				// not yet implemented
+				//gpio_int_enable(i, mode, IR_GPI_IntHandler);
+			} else {
+				gpio_int_enable(i, mode, PIN_IntHandler);
+			}
+		} else {
+			gpio_int_disable(i);
+		}
+	}
+#endif
+#endif
+
 	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL,"PIN_SetupPins pins have been set up.\r\n");
 }
 
@@ -444,6 +529,10 @@ void PIN_SetPinRoleForPinIndex(int index, int role) {
 	}
 #endif
 	if (g_enable_pins) {
+
+		// remove from active inputs
+		setGPIActive(index, 0, 0);
+
 		switch(g_cfg.pins.roles[index])
 		{
 		case IOR_Button:
@@ -493,23 +582,30 @@ void PIN_SetPinRoleForPinIndex(int index, int role) {
 	}
 
 	if (g_enable_pins) {
+		int falling = 0;
+
 		// init new role
 		switch(role)
 		{
 		case IOR_Button:
-		case IOR_Button_n:
         case IOR_Button_ToggleAll:
-		case IOR_Button_ToggleAll_n:
 		case IOR_Button_NextColor:
-		case IOR_Button_NextColor_n:
 		case IOR_Button_NextDimmer:
-		case IOR_Button_NextDimmer_n:
 		case IOR_Button_NextTemperature:
-		case IOR_Button_NextTemperature_n:
 		case IOR_Button_ScriptOnly:
+			falling = 1;
+
+		case IOR_Button_n:
+		case IOR_Button_ToggleAll_n:
+		case IOR_Button_NextColor_n:
+		case IOR_Button_NextDimmer_n:
+		case IOR_Button_NextTemperature_n:
 		case IOR_Button_ScriptOnly_n:
 			{
 				pinButton_s *bt = &g_buttons[index];
+
+				// add to active inputs
+				setGPIActive(index, 1, falling);
 
 				// digital input
 				HAL_PIN_Setup_Input_Pullup(index);
@@ -518,24 +614,42 @@ void PIN_SetPinRoleForPinIndex(int index, int role) {
 				NEW_button_init(bt, button_generic_get_gpio_value, 0);
 			}
 			break;
+
+		case IOR_IRRecv:
+			falling = 1;
+			// add to active inputs
+			setGPIActive(index, 1, falling);
+			break;
+
 		case IOR_ToggleChannelOnToggle:
 			{
+				// add to active inputs
+				falling = 1;
+				setGPIActive(index, 1, falling);
+
 				// digital input
 				HAL_PIN_Setup_Input_Pullup(index);
 				// otherwise we get a toggle on start
 				g_lastValidState[index] = PIN_ReadDigitalInputValue_WithInversionIncluded(index);
 			}
 			break;
-		case IOR_DigitalInput:
 		case IOR_DigitalInput_n:
+			falling = 1;
+		case IOR_DigitalInput:
 			{
+				// add to active inputs
+				setGPIActive(index, 1, falling);
 				// digital input
 				HAL_PIN_Setup_Input_Pullup(index);
 			}
 			break;
-		case IOR_DigitalInput_NoPup:
 		case IOR_DigitalInput_NoPup_n:
+			falling = 1;
+		case IOR_DigitalInput_NoPup:
 			{
+				// add to active inputs
+				// TODO: We cannot set active here, as later code may enforce pullup/down????
+				//setGPIActive(index, 1, falling);
 				// digital input
 				HAL_PIN_Setup_Input(index);
 			}
@@ -1076,6 +1190,7 @@ void PIN_set_wifi_led(int value){
 
 static uint32_t g_time = 0;
 static uint32_t g_last_time = 0;
+static int activepoll_time = 0; // time to keep polling active until
 
 #define TOGGLE_PIN_DEBOUNCE_CYCLES 50
 //  background ticks, timer repeat invoking interval defined by PIN_TMR_DURATION.
@@ -1105,7 +1220,33 @@ void PIN_ticks(void *param)
 	BTN_LONG_MS = (g_cfg.buttonLongPress * 100);
 	BTN_HOLD_REPEAT_MS = (g_cfg.buttonHoldRepeat * 100);
 
+	int activepins = 0;
+	UINT32 pinvalues = 0;
 	for(i = 0; i < PLATFORM_GPIO_MAX; i++) {
+		// note pins which are active - i.e. would not trigger an edge interrupt on change.
+		// if we have any, then we must poll until none
+		// TODO: this will only be used when GPI interrupt triggeringis used.
+		// but it's useful info anyway...
+		if (g_gpio_index_map & (1<<i)){
+			UINT32 level = 1;
+			if (g_gpio_edge_map & (1<<i)){
+				level = 0;
+			}
+			int rawval = HAL_PIN_ReadDigitalInput(i);
+			if (rawval && level == 1){
+				activepins ++;
+				pinvalues |= (1 << i);
+			}
+			if (!rawval && level == 0){
+				activepins ++;
+				pinvalues |= (1 << i);
+			}
+		}
+		// activepins is count of pins which are 'active', i.e. match thier expected active level
+		if (activepins){
+			activepoll_time = 1000; //20 x 50ms = 1s of polls after button release
+		}
+
 #if 1
 		if(g_cfg.pins.roles[i] == IOR_PWM) {
 			HAL_PIN_PWM_Update(i,g_channelValues[g_cfg.pins.channels[i]]);
@@ -1191,6 +1332,44 @@ void PIN_ticks(void *param)
 			}
 		}
 	}
+
+#ifdef PLATFORM_BEKEN
+#ifdef BEKEN_PIN_GPI_INTERRUPTS
+	// TODO: not implemented yet - this bit continues polling
+	// for a while after a GPI is fired, so that we can see long press, etc.
+	if (param){
+		addLogAdv(LOG_DEBUG, LOG_FEATURE_GENERAL,"Pin intr at %d (+%d) (%x)", g_time, t_diff, pinvalues);
+	}
+#endif
+#endif
+
+	if (activepoll_time){
+		activepoll_time -= t_diff;
+		if (activepoll_time <= 0){
+			activepoll_time = 0;
+		}
+	}
+	if (activepoll_time){
+		// setup to poll in 50ms
+#ifdef PLATFORM_BEKEN
+#ifdef BEKEN_PIN_GPI_INTERRUPTS
+		PIN_TriggerPoll();
+		if (activepins){
+			addLogAdv(LOG_DEBUG, LOG_FEATURE_GENERAL,"Pins active at %d (%x)", g_time, pinvalues);
+		} else {
+			addLogAdv(LOG_DEBUG, LOG_FEATURE_GENERAL,"Pins ->inactive at %d (%x)", g_time, pinvalues);
+		}
+#endif
+#endif
+
+	} else {
+#ifdef PLATFORM_BEKEN
+#ifdef BEKEN_PIN_GPI_INTERRUPTS
+		addLogAdv(LOG_DEBUG, LOG_FEATURE_GENERAL,"Pins inactive at %d", g_time, pinvalues);
+#endif		
+#endif		
+	}
+
 }
 // setChannelType 3 LowMidHigh
 int CHANNEL_ParseChannelType(const char *s) {

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -96,7 +96,7 @@ static byte g_lastValidState[PLATFORM_GPIO_MAX];
  *              gpio_edge_map is hex and every bits is map to gpio0-gpio31.
  *              0:rising,1:falling.
  */
-// these map directly to void bk_enter_deep_sleep(UINT32 gpio_index_map,UINT32 gpio_edge_map);
+// these map directly to void bk_enter_deep_sleep(uint32_t gpio_index_map,uint32_t gpio_edge_map);
 uint32_t g_gpio_index_map = 0;
 uint32_t g_gpio_edge_map = 0; // note: 0->rising, 1->falling
 
@@ -156,7 +156,7 @@ void PIN_SetupPins() {
 	// NOT YET ENABLED
 	for (int i = 0; i < 32; i++){
 		if (g_gpio_index_map & (1<<i)){
-			UINT32 mode = GPIO_INT_LEVEL_RISING;
+			uint32_t mode = GPIO_INT_LEVEL_RISING;
 			if (g_gpio_edge_map & (1<<i)){
 				mode = GPIO_INT_LEVEL_FALLING;
 			}
@@ -1221,14 +1221,14 @@ void PIN_ticks(void *param)
 	BTN_HOLD_REPEAT_MS = (g_cfg.buttonHoldRepeat * 100);
 
 	int activepins = 0;
-	UINT32 pinvalues = 0;
+	uint32_t pinvalues = 0;
 	for(i = 0; i < PLATFORM_GPIO_MAX; i++) {
 		// note pins which are active - i.e. would not trigger an edge interrupt on change.
 		// if we have any, then we must poll until none
 		// TODO: this will only be used when GPI interrupt triggeringis used.
 		// but it's useful info anyway...
 		if (g_gpio_index_map & (1<<i)){
-			UINT32 level = 1;
+			uint32_t level = 1;
 			if (g_gpio_edge_map & (1<<i)){
 				level = 0;
 			}

--- a/src/quicktick.h
+++ b/src/quicktick.h
@@ -2,3 +2,6 @@
 
 #define QUICK_TMR_DURATION      25 // Delay (in ms) between button scan iterations
 
+// define this to use edge based GPI interrupts to drive Pin_ticks()
+//#define BEKEN_PIN_GPI_INTERRUPTS
+

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -581,7 +581,12 @@ static uint32_t g_last_time = 0;
 // this is what we do in a qucik tick
 void QuickTick(void *param)
 {
+
+#if defined(PLATFORM_BEKEN) && defined(BEKEN_PIN_GPI_INTERRUPTS)
+	// if using interrupt driven GPI for pins, don't call PIN_ticks() in QuickTick
+#else
 	PIN_ticks(param);
+#endif
 
 #if defined(PLATFORM_BEKEN) || defined(WINDOWS)
 	g_time = rtos_get_time();


### PR DESCRIPTION
Implementation of GPI interrupts on Beken.
You can enable them for testing by setting
#define BEKEN_PIN_GPI_INTERRUPTS
in quicktick.h
Also changes MQTT triggering to trigger a single read cycle even if multiple MQTT messages arrive before they are serviced.

NOTE THAT GPI Interrupts are currently NOT enabled in this PR.
But the functionality was previously tested on N, and I have subsequently ported on top of main, and tested the binaries with and without GPI ints enabled - but NOT *retested* actual button functionality!!!! (as I have no buttons...).

Why do we need this? - it goes towards Deep Sleep.  Even if we don't use the GPI interrupts, the features of gathering the pins and levels are needed for deep sleep waking from GPI.
