### PR TITLE
W600: Basic driver support

### DIFF
--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -186,6 +186,20 @@ float led_lerpSpeedUnitsPerSecond = 200.f;
 float led_current_value_brightness = 0;
 float led_current_value_cold_or_warm = 0;
 
+void led_Save_finalRGBCW(byte* finalRGBCW) {
+#ifdef LED_DRIVER_SUPPORT
+	if (DRV_IsRunning("SM2135")) {
+		SM2135_Write(finalRGBCW);
+	}
+	if (DRV_IsRunning("BP5758D")) {
+		BP5758D_Write(finalRGBCW);
+	}
+	if (DRV_IsRunning("BP1658CJ")) {
+		BP1658CJ_Write(finalRGBCW);
+	}
+#endif
+}
+
 void LED_RunQuickColorLerp(int deltaMS) {
 	int i;
 	int firstChannelIndex;
@@ -263,17 +277,8 @@ void LED_RunQuickColorLerp(int deltaMS) {
 			}
 		}
 	}
-#ifndef OBK_DISABLE_ALL_DRIVERS
-	if(DRV_IsRunning("SM2135")) {
-		SM2135_Write(finalRGBCW);
-	}
-	if(DRV_IsRunning("BP5758D")) {
-		BP5758D_Write(finalRGBCW);
-	}
-	if(DRV_IsRunning("BP1658CJ")) {
-		BP1658CJ_Write(finalRGBCW);
-	}
-#endif
+	
+	led_Save_finalRGBCW(finalRGBCW);
 }
 #if WINDOWS
 int exponential_mode = 0;
@@ -427,17 +432,7 @@ void apply_smart_light() {
 		}
 	}
 	if(CFG_HasFlag(OBK_FLAG_LED_SMOOTH_TRANSITIONS) == false) {
-#ifndef OBK_DISABLE_ALL_DRIVERS
-		if(DRV_IsRunning("SM2135")) {
-			SM2135_Write(finalRGBCW);
-		}
-		if(DRV_IsRunning("BP5758D")) {
-			BP5758D_Write(finalRGBCW);
-		}
-		if(DRV_IsRunning("BP1658CJ")) {
-			BP1658CJ_Write(finalRGBCW);
-		}
-#endif
+		led_Save_finalRGBCW(finalRGBCW);
 	}
 
 	if(CFG_HasFlag(OBK_FLAG_LED_REMEMBERLASTSTATE)) {

--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -187,7 +187,7 @@ float led_current_value_brightness = 0;
 float led_current_value_cold_or_warm = 0;
 
 void led_Save_finalRGBCW(byte* finalRGBCW) {
-#ifdef LED_DRIVER_SUPPORT
+#ifdef ENABLE_DRIVER_LED
 	if (DRV_IsRunning("SM2135")) {
 		SM2135_Write(finalRGBCW);
 	}

--- a/src/driver/drv_bl0937.c
+++ b/src/driver/drv_bl0937.c
@@ -33,6 +33,10 @@ int GPIO_HLW_SEL = 24; // pwm4
 int GPIO_HLW_CF = 7;
 int GPIO_HLW_CF1 = 8;
 
+//The above three actually are pin indices. For W600 the actual gpio_pins are different.
+unsigned int GPIO_HLW_CF_pin;
+unsigned int GPIO_HLW_CF1_pin;
+
 bool g_sel = true;
 uint32_t res_v = 0;
 uint32_t res_c = 0;
@@ -47,13 +51,29 @@ volatile uint32_t g_vc_pulses = 0;
 volatile uint32_t g_p_pulses = 0;
 static portTickType pulseStamp;
 
+#if PLATFORM_W600
+
+static void HlwCf1Interrupt(void* context) {
+	tls_clr_gpio_irq_status(GPIO_HLW_CF1_pin);
+	g_vc_pulses++;
+}
+static void HlwCfInterrupt(void* context) {
+	tls_clr_gpio_irq_status(GPIO_HLW_CF_pin);
+	g_p_pulses++;
+}
+
+#else
+
 void HlwCf1Interrupt(unsigned char pinNum) {  // Service Voltage and Current
 	g_vc_pulses++;
 }
 void HlwCfInterrupt(unsigned char pinNum) {  // Service Power
 	g_p_pulses++;
 }
-commandResult_t BL0937_PowerSet(const void *context, const char *cmd, const char *args, int cmdFlags) {
+
+#endif
+
+commandResult_t BL0937_PowerSet(const void* context, const char* cmd, const char* args, int cmdFlags) {
 	float realPower;
 
 	if(args==0||*args==0) {
@@ -179,24 +199,27 @@ commandResult_t BL0937_CurrentSet(const void *context, const char *cmd, const ch
 
 void BL0937_Shutdown_Pins()
 {
-
-#if PLATFORM_BEKEN
+#if PLATFORM_W600
+	tls_gpio_irq_disable(GPIO_HLW_CF1_pin);
+	tls_gpio_irq_disable(GPIO_HLW_CF_pin);
+#elif PLATFORM_BEKEN
 	gpio_int_disable(GPIO_HLW_CF1);
-#else
-
-#endif
-#if PLATFORM_BEKEN
 	gpio_int_disable(GPIO_HLW_CF);
-#else
-
 #endif
-
 }
+
 void BL0937_Init_Pins() {
 	// if not found, this will return the already set value
 	GPIO_HLW_SEL = PIN_FindPinIndexForRole(IOR_BL0937_SEL, GPIO_HLW_SEL);
 	GPIO_HLW_CF = PIN_FindPinIndexForRole(IOR_BL0937_CF, GPIO_HLW_CF);
 	GPIO_HLW_CF1 = PIN_FindPinIndexForRole(IOR_BL0937_CF1, GPIO_HLW_CF1);
+
+#if PLATFORM_W600
+	GPIO_HLW_CF1_pin = HAL_GetGPIOPin(GPIO_HLW_CF1);
+	GPIO_HLW_CF_pin = HAL_GetGPIOPin(GPIO_HLW_CF);
+	//printf("GPIO_HLW_CF=%d GPIO_HLW_CF1=%d\n", GPIO_HLW_CF, GPIO_HLW_CF1);
+	//printf("GPIO_HLW_CF1_pin=%d GPIO_HLW_CF_pin=%d\n", GPIO_HLW_CF1_pin, GPIO_HLW_CF_pin);
+#endif
 
 	// UPDATE: now they are automatically saved
 	BL0937_VREF = CFG_GetPowerMeasurementCalibrationFloat(CFG_OBK_VOLTAGE, BL0937_VREF);
@@ -209,17 +232,22 @@ void BL0937_Init_Pins() {
 
 	HAL_PIN_Setup_Input_Pullup(GPIO_HLW_CF1);
 
-#if PLATFORM_BEKEN
+#if PLATFORM_W600
+	tls_gpio_isr_register(GPIO_HLW_CF1_pin, HlwCf1Interrupt, NULL);
+	tls_gpio_irq_enable(GPIO_HLW_CF1_pin, WM_GPIO_IRQ_TRIG_FALLING_EDGE);
+#elif PLATFORM_BEKEN
 	gpio_int_enable(GPIO_HLW_CF1, IRQ_TRIGGER_FALLING_EDGE, HlwCf1Interrupt);
-#else
-
 #endif
+
 	HAL_PIN_Setup_Input_Pullup(GPIO_HLW_CF);
-#if PLATFORM_BEKEN
-	gpio_int_enable(GPIO_HLW_CF, IRQ_TRIGGER_FALLING_EDGE, HlwCfInterrupt);
-#else
 
+#if PLATFORM_W600
+	tls_gpio_isr_register(GPIO_HLW_CF_pin, HlwCfInterrupt, NULL);
+	tls_gpio_irq_enable(GPIO_HLW_CF_pin, WM_GPIO_IRQ_TRIG_FALLING_EDGE);
+#elif PLATFORM_BEKEN
+	gpio_int_enable(GPIO_HLW_CF, IRQ_TRIGGER_FALLING_EDGE, HlwCfInterrupt);
 #endif
+
 	g_vc_pulses = 0;
 	g_p_pulses = 0;
 	pulseStamp = xTaskGetTickCount();
@@ -267,7 +295,7 @@ void BL0937_Init()
 	BL0937_Init_Pins();
 }
 
-void BL0937_RunFrame() 
+void BL0937_RunFrame()
 {
 	float final_v;
 	float final_c;
@@ -286,11 +314,11 @@ void BL0937_RunFrame()
 		bNeedRestart = true;
 	}
 
-    ticksElapsed = (xTaskGetTickCount() - pulseStamp);
+	ticksElapsed = (xTaskGetTickCount() - pulseStamp);
 
 #if PLATFORM_BEKEN
-    GLOBAL_INT_DECLARATION();
-    GLOBAL_INT_DISABLE();
+	GLOBAL_INT_DECLARATION();
+	GLOBAL_INT_DISABLE();
 #else
 
 #endif
@@ -329,20 +357,20 @@ void BL0937_RunFrame()
 
 #endif
 
-    pulseStamp = xTaskGetTickCount();
+	pulseStamp = xTaskGetTickCount();
 	//addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"Voltage pulses %i, current %i, power %i\n", res_v, res_c, res_p);
 
 	final_v = res_v * BL0937_VREF;
-    final_v *= (float)ticksElapsed;
-    final_v /= (1000.0f / (float)portTICK_PERIOD_MS); 
-	
-    final_c = res_c * BL0937_CREF;
-    final_c *= (float)ticksElapsed;
-    final_c /= (1000.0f / (float)portTICK_PERIOD_MS);
-	
-    final_p = res_p * BL0937_PREF;
-    final_p *= (float)ticksElapsed;
-    final_p /= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_v *= (float)ticksElapsed;
+	final_v /= (1000.0f / (float)portTICK_PERIOD_MS);
+
+	final_c = res_c * BL0937_CREF;
+	final_c *= (float)ticksElapsed;
+	final_c /= (1000.0f / (float)portTICK_PERIOD_MS);
+
+	final_p = res_p * BL0937_PREF;
+	final_p *= (float)ticksElapsed;
+	final_p /= (1000.0f / (float)portTICK_PERIOD_MS);
 
     /* patch to limit max power reading, filter random reading errors */
     if (final_p > BL0937_PMAX)

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -66,31 +66,31 @@ typedef struct driver_s {
 // startDriver BL0937
 static driver_t g_drivers[] = {
 
-#ifdef TUYA_SUPPORT
+#ifdef ENABLE_DRIVER_TUYAMCU
 	{ "TuyaMCU",	TuyaMCU_Init,		TuyaMCU_RunFrame,			NULL, NULL, NULL, NULL, false },
 	{ "tmSensor",	TuyaMCU_Sensor_Init, TuyaMCU_Sensor_RunFrame,	NULL, NULL, NULL, NULL, false },
 #endif
 
-#ifdef BASIC_DRIVER_SUPPORT
+#ifdef ENABLE_BASIC_DRIVERS
 	{ "NTP",		NTP_Init,			NTP_OnEverySecond,			NTP_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 	{ "TESTPOWER",	Test_Power_Init,	 Test_Power_RunFrame,		BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 	{ "TESTLED",	Test_LED_Driver_Init, Test_LED_Driver_RunFrame, NULL, NULL, NULL, Test_LED_Driver_OnChannelChanged, false },
 	{ "HTTPButtons",	DRV_InitHTTPButtons, NULL, NULL, NULL, NULL, NULL, false },
 #endif
 
-#if I2C_SUPPORT
+#if ENABLE_I2C
 	{ "I2C",		DRV_I2C_Init,		DRV_I2C_EverySecond,		NULL, NULL, NULL, NULL, false },
 #endif
 
-#ifdef POWER_BL0942_SUPPORT
+#ifdef ENABLE_DRIVER_BL0942
 	{ "BL0942",		BL0942_Init,		BL0942_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 #endif
 
-#ifdef POWER_BL0937_SUPPORT	
+#ifdef ENABLE_DRIVER_BL0937	
 	{ "BL0937",		BL0937_Init,		BL0937_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 #endif
 	
-#ifdef POWER_CSE7766_SUPPORT
+#ifdef ENABLE_DRIVER_CSE7766
 	{ "CSE7766",	CSE7766_Init,		CSE7766_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 #endif
 
@@ -105,7 +105,7 @@ static driver_t g_drivers[] = {
 	{ "DGR",		DRV_DGR_Init,		DRV_DGR_RunEverySecond,		NULL, DRV_DGR_RunQuickTick, DRV_DGR_Shutdown, DRV_DGR_OnChannelChanged, false },
 #endif
 
-#ifdef LED_DRIVER_SUPPORT
+#ifdef ENABLE_DRIVER_LED
 	{ "SM2135",		SM2135_Init,		SM2135_RunFrame,			NULL, NULL, NULL, SM2135_OnChannelChanged, false },
 	{ "BP5758D",	BP5758D_Init,		BP5758D_RunFrame,			NULL, NULL, NULL, BP5758D_OnChannelChanged, false },
 	{ "BP1658CJ",	BP1658CJ_Init,		BP1658CJ_RunFrame,			NULL, NULL, NULL, BP1658CJ_OnChannelChanged, false },

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -62,23 +62,37 @@ typedef struct driver_s {
 	bool bLoaded;
 } driver_t;
 
+
 // startDriver BL0937
 static driver_t g_drivers[] = {
-	{ "TuyaMCU",	TuyaMCU_Init,		TuyaMCU_RunFrame,			NULL, NULL, NULL, NULL, false },
-	{ "NTP",		NTP_Init,			NTP_OnEverySecond,			NTP_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
-#if DRV_ENABLE_I2C
-	{ "I2C",		DRV_I2C_Init,		DRV_I2C_EverySecond,		NULL, NULL, NULL, NULL, false },
-#endif
-	//These 4 measure power
-	{ "BL0942",		BL0942_Init,		BL0942_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
-	{ "BL0937",		BL0937_Init,		BL0937_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
-	{ "CSE7766",	CSE7766_Init,		CSE7766_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 
-	//Test drivers
+#ifdef TUYA_SUPPORT
+	{ "TuyaMCU",	TuyaMCU_Init,		TuyaMCU_RunFrame,			NULL, NULL, NULL, NULL, false },
+	{ "tmSensor",	TuyaMCU_Sensor_Init, TuyaMCU_Sensor_RunFrame,	NULL, NULL, NULL, NULL, false },
+#endif
+
+#ifdef BASIC_DRIVER_SUPPORT
+	{ "NTP",		NTP_Init,			NTP_OnEverySecond,			NTP_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 	{ "TESTPOWER",	Test_Power_Init,	 Test_Power_RunFrame,		BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 	{ "TESTLED",	Test_LED_Driver_Init, Test_LED_Driver_RunFrame, NULL, NULL, NULL, Test_LED_Driver_OnChannelChanged, false },
 	{ "HTTPButtons",	DRV_InitHTTPButtons, NULL, NULL, NULL, NULL, NULL, false },
+#endif
 
+#if I2C_SUPPORT
+	{ "I2C",		DRV_I2C_Init,		DRV_I2C_EverySecond,		NULL, NULL, NULL, NULL, false },
+#endif
+
+#ifdef POWER_BL0942_SUPPORT
+	{ "BL0942",		BL0942_Init,		BL0942_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
+#endif
+
+#ifdef POWER_BL0937_SUPPORT	
+	{ "BL0937",		BL0937_Init,		BL0937_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
+#endif
+	
+#ifdef POWER_CSE7766_SUPPORT
+	{ "CSE7766",	CSE7766_Init,		CSE7766_RunFrame,			BL09XX_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
+#endif
 
 #if PLATFORM_BEKEN	
 	{ "SM16703P",	SM16703P_Init,		NULL,						NULL, NULL, NULL, NULL, false },
@@ -90,10 +104,13 @@ static driver_t g_drivers[] = {
 	{ "PWMToggler",	DRV_InitPWMToggler, NULL, DRV_Toggler_AppendInformationToHTTPIndexPage, NULL, NULL, NULL, false },
 	{ "DGR",		DRV_DGR_Init,		DRV_DGR_RunEverySecond,		NULL, DRV_DGR_RunQuickTick, DRV_DGR_Shutdown, DRV_DGR_OnChannelChanged, false },
 #endif
+
+#ifdef LED_DRIVER_SUPPORT
 	{ "SM2135",		SM2135_Init,		SM2135_RunFrame,			NULL, NULL, NULL, SM2135_OnChannelChanged, false },
 	{ "BP5758D",	BP5758D_Init,		BP5758D_RunFrame,			NULL, NULL, NULL, BP5758D_OnChannelChanged, false },
 	{ "BP1658CJ",	BP1658CJ_Init,		BP1658CJ_RunFrame,			NULL, NULL, NULL, BP1658CJ_OnChannelChanged, false },
-	{ "tmSensor",	TuyaMCU_Sensor_Init, TuyaMCU_Sensor_RunFrame,	NULL, NULL, NULL, NULL, false }
+#endif
+
 };
 
 static const int g_numDrivers = sizeof(g_drivers) / sizeof(g_drivers[0]);

--- a/src/hal/hal_pins.h
+++ b/src/hal/hal_pins.h
@@ -9,9 +9,5 @@ void HAL_PIN_PWM_Start(int index);
 // Value range is 0 to 100, value is clamped
 void HAL_PIN_PWM_Update(int index, int value);
 int HAL_PIN_CanThisPinBePWM(int index);
-const char *HAL_PIN_GetPinNameAlias(int index);
-
-
-
-
-
+const char* HAL_PIN_GetPinNameAlias(int index);
+unsigned int HAL_GetGPIOPin(int index);

--- a/src/hal/w800/hal_pins_w800.c
+++ b/src/hal/w800/hal_pins_w800.c
@@ -185,5 +185,7 @@ void HAL_PIN_PWM_Update(int index, int value) {
 	tls_pwm_duty_set(channel, value * 2.55f);
 }
 
-
+unsigned int HAL_GetGPIOPin(int index) {
+	return g_pins[index].code;
+}
 #endif

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -809,7 +809,7 @@ int http_fn_index(http_request_t* request) {
 		hprintf255(request, "<h5 style='color:red'>You are in safe mode (AP mode) because full reboot failed %i times. ",
 			Main_GetLastRebootBootFailures());
 		hprintf255(request, "Pins, relays, etc are disabled.</h5>");
-		
+
 	}
 	// for normal page loads, show the rest of the HTML
 	if (!http_getArg(request->url, "state", tmpA, sizeof(tmpA))) {
@@ -1425,7 +1425,7 @@ int http_fn_uart_tool(http_request_t* request) {
 	poststr(request, "<h4>UART Tool</h4>");
 
 	if (http_getArg(request->url, "data", tmpA, sizeof(tmpA))) {
-#ifndef OBK_DISABLE_ALL_DRIVERS
+#ifdef TUYA_SUPPORT
 		byte results[128];
 
 		hprintf255(request, "<h3>Sent %s!</h3>", tmpA);
@@ -1801,7 +1801,7 @@ int http_tasmota_json_power(http_request_t* request) {
 	int lastRelayState;
 	bool bRelayIndexingStartsWithZero;
 	int relayIndexingOffset;
-	int temperature; 
+	int temperature;
 	int dimmer;
 
 	bRelayIndexingStartsWithZero = CHANNEL_HasChannelPinWithRoleOrRole(0, IOR_Relay, IOR_Relay_n);
@@ -1847,7 +1847,7 @@ int http_tasmota_json_power(http_request_t* request) {
 
 			// it looks like they include C and W in color
 			if (LED_IsLedDriverChipRunning() || numPWMs == 5) {
-				hprintf255(request, "\"Color\":\"%i,%i,%i,%i,%i\",", 
+				hprintf255(request, "\"Color\":\"%i,%i,%i,%i,%i\",",
 					(int)rgbcw[0], (int)rgbcw[1], (int)rgbcw[2], (int)rgbcw[3], (int)rgbcw[4]);
 			}
 			else {
@@ -1966,7 +1966,7 @@ int http_tasmota_json_status_SNS(http_request_t* request) {
 
 	return 0;
 }
-#if defined(PLATFORM_W600) || defined (PLATFORM_W800)
+#ifndef BASIC_DRIVER_SUPPORT
 unsigned int NTP_GetCurrentTime() {
 	return 0;
 }
@@ -2522,7 +2522,7 @@ const char* g_obk_flagNames[] = {
 	"error",
 	"error",
 	"error",
-}; 
+};
 int http_fn_cfg_generic(http_request_t* request) {
 	int i;
 	char tmpA[64];

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1425,7 +1425,7 @@ int http_fn_uart_tool(http_request_t* request) {
 	poststr(request, "<h4>UART Tool</h4>");
 
 	if (http_getArg(request->url, "data", tmpA, sizeof(tmpA))) {
-#ifdef TUYA_SUPPORT
+#ifdef ENABLE_DRIVER_TUYAMCU
 		byte results[128];
 
 		hprintf255(request, "<h3>Sent %s!</h3>", tmpA);
@@ -1966,7 +1966,7 @@ int http_tasmota_json_status_SNS(http_request_t* request) {
 
 	return 0;
 }
-#ifndef BASIC_DRIVER_SUPPORT
+#ifndef ENABLE_BASIC_DRIVERS
 unsigned int NTP_GetCurrentTime() {
 	return 0;
 }

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1966,6 +1966,11 @@ int http_tasmota_json_status_SNS(http_request_t* request) {
 
 	return 0;
 }
+
+#ifdef PLATFORM_XR809
+//XR809 does not support drivers but its build script compiles many drivers including ntp.
+
+#else
 #ifndef ENABLE_BASIC_DRIVERS
 unsigned int NTP_GetCurrentTime() {
 	return 0;
@@ -1974,6 +1979,8 @@ unsigned int NTP_GetCurrentTimeWithoutOffset() {
 	return 0;
 }
 #endif
+#endif
+
 /*
 {"Status":{"Module":0,"DeviceName":"Tasmota","FriendlyName":["Tasmota"],"Topic":"tasmota_48E7F3","ButtonTopic":"0","Power":1,"PowerOnState":3,"LedState":1,"LedMask":"FFFF","SaveData":1,"SaveState":1,"SwitchTopic":"0","SwitchMode":[0,0,0,0,0,0,0,0],"ButtonRetain":0,"SwitchRetain":0,"SensorRetain":0,"PowerRetain":0,"InfoRetain":0,"StateRetain":0}}
 */

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -1450,7 +1450,7 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx)
 	if (CHANNEL_HasRoleThatShouldBePublished(idx)) {
 		bWantsToPublish = true;
 	}
-#ifdef TUYA_SUPPORT
+#ifdef ENABLE_DRIVER_TUYAMCU
 	// publish if channel is used by TuyaMCU (no pin role set), for example door sensor state with power saving V0 protocol
 	// Not enabled by default, you have to set OBK_FLAG_TUYAMCU_ALWAYSPUBLISHCHANNELS flag
 	if (CFG_HasFlag(OBK_FLAG_TUYAMCU_ALWAYSPUBLISHCHANNELS) && TuyaMCU_IsChannelUsedByTuyaMCU(idx)) {

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -30,11 +30,11 @@ extern void MQTT_TriggerRead();
 
 // these won't exist except on Beken?
 #ifndef LOCK_TCPIP_CORE
-	#define LOCK_TCPIP_CORE()
+#define LOCK_TCPIP_CORE()
 #endif
 
 #ifndef UNLOCK_TCPIP_CORE
-	#define UNLOCK_TCPIP_CORE()
+#define UNLOCK_TCPIP_CORE()
 #endif
 
 /////////////////////////////////////////////////////////////
@@ -540,9 +540,9 @@ char* MQTT_RemoveClientFromTopic(char* topic) {
 	if (*topic != '/') {
 		hasClient = NULL;
 	}
-	
+
 	// If we have the client/, return the pointer, otherwise, return NULL.
-	return hasClient ? topic + 1 : NULL; 
+	return hasClient ? topic + 1 : NULL;
 }
 
 // this accepts obkXXXXXX/<chan>/set to receive data to set channels
@@ -561,7 +561,7 @@ int channelSet(obk_mqtt_request_t* request) {
 	}
 
 	addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "channelSet part topic %s", p);
-	
+
 	// atoi won't parse any non-decimal chars, so it should skip over the rest of the topic.
 	channel = atoi(p);
 
@@ -632,9 +632,9 @@ static void MQTT_disconnect(mqtt_client_t* client)
 	if (!client)
 		return;
 	// this is what it was renamed to.  why?
-    LOCK_TCPIP_CORE();
+	LOCK_TCPIP_CORE();
 	mqtt_disconnect(client);
-    UNLOCK_TCPIP_CORE();
+	UNLOCK_TCPIP_CORE();
 
 }
 
@@ -714,9 +714,9 @@ static OBK_Publish_Result MQTT_PublishTopicToClient(mqtt_client_t* client, const
 			addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "Publishing val (%d bytes) to %s retain=%i\n", sVal_len, pub_topic, retain);
 		}
 
-    	LOCK_TCPIP_CORE();
+		LOCK_TCPIP_CORE();
 		err = mqtt_publish(client, pub_topic, sVal, strlen(sVal), qos, retain, mqtt_pub_request_cb, 0);
-    	UNLOCK_TCPIP_CORE();
+		UNLOCK_TCPIP_CORE();
 		os_free(pub_topic);
 
 		if (err != ERR_OK)
@@ -894,12 +894,12 @@ static void mqtt_connection_cb(mqtt_client_t* client, void* arg, mqtt_connection
 	{
 		addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "mqtt_connection_cb: Successfully connected\n");
 
-    	//LOCK_TCPIP_CORE();
+		//LOCK_TCPIP_CORE();
 		mqtt_set_inpub_callback(mqtt_client,
 			mqtt_incoming_publish_cb,
 			mqtt_incoming_data_cb,
 			LWIP_CONST_CAST(void*, &mqtt_client_info));
-    	//UNLOCK_TCPIP_CORE();
+		//UNLOCK_TCPIP_CORE();
 
 		// subscribe to all callback subscription topics
 		// this makes a BIG assumption that we can subscribe multiple times to the same one?
@@ -924,9 +924,9 @@ static void mqtt_connection_cb(mqtt_client_t* client, void* arg, mqtt_connection
 		clientId = CFG_GetMQTTClientId();
 
 		snprintf(tmp, sizeof(tmp), "%s/connected", clientId);
-    	//LOCK_TCPIP_CORE();
+		//LOCK_TCPIP_CORE();
 		err = mqtt_publish(client, tmp, "online", strlen("online"), 2, true, mqtt_pub_request_cb, 0);
-    	//UNLOCK_TCPIP_CORE();
+		//UNLOCK_TCPIP_CORE();
 		if (err != ERR_OK) {
 			addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "Publish err: %d\n", err);
 			if (err == ERR_CONN) {
@@ -1025,12 +1025,12 @@ static void MQTT_do_connect(mqtt_client_t* client)
 		  to establish a connection with the server.
 		  For now MQTT version 3.1.1 is always used */
 
-    	LOCK_TCPIP_CORE();
+		LOCK_TCPIP_CORE();
 		res = mqtt_client_connect(mqtt_client,
 			&mqtt_ip, mqtt_port,
 			mqtt_connection_cb, LWIP_CONST_CAST(void*, &mqtt_client_info),
 			&mqtt_client_info);
-    	UNLOCK_TCPIP_CORE();
+		UNLOCK_TCPIP_CORE();
 		mqtt_connect_result = res;
 		if (res != ERR_OK)
 		{
@@ -1080,7 +1080,7 @@ OBK_Publish_Result MQTT_ChannelChangeCallback(int channel, int iVal)
 	char channelNameStr[8];
 	char valueStr[16];
 	int flags;
-	
+
 	flags = 0;
 	addLogAdv(LOG_INFO, LOG_FEATURE_MAIN, "Channel has changed! Publishing change %i with %i \n", channel, iVal);
 
@@ -1180,10 +1180,10 @@ void MQTT_Test_Tick(void* param)
 	{
 		while (1)
 		{
-		
-    		LOCK_TCPIP_CORE();
+
+			LOCK_TCPIP_CORE();
 			int res = mqtt_client_is_connected(mqtt_client);
-    		UNLOCK_TCPIP_CORE();
+			UNLOCK_TCPIP_CORE();
 
 			if (res == 0)
 				break;
@@ -1191,9 +1191,9 @@ void MQTT_Test_Tick(void* param)
 			{
 				sprintf(info->value, "TestMSG: %li/%li Time: %i s, Rate: %i msg/s", info->msg_cnt, info->msg_num,
 					(int)info->bench_time, (int)info->bench_rate);
-    			LOCK_TCPIP_CORE();
+				LOCK_TCPIP_CORE();
 				err = mqtt_publish(mqtt_client, info->topic, info->value, strlen(info->value), qos, retain, mqtt_pub_request_cb, 0);
-	    		UNLOCK_TCPIP_CORE();
+				UNLOCK_TCPIP_CORE();
 				if (err == ERR_OK)
 				{
 					/* MSG published */
@@ -1221,9 +1221,9 @@ void MQTT_Test_Tick(void* param)
 					/* Publish report */
 					sprintf(info->value, "Benchmark completed. %li msg published. Total Time: %i s MsgRate: %i msg/s",
 						info->msg_cnt, (int)info->bench_time, (int)info->bench_rate);
-	    			LOCK_TCPIP_CORE();
+					LOCK_TCPIP_CORE();
 					err = mqtt_publish(mqtt_client, info->topic, info->value, strlen(info->value), qos, retain, mqtt_pub_request_cb, 0);
-		    		UNLOCK_TCPIP_CORE();
+					UNLOCK_TCPIP_CORE();
 					if (err == ERR_OK)
 					{
 						/* Report published */
@@ -1450,7 +1450,7 @@ OBK_Publish_Result MQTT_DoItemPublish(int idx)
 	if (CHANNEL_HasRoleThatShouldBePublished(idx)) {
 		bWantsToPublish = true;
 	}
-#ifndef OBK_DISABLE_ALL_DRIVERS
+#ifdef TUYA_SUPPORT
 	// publish if channel is used by TuyaMCU (no pin role set), for example door sensor state with power saving V0 protocol
 	// Not enabled by default, you have to set OBK_FLAG_TUYAMCU_ALWAYSPUBLISHCHANNELS flag
 	if (CFG_HasFlag(OBK_FLAG_TUYAMCU_ALWAYSPUBLISHCHANNELS) && TuyaMCU_IsChannelUsedByTuyaMCU(idx)) {

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -280,6 +280,8 @@ OSStatus rtos_create_thread( beken_thread_t* thread,
 #define os_memset memset
 
 
+#define portTICK_PERIOD_MS portTICK_RATE_MS
+
 #define rtos_delay_milliseconds sys_msleep
 #define delay_ms sys_msleep
 

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -748,7 +748,7 @@ static void Channel_OnChanged(int ch, int prevValue, int iFlags) {
 	iVal = g_channelValues[ch];
 	bOn = iVal > 0;
 
-#if I2C_SUPPORT
+#if ENABLE_I2C
 	I2C_OnChannelChanged(ch,iVal);
 #endif
 
@@ -756,7 +756,7 @@ static void Channel_OnChanged(int ch, int prevValue, int iFlags) {
 	DRV_OnChannelChanged(ch,iVal);
 #endif
 
-#if TUYA_SUPPORT
+#if ENABLE_DRIVER_TUYAMCU
 	TuyaMCU_OnChannelChanged(ch, iVal);
 #endif
 

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -748,11 +748,15 @@ static void Channel_OnChanged(int ch, int prevValue, int iFlags) {
 	iVal = g_channelValues[ch];
 	bOn = iVal > 0;
 
-#ifndef OBK_DISABLE_ALL_DRIVERS
-#if DRV_ENABLE_I2C
+#if I2C_SUPPORT
 	I2C_OnChannelChanged(ch,iVal);
 #endif
+
+#ifndef OBK_DISABLE_ALL_DRIVERS
 	DRV_OnChannelChanged(ch,iVal);
+#endif
+
+#if TUYA_SUPPORT
 	TuyaMCU_OnChannelChanged(ch, iVal);
 #endif
 

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -4,23 +4,53 @@
 #ifndef OBK_CONFIG_H
 #define OBK_CONFIG_H
 
+//Start with all driver flags undefined
+
+#undef BASIC_DRIVER_SUPPORT    //This includes Test drivers, NTP and HttpButton
+#undef LED_DRIVER_SUPPORT      //This includes all LED driver variants
+#undef I2C_SUPPORT
+#undef POWER_BL0937_SUPPORT
+#undef POWER_BL0942_SUPPORT
+#undef POWER_CSE7766_SUPPORT
+#undef TUYA_SUPPORT            //This includes TuyaMCU and tmSensor
+
+
 #if PLATFORM_XR809
 	///#define DEBUG_USE_SIMPLE_LOGGER
-#define OBK_DISABLE_ALL_DRIVERS 1
+#define OBK_DISABLE_ALL_DRIVERS       1
 
-#elif PLATFORM_W600 || PLATFORM_W800
+#elif PLATFORM_W600
 
-#define OBK_DISABLE_ALL_DRIVERS 1
+//Some limited drivers are supported on W600, OBK_DISABLE_ALL_DRIVERS is not defined
+#define BASIC_DRIVER_SUPPORT    1
+#define POWER_BL0937_SUPPORT    1
+
+#elif PLATFORM_W800
+
+#define OBK_DISABLE_ALL_DRIVERS      1
 
 #elif WINDOWS
 
 // comment out to remove littlefs
 #define BK_LITTLEFS
 
+#define BASIC_DRIVER_SUPPORT    1
+#define LED_DRIVER_SUPPORT      1
+#define POWER_BL0937_SUPPORT    1
+#define POWER_BL0942_SUPPORT    1
+#define POWER_CSE7766_SUPPORT   1
+#define TUYA_SUPPORT            1
+
+
 #elif PLATFORM_BL602
 
 // I have enabled drivers on BL602
-
+#define BASIC_DRIVER_SUPPORT    1
+#define LED_DRIVER_SUPPORT      1
+#define POWER_BL0937_SUPPORT    1
+#define POWER_BL0942_SUPPORT    1
+#define POWER_CSE7766_SUPPORT   1
+#define TUYA_SUPPORT            1
 
 #else
 
@@ -30,6 +60,14 @@
 #define BK_LITTLEFS
 
 // add further app wide defined here, and used them to control build inclusion.
+
+#define BASIC_DRIVER_SUPPORT    1
+#define LED_DRIVER_SUPPORT      1
+#define POWER_BL0937_SUPPORT    1
+#define POWER_BL0942_SUPPORT    1
+#define POWER_CSE7766_SUPPORT   1
+#define TUYA_SUPPORT            1
+
 
 #endif
 

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -6,13 +6,13 @@
 
 //Start with all driver flags undefined
 
-#undef BASIC_DRIVER_SUPPORT    //This includes Test drivers, NTP and HttpButton
-#undef LED_DRIVER_SUPPORT      //This includes all LED driver variants
-#undef I2C_SUPPORT
-#undef POWER_BL0937_SUPPORT
-#undef POWER_BL0942_SUPPORT
-#undef POWER_CSE7766_SUPPORT
-#undef TUYA_SUPPORT            //This includes TuyaMCU and tmSensor
+//ENABLE_BASIC_DRIVERS - Enable support for Test drivers, NTP and HttpButton
+//ENABLE_DRIVER_LED - Enable support for all LED drivers
+//ENABLE_I2C - Enable support for I2C
+//ENABLE_DRIVER_BL0937 - Enable support for BL0937
+//ENABLE_DRIVER_BL0942 - Enable support for BL0942
+//ENABLE_DRIVER_CSE7766 - Enable support for CSE7766
+//ENABLE_DRIVER_TUYAMCU - Enable support for TuyaMCU and tmSensor
 
 
 #if PLATFORM_XR809
@@ -22,8 +22,8 @@
 #elif PLATFORM_W600
 
 //Some limited drivers are supported on W600, OBK_DISABLE_ALL_DRIVERS is not defined
-#define BASIC_DRIVER_SUPPORT    1
-#define POWER_BL0937_SUPPORT    1
+#define ENABLE_BASIC_DRIVERS    1
+#define ENABLE_DRIVER_BL0937    1
 
 #elif PLATFORM_W800
 
@@ -34,23 +34,23 @@
 // comment out to remove littlefs
 #define BK_LITTLEFS
 
-#define BASIC_DRIVER_SUPPORT    1
-#define LED_DRIVER_SUPPORT      1
-#define POWER_BL0937_SUPPORT    1
-#define POWER_BL0942_SUPPORT    1
-#define POWER_CSE7766_SUPPORT   1
-#define TUYA_SUPPORT            1
+#define ENABLE_BASIC_DRIVERS    1
+#define ENABLE_DRIVER_LED       1
+#define ENABLE_DRIVER_BL0937    1
+#define ENABLE_DRIVER_BL0942    1
+#define ENABLE_DRIVER_CSE7766   1
+#define ENABLE_DRIVER_TUYAMCU   1
 
 
 #elif PLATFORM_BL602
 
 // I have enabled drivers on BL602
-#define BASIC_DRIVER_SUPPORT    1
-#define LED_DRIVER_SUPPORT      1
-#define POWER_BL0937_SUPPORT    1
-#define POWER_BL0942_SUPPORT    1
-#define POWER_CSE7766_SUPPORT   1
-#define TUYA_SUPPORT            1
+#define ENABLE_BASIC_DRIVERS    1
+#define ENABLE_DRIVER_LED       1
+#define ENABLE_DRIVER_BL0937    1
+#define ENABLE_DRIVER_BL0942    1
+#define ENABLE_DRIVER_CSE7766   1
+#define ENABLE_DRIVER_TUYAMCU   1
 
 #else
 
@@ -61,12 +61,12 @@
 
 // add further app wide defined here, and used them to control build inclusion.
 
-#define BASIC_DRIVER_SUPPORT    1
-#define LED_DRIVER_SUPPORT      1
-#define POWER_BL0937_SUPPORT    1
-#define POWER_BL0942_SUPPORT    1
-#define POWER_CSE7766_SUPPORT   1
-#define TUYA_SUPPORT            1
+#define ENABLE_BASIC_DRIVERS    1
+#define ENABLE_DRIVER_LED       1
+#define ENABLE_DRIVER_BL0937    1
+#define ENABLE_DRIVER_BL0942    1
+#define ENABLE_DRIVER_CSE7766   1
+#define ENABLE_DRIVER_TUYAMCU   1
 
 
 #endif


### PR DESCRIPTION
I redid the merge to avoid white space changes. As the project owner, at some point, you should make a decision to ensure consistent code with the goal of providing a better dev environment. That will promote more input into this project and also make it a joy to develop. The new simulation checks are in that direction. Unfortunately, formatting is a mess .. even on the same line. I tend to use VSCode because I can build directly without jumping into CygWin console and I like to make the code I touch consistent. This has been my experience with other Github project I have worked with.

But I completely understand the review effort for those unintentional formatting changes; I occasionally run into the same while reviewing changes from over enthusiastic developers :-)

====
This provides limited drive support on W600 - NTP, BL0937, HttpButton and TestDrivers.

I don't have BL0937 hardware so I tested this using PWM output from another chip. I can see power/current/voltage outputs but cannot verify their accuracy. So someone else will have to verify the actual functionality.

But I have verified that NTP driver works

I have defined a few controlling variables in `obk_config.h` to control the drivers. Some of that is mess due to inter dependency and I decided to keep changes to existing code limited.

* DRV_ENABLE_I2C has been I2C_SUPPORT; I did not see DRV_ENABLE_I2C being set anywhere.

