### PR TITLE
Added DHT support in W600

### DIFF
--- a/src/driver/drv_dht_internal.c
+++ b/src/driver/drv_dht_internal.c
@@ -24,7 +24,7 @@ our DHT sensors wrapper is in drv_dht.c
 #include "../new_common.h"
 #include "../new_pins.h"
 #include "../new_cfg.h"
-// Commands register, execution API and cmd tokenizer
+ // Commands register, execution API and cmd tokenizer
 #include "../cmnds/cmd_public.h"
 #include "../mqtt/new_mqtt.h"
 #include "../logging/logging.h"
@@ -40,7 +40,7 @@ void usleep2(int r) //delay function do 10*r nops, because rtos_delay_millisecon
 {
 #ifdef WIN32
 	// not possible on Windows port
-#elif PLATFORM_BL602
+#elif PLATFORM_BL602 
 	for (volatile int i = 0; i < r; i++) {
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
@@ -48,6 +48,16 @@ void usleep2(int r) //delay function do 10*r nops, because rtos_delay_millisecon
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
+	}
+#elif PLATFORM_W600
+	for (volatile int i = 0; i < r; i++) {
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
@@ -281,12 +291,12 @@ bool DHT_read(dht_t *dht, bool force) {
 	data[0] = data[1] = data[2] = data[3] = data[4] = 0;
 
 
-	addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "DHT start, pin is %i",(int)dht->_pin);
+	addLogAdv(LOG_INFO, LOG_FEATURE_DHT, "DHT start, pin is %i",(int)dht->_pin);
   // Send start signal.  See DHT datasheet for full signal diagram:
   //   http://www.adafruit.com/datasheets/Digital%20humidity%20and%20temperature%20sensor%20AM2302.pdf
 
   // Go into high impedence state to let pull-up raise data line level and
-  // start the reading process.
+	// start the reading process.
 	HAL_PIN_Setup_Input_Pullup(dht->_pin);
 	delay(1);
 
@@ -327,7 +337,7 @@ bool DHT_read(dht_t *dht, bool force) {
 #ifdef PLATFORM_BEKEN
 			GLOBAL_INT_RESTORE();
 #endif
-			addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "DHT timeout waiting for start signal low pulse.");
+			addLogAdv(LOG_INFO, LOG_FEATURE_DHT, "DHT timeout waiting for start signal low pulse.");
 			dht->_lastresult = false;
 			return dht->_lastresult;
 		}
@@ -335,7 +345,7 @@ bool DHT_read(dht_t *dht, bool force) {
 #ifdef PLATFORM_BEKEN
 			GLOBAL_INT_RESTORE();
 #endif
-			addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "DHT timeout waiting for start signal high pulse.");
+			addLogAdv(LOG_INFO, LOG_FEATURE_DHT, "DHT timeout waiting for start signal high pulse.");
 			dht->_lastresult = false;
 			return dht->_lastresult;
 		}
@@ -363,7 +373,7 @@ bool DHT_read(dht_t *dht, bool force) {
 		uint32_t lowCycles = cycles[2 * i];
 		uint32_t highCycles = cycles[2 * i + 1];
 		if ((lowCycles == TIMEOUT) || (highCycles == TIMEOUT)) {
-			addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "DHT timeout waiting for pulse.");
+			addLogAdv(LOG_INFO, LOG_FEATURE_DHT, "DHT timeout waiting for pulse.");
 			dht->_lastresult = false;
 			return dht->_lastresult;
 		}
@@ -397,7 +407,7 @@ bool DHT_read(dht_t *dht, bool force) {
 		return dht->_lastresult;
 	}
 	else {
-		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "DHT checksum failure!");
+		addLogAdv(LOG_INFO, LOG_FEATURE_DHT, "DHT checksum failure!");
 		dht->_lastresult = false;
 		return dht->_lastresult;
 	}

--- a/src/hal/bk7231/hal_pins_bk7231.c
+++ b/src/hal/bk7231/hal_pins_bk7231.c
@@ -141,3 +141,7 @@ void HAL_PIN_PWM_Update(int index, int value) {
 	bk_pwm_update_param(pwmIndex, period, duty);
 #endif
 }
+
+unsigned int HAL_GetGPIOPin(int index) {
+	return index;
+}

--- a/src/hal/bl602/hal_pins_bl602.c
+++ b/src/hal/bl602/hal_pins_bl602.c
@@ -92,5 +92,8 @@ void HAL_PIN_PWM_Update(int index, int value) {
 
 }
 
+unsigned int HAL_GetGPIOPin(int index) {
+	return index;
+}
 
 #endif

--- a/src/hal/hal_pins.h
+++ b/src/hal/hal_pins.h
@@ -10,4 +10,8 @@ void HAL_PIN_PWM_Start(int index);
 void HAL_PIN_PWM_Update(int index, int value);
 int HAL_PIN_CanThisPinBePWM(int index);
 const char* HAL_PIN_GetPinNameAlias(int index);
+
+/// @brief Get the actual GPIO pin for the pin index.
+/// @param index 
+/// @return 
 unsigned int HAL_GetGPIOPin(int index);

--- a/src/hal/win32/hal_pins_win32.c
+++ b/src/hal/win32/hal_pins_win32.c
@@ -214,7 +214,9 @@ void HAL_PIN_PWM_Update(int index, int value) {
 	g_simulatedPWMs[index] = value;
 }
 
-
+unsigned int HAL_GetGPIOPin(int index) {
+	return index;
+}
 
 #endif
 

--- a/src/hal/xr809/hal_pins_xr809.c
+++ b/src/hal/xr809/hal_pins_xr809.c
@@ -126,7 +126,12 @@ void HAL_PIN_PWM_Update(int index, int value) {
 		value = 100;
 }
 
-
+unsigned int HAL_GetGPIOPin(int index) {
+	int xr_port;
+	int xr_pin;
+	PIN_XR809_GetPortPinForIndex(index, &xr_port, &xr_pin);
+	return xr_pin;
+}
 
 #endif
 

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -82,8 +82,9 @@ typedef enum {
 	LOG_FEATURE_RAW				= 18,
     // add in here - but also in names in logging.c
     LOG_FEATURE_HASS            = 19,
-    LOG_FEATURE_IR		        = 20,
-    LOG_FEATURE_MAX             = 21,
+    LOG_FEATURE_IR              = 20,
+    LOG_FEATURE_DHT             = 21,
+    LOG_FEATURE_MAX             = 22,
 } log_features;
 
 #endif

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -596,7 +596,7 @@ void Main_OnEverySecond()
 	}
 
 	if (bSafeMode == 0) {
-#if defined(PLATFORM_BEKEN) || defined(PLATFORM_BL602)
+#if defined(PLATFORM_BEKEN) || defined(PLATFORM_BL602) || defined(PLATFORM_W600)
 		DHT_OnEverySecond();
 #endif
 	}


### PR DESCRIPTION
My first attempt was to use rising+falling edge interrupts which would avoid the need to continuously poll for pulse detection. But there is seem to no high (micro) resolution timer so was not able to identify the pulse.
Next I attempted to use native `tls_usleep` and `tls_msleep` for delay but that seemed to lock the chip... probably because the timer might be used elsewhere.
So finally fell back to adjusting the nop delay to suit W600.

![image](https://user-images.githubusercontent.com/6459774/210154868-f06b28a3-66a6-4655-be16-dda86322ec59.png)


The DHT source files are included in https://github.com/openshwprojects/OpenW600/pull/3 and has to be merged first. Please don't forget to update the submodules after that.