### PR TITLE
Return supportsSSDP

### DIFF
--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -39,6 +39,9 @@ extern UINT32 flash_read(char* user_buf, UINT32 count, UINT32 address);
 // Commands register, execution API and cmd tokenizer
 #include "../cmnds/cmd_public.h"
 
+#ifndef OBK_DISABLE_ALL_DRIVERS
+#include "../driver/drv_local.h"
+#endif
 
 #define MAX_JSON_VALUE_LENGTH   128
 

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -759,6 +759,13 @@ static int http_rest_get_info(http_request_t* request) {
 	hprintf255(request, "\"mqtttopic\":\"%s\",", CFG_GetMQTTClientId());
 	hprintf255(request, "\"chipset\":\"%s\",", PLATFORM_MCU_NAME);
 	hprintf255(request, "\"webapp\":\"%s\",", CFG_GetWebappRoot());
+
+#ifndef OBK_DISABLE_ALL_DRIVERS
+	hprintf255(request, "\"supportsSSDP\":%d,", DRV_IsRunning("SSDP") ? 1 : 0);
+#else
+	hprintf255(request, "\"supportsSSDP\":0,");
+#endif
+
 	hprintf255(request, "\"supportsClientDeviceDB\":true}");
 
 	poststr(request, NULL);


### PR DESCRIPTION
Currently, webApp logs error if the chip is on older firmware or if the chip not supporting SSDP or if SSDP is not running.

![image](https://user-images.githubusercontent.com/6459774/210226821-a9b87c39-3879-4db3-b393-f0a35584203a.png)

This is because the webApp calls the end point `obkdevicelist` which is absent. We can handle this more gracefully in webApp by checking if the chip is currently supporting SSDP and that is what this PR does.

WebApp PR: https://github.com/OpenBekenIOT/webapp/pull/34

