### PR TITLE
Add support for binary sensor (digital input) in Home Assistant discovery

### DIFF
--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -244,6 +244,18 @@ HassDeviceInfo* hass_init_light_device_info(ENTITY_TYPE type) {
 	return info;
 }
 
+/// @brief Initializes HomeAssistant binary sensor device discovery storage.
+/// @param index
+/// @return
+HassDeviceInfo* hass_init_binary_sensor_device_info(int index) {
+	HassDeviceInfo* info = hass_init_device_info(ENTITY_BINARY_SENSOR, index, "1", "0");
+
+	sprintf(g_hassBuffer, "~/%i/get", index);
+	cJSON_AddStringToObject(info->root, STATE_TOPIC_KEY, g_hassBuffer);   //state_topic
+
+	return info;
+}
+
 #ifndef OBK_DISABLE_ALL_DRIVERS
 
 /// @brief Initializes HomeAssistant sensor device discovery storage.
@@ -278,18 +290,6 @@ HassDeviceInfo* hass_init_sensor_device_info(int index) {
 		sprintf(g_hassBuffer, "~/%s/get", counter_mqttNames[index - OBK_CONSUMPTION_TOTAL]);
 		cJSON_AddStringToObject(info->root, STATE_TOPIC_KEY, g_hassBuffer);
 	}
-
-	return info;
-}
-
-/// @brief Initializes HomeAssistant binary sensor device discovery storage.
-/// @param index
-/// @return
-HassDeviceInfo* hass_init_binary_sensor_device_info(int index) {
-	HassDeviceInfo* info = hass_init_device_info(ENTITY_BINARY_SENSOR, index, "1", "0");
-
-	sprintf(g_hassBuffer, "~/%i/get", index);
-	cJSON_AddStringToObject(info->root, STATE_TOPIC_KEY, g_hassBuffer);   //state_topic
 
 	return info;
 }

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -46,6 +46,10 @@ void hass_populate_unique_id(ENTITY_TYPE type, int index, char* uniq_id) {
 	case ENTITY_SENSOR:
 		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "sensor", index);
 		break;
+
+	case ENTITY_BINARY_SENSOR:
+		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "binary_sensor", index);
+		break;
 	}
 }
 
@@ -80,6 +84,9 @@ void hass_populate_device_config_channel(ENTITY_TYPE type, char* uniq_id, HassDe
 	case ENTITY_SENSOR:
 		sprintf(info->channel, "sensor/%s/config", uniq_id);
 		break;
+
+	case ENTITY_BINARY_SENSOR:
+		sprintf(info->channel, "binary_sensor/%s/config", uniq_id);
 	}
 }
 
@@ -128,6 +135,7 @@ HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, char* payload
 	switch (type) {
 	case ENTITY_LIGHT_PWM:
 	case ENTITY_RELAY:
+	case ENTITY_BINARY_SENSOR:
 		sprintf(g_hassBuffer, "%s %i", CFG_GetShortDeviceName(), index);
 		break;
 	case ENTITY_LIGHT_PWMCW:
@@ -270,6 +278,18 @@ HassDeviceInfo* hass_init_sensor_device_info(int index) {
 		sprintf(g_hassBuffer, "~/%s/get", counter_mqttNames[index - OBK_CONSUMPTION_TOTAL]);
 		cJSON_AddStringToObject(info->root, STATE_TOPIC_KEY, g_hassBuffer);
 	}
+
+	return info;
+}
+
+/// @brief Initializes HomeAssistant binary sensor device discovery storage.
+/// @param index
+/// @return
+HassDeviceInfo* hass_init_binary_sensor_device_info(int index) {
+	HassDeviceInfo* info = hass_init_device_info(ENTITY_BINARY_SENSOR, index, "1", "0");
+
+	sprintf(g_hassBuffer, "~/%i/get", index);
+	cJSON_AddStringToObject(info->root, STATE_TOPIC_KEY, g_hassBuffer);   //state_topic
 
 	return info;
 }

--- a/src/httpserver/hass.h
+++ b/src/httpserver/hass.h
@@ -53,5 +53,6 @@ void hass_print_unique_id(http_request_t* request, const char* fmt, ENTITY_TYPE 
 HassDeviceInfo* hass_init_relay_device_info(int index);
 HassDeviceInfo* hass_init_light_device_info(ENTITY_TYPE type);
 HassDeviceInfo* hass_init_sensor_device_info(int index);
+HassDeviceInfo* hass_init_binary_sensor_device_info(int index);
 char* hass_build_discovery_json(HassDeviceInfo* info);
 void hass_free_device_info(HassDeviceInfo* info);

--- a/src/httpserver/hass.h
+++ b/src/httpserver/hass.h
@@ -21,7 +21,10 @@ typedef enum {
 	ENTITY_LIGHT_RGBCW,
 
 	/// @brief Sensor (voltage, current, power)
-	ENTITY_SENSOR
+	ENTITY_SENSOR,
+
+	/// @Brief Binary Sensor
+	ENTITY_BINARY_SENSOR
 } ENTITY_TYPE;
 
 //unique_id is defined in hass_populate_unique_id and is based on CFG_GetDeviceName() whose size is CGF_DEVICE_NAME_SIZE.

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -1618,6 +1618,21 @@ int h_isChannelRelay(int tg_ch) {
     }
 	return false;
 }
+int h_isChannelDigitalInput(int tg_ch) {
+    int i;
+	int role;
+
+    for(i = 0; i < PLATFORM_GPIO_MAX; i++) {
+        int ch = PIN_GetPinChannelForPinIndex(i);
+		if(tg_ch != ch)
+			continue;
+        role = PIN_GetPinRoleForPinIndex(i);
+        if(role == IOR_DigitalInput || role == IOR_DigitalInput_n || role == IOR_DigitalInput_NoPup || role == IOR_DigitalInput_NoPup_n) {
+			return true;
+        }
+    }
+	return false;
+}
 static commandResult_t showgpi(const void *context, const char *cmd, const char *args, int cmdFlags){
 	int i;
 	unsigned int value = 0;

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -348,6 +348,7 @@ int CHANNEL_FindMaxValueForChannel(int ch);
 
 int h_isChannelPWM(int tg_ch);
 int h_isChannelRelay(int tg_ch);
+int h_isChannelDigitalInput(int tg_ch);
 
 
 //int PIN_GetPWMIndexForPinIndex(int pin);


### PR DESCRIPTION
This change was motivated by a door/window sensor from Tuya, where I had to manually publish the discovery payload for the sensor (after converting to OpenBK) otherwise HASS would report the sensor as unavailable after a reboot or integration reload.

I had to change `get_Relay_PWM_Count`, and I found out it is also used by a Tasmota-related function, but that remains to be done as I have no idea how it would work to report or configure a binary sensor for Tasmota.