### PR TITLE
Added POWERSAVE status message

### DIFF
--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -31,14 +31,17 @@ static int generateHashValue(const char *fname) {
 }
 
 command_t *g_commands[HASH_SIZE] = { NULL };
+bool g_powersave;
 
 static commandResult_t CMD_PowerSave(const void* context, const char* cmd, const char* args, int cmdFlags) {
 	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_PowerSave: enable power save");
 #ifdef PLATFORM_BEKEN
 	extern int bk_wlan_power_save_set_level(BK_PS_LEVEL level);
     bk_wlan_power_save_set_level(/*PS_DEEP_SLEEP_BIT */  PS_RF_SLEEP_BIT | PS_MCU_SLEEP_BIT);	
+	g_powersave = true;
 #elif defined(PLATFORM_W600)
 	tls_wifi_set_psflag(1, 0);	//Enable powersave but don't save to flash
+	g_powersave = true;
 #endif
 
 	return CMD_RES_OK;

--- a/src/cmnds/cmd_public.h
+++ b/src/cmnds/cmd_public.h
@@ -28,6 +28,7 @@ typedef commandResult_t (*commandHandler_t)(const void* context, const char* cmd
 // command was sent by TCP CMD
 #define COMMAND_FLAG_SOURCE_IR			32
 
+extern bool g_powersave;
 
 //
 void CMD_Init_Early();

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -453,9 +453,10 @@ void Main_OnEverySecond()
 		//int mqtt_max, mqtt_cur, mqtt_mem;
 		//MQTT_GetStats(&mqtt_cur, &mqtt_max, &mqtt_mem);
 	    //ADDLOGF_INFO("mqtt req %i/%i, free mem %i\n", mqtt_cur,mqtt_max,mqtt_mem);
-		ADDLOGF_INFO("%sTime %i, idle %i/s, free %d, MQTT %i(%i), bWifi %i, secondsWithNoPing %i, socks %i/%i\n",
+		ADDLOGF_INFO("%sTime %i, idle %i/s, free %d, MQTT %i(%i), bWifi %i, secondsWithNoPing %i, socks %i/%i %s\n",
 			safe, g_secondsElapsed, idleCount, xPortGetFreeHeapSize(),bMQTTconnected, MQTT_GetConnectEvents(), 
-            g_bHasWiFiConnected, g_timeSinceLastPingReply, LWIP_GetActiveSockets(), LWIP_GetMaxSockets());
+			g_bHasWiFiConnected, g_timeSinceLastPingReply, LWIP_GetActiveSockets(), LWIP_GetMaxSockets(),
+			g_powersave ? "POWERSAVE" : "");
 		// reset so it's a per-second counter.
 		idleCount = 0;
 	}


### PR DESCRIPTION
While (test) powersave can be enabled via command, it is currently difficult to know if a device is in that mode. This PR appends the status to the status message.