### PR TITLE
allow storage of WPA2 PSK as hexadecimal string

### DIFF
--- a/src/new_cfg.c
+++ b/src/new_cfg.c
@@ -285,7 +285,11 @@ const char *CFG_GetWiFiSSID(){
 	return g_cfg.wifi_ssid;
 }
 const char *CFG_GetWiFiPass(){
-	return g_cfg.wifi_pass;
+	static char wifi_pass[sizeof(g_cfg.wifi_pass) + 1];
+
+	memcpy(wifi_pass, g_cfg.wifi_pass, sizeof(g_cfg.wifi_pass));
+	wifi_pass[sizeof(g_cfg.wifi_pass)] = 0;
+	return wifi_pass;
 }
 void CFG_SetWiFiSSID(const char *s) {
 	// this will return non-zero if there were any changes
@@ -295,8 +299,13 @@ void CFG_SetWiFiSSID(const char *s) {
 	}
 }
 void CFG_SetWiFiPass(const char *s) {
-	// this will return non-zero if there were any changes
-	if(strcpy_safe_checkForChanges(g_cfg.wifi_pass, s,sizeof(g_cfg.wifi_pass))) {
+	uint32_t len;
+
+	len = strlen(s) + 1;
+	if(len > sizeof(g_cfg.wifi_pass))
+		len = sizeof(g_cfg.wifi_pass);
+	if(memcmp(g_cfg.wifi_pass, s, len)) {
+		memcpy(g_cfg.wifi_pass, s, len);
 		// mark as dirty (value has changed)
 		g_cfg_pendingChanges++;
 	}


### PR DESCRIPTION
This is the main part of the fix for #553. It uses a separate statically allocated buffer for the key that is one byte larger than array in the on-flash config structure and places a terminating null byte at the end.

I have to admit that I don't know why there are os_* functions, but I guess they are supposed to be used since they exist.

This change depends on openshwprojects/OpenBK7231N#13 and openshwprojects/OpenBK7231T#18.
For BL602 the psk element in struct wifi_mgmr_connect_ind_stat_info is already 65 bytes long.
For XR809 the Doxygen comment of wlan_sta_set says that 64 digit hexadecimal keys are supported.
For W800 and W600 the disassembly of tls_wifi_connect shows that the function exits early if the key length is >= 65, so I assume 64 is ok.