### PR TITLE
Win32 app / optional port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ output/**
 .vscode
 node_modules
 Debug*/**
+libs_for_simulator/**

--- a/openBeken_win32_mvsc2017.vcxproj
+++ b/openBeken_win32_mvsc2017.vcxproj
@@ -83,6 +83,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
+	<TargetName>openBeken_win32</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug BL602|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
@@ -91,6 +92,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Win32|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
+	<TargetName>openBeken_win32</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Win32 ScriptOnly|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>

--- a/src/httpserver/http_tcp_server_nonblocking.c
+++ b/src/httpserver/http_tcp_server_nonblocking.c
@@ -10,7 +10,7 @@
 
  SOCKET ListenSocket = INVALID_SOCKET;
 
-#define DEFAULT_PORT "80"
+int g_port = 80;
 
 int HTTPServer_Start() {
 
@@ -29,7 +29,10 @@ int HTTPServer_Start() {
 		closesocket(ListenSocket);
 	}
     // Resolve the server address and port
-    iResult = getaddrinfo(NULL, DEFAULT_PORT, &hints, &result);
+	char service[6];
+	snprintf(service, sizeof(service), "%u", g_port);
+
+	iResult = getaddrinfo(NULL, service, &hints, &result);
     if ( iResult != 0 ) {
         printf("getaddrinfo failed with error: %d\n", iResult);
         WSACleanup();

--- a/src/sim/Simulator.cpp
+++ b/src/sim/Simulator.cpp
@@ -324,9 +324,9 @@ bool CSimulator::saveSimulationAs(const char *s) {
 void CSimulator::showExitSaveMessageBox() {
 	const SDL_MessageBoxButtonData buttons[] =
 	{
+		{SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 2, "Cancel"},
 		{ /* .flags, .buttonid, .text */        0, 0, "No" },
-		{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes" },
-		{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 2, "Cancel" },
+		{SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes"}
 	};
 	const SDL_MessageBoxColorScheme colorScheme =
 	{

--- a/src/sim/Simulator.cpp
+++ b/src/sim/Simulator.cpp
@@ -438,5 +438,11 @@ void CSimulator::onKeyDown(int keyCode) {
 	}
 }
 
+void CSimulator::loadRecentProject() {
+	if (recents->size() > 0) {
+		loadSimulation(recents->get(0));
+	}
+}
+
 
 #endif

--- a/src/sim/Simulator.h
+++ b/src/sim/Simulator.h
@@ -66,6 +66,11 @@ public:
 			return true;
 		return false;
 	}
+
+	/// <summary>
+	/// Load the last project.
+	/// </summary>
+	void loadRecentProject();
 };
 
 #endif

--- a/src/sim/sim_sdl.cpp
+++ b/src/sim/sim_sdl.cpp
@@ -179,6 +179,7 @@ extern "C" int SIM_CreateWindow(int argc, char **argv)
 	glutInit(&argc, argv);
 	sim = new CSimulator();
 	sim->createWindow();
+	sim->loadRecentProject();
 	return 0;
 }
 extern "C" void SIM_RunWindow() {

--- a/src/win_main.c
+++ b/src/win_main.c
@@ -27,6 +27,7 @@ int accum_time = 0;
 int win_frameNum = 0;
 // this time counter is simulated, I need this for unit tests to work
 int g_simulatedTimeNow = 0;
+extern int g_port;
 #define DEFAULT_FRAME_TIME 5
 
 
@@ -181,6 +182,15 @@ int g_bDoingUnitTestsNow = 0;
 #include "sim/sim_public.h"
 int __cdecl main(int argc, char **argv)
 {
+	if (argc == 2) {
+		if (strncmp(argv[1], "port=", 5) == 0) {
+			int port;
+			if (sscanf(argv[1] + 5, "%d", &port) == 1) {
+				g_port = port;
+			}
+		}
+	}
+
 	bool bWantsUnitTests = 1;
     WSADATA wsaData;
     int iResult;

--- a/src/win_main.c
+++ b/src/win_main.c
@@ -182,16 +182,30 @@ int g_bDoingUnitTestsNow = 0;
 #include "sim/sim_public.h"
 int __cdecl main(int argc, char **argv)
 {
-	if (argc == 2) {
-		if (strncmp(argv[1], "port=", 5) == 0) {
-			int port;
-			if (sscanf(argv[1] + 5, "%d", &port) == 1) {
-				g_port = port;
+	bool bWantsUnitTests = true;
+
+	if (argc > 1) {
+		int value;
+
+		for (int i = 1; i < argc; i++) {
+			if (argv[i][0] == '-') {
+				if (wal_strnicmp(argv[i] + 1, "port", 4) == 0) {
+					i++;
+
+					if (i < argc && sscanf(argv[i], "%d", &value) == 1) {
+						g_port = value;
+					}
+				} else if (wal_strnicmp(argv[i] + 1, "runUnitTests", 12) == 0) {
+					i++;
+
+					if (i < argc && sscanf(argv[i], "%d", &value) == 1) {
+						bWantsUnitTests = value != 0;
+					}
+				}
 			}
 		}
 	}
 
-	bool bWantsUnitTests = 1;
     WSADATA wsaData;
     int iResult;
 


### PR DESCRIPTION
By default the Win32 app runs on port 80 but it could be that 80 was already taken. I added an option to define `port=8080` in debugger command line options. The debugger command line options get saved into `openBeken_win32_mvsc2017.vcxproj.user` which should not be included in the repo. The argv params do get passed down to `glutInit` but I don't think that part should be impacted since we did not have any command line params to start with.

Also fixed the order of buttons which appear when Simulator is shutdown to be Yes/No/Cancel instead of Cancel/Yes/No.