### PR TITLE
Add OffDimBright channel type for LED indicator brightness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Some channels have "_div10" or "_div100" sufixes. This is for TuyaMCU. This is n
 | Voltage_div10 | Divide by 10 and display value as a V voltage. | TODO |
 | Current_div100 | Divide by 100 and display value as a A current. | TODO |
 | Current_div1000 | Divide by 1000 and display value as a A current. | TODO |
+| OffDimBright | 3 options - Off (0), Dim (1), Bright (2). Used for TuyaMCU LED indicator. | TODO |
   
 # Simple TCP command server for scripting
   

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -653,6 +653,25 @@ int http_fn_index(http_request_t* request) {
 			hprintf255(request, "<input type=\"submit\" class='disp-none' value=\"Toggle %s\"/></form>", CHANNEL_GetLabel(i));
 			poststr(request, "</td></tr>");
 		}
+		else if (channelType == ChType_OffDimBright) {
+			const char* types[] = { "Off","Dim","Bright" };
+			iValue = CHANNEL_Get(i);
+
+			poststr(request, "<tr><td>");
+			hprintf255(request, "<p>Select level:</p><form action=\"index\">");
+			hprintf255(request, "<input type=\"hidden\" name=\"setIndex\" value=\"%i\">", i);
+			for (j = 0; j < 3; j++) {
+				const char* check;
+				if (j == iValue)
+					check = "checked";
+				else
+					check = "";
+				hprintf255(request, "<input type=\"radio\" name=\"set\" value=\"%i\" onchange=\"this.form.submit()\" %s>%s", j, check, types[j]);
+			}
+			hprintf255(request, "</form>");
+			poststr(request, "</td></tr>");
+
+		}
 	}
 
 	if (bRawPWMs == 0 || bForceShowRGBCW || bForceShowRGB) {

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -1532,6 +1532,8 @@ int CHANNEL_ParseChannelType(const char *s) {
 		return ChType_OpenClosed_Inv;
 	if (!stricmp(s, "BatteryLevelPercent"))
 		return ChType_BatteryLevelPercent;
+	if (!stricmp(s, "OffDimBright"))
+		return ChType_OffDimBright;
 	return ChType_Error;
 }
 static commandResult_t CMD_setButtonHoldRepeat(const void *context, const char *cmd, const char *args, int cmdFlags){

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -130,6 +130,7 @@ typedef enum {
 	ChType_OpenClosed,
 	ChType_OpenClosed_Inv,
 	ChType_BatteryLevelPercent,
+	ChType_OffDimBright,
 
 } ChannelType;
 


### PR DESCRIPTION
I have a [Feit Smart Dimmer](https://www.elektroda.com/rtvforum/topic3949246.html) which has a LED indicator on the front. Its brightness level in controllable. Options are off, dim, and bright. I have added a channel type to support this.