### PR TITLE
Improved LED Smooth Transition function

### DIFF
--- a/src/user_main.c
+++ b/src/user_main.c
@@ -1164,4 +1164,3 @@ void Main_Init()
 
 }
 
-


### PR DESCRIPTION
With the introduction of LED gamma correction and calibration the smooth transition function got some new issues. This PR corrects these issues and generally improves transitions. To get it working the lerp function is now applied on the channel values prior to brightness and gamma correction, and separately on channel and brightness values. Brightness also implements soft start and stop lerp for even smoother operation.

The lerp function was previously implemented in a separate function that was very similar to the apply_smart_light() function - this is now merged into a single function, which should make it easier to maintain and add new features. I have tested the code in the different PWM operation modes, but don't have any LED's with external PWM chips so this is only tested by simulation.

I also disabled the MQTT Log messages by default. When the messages are enabled the LED transitions can get quite choppy. The root cause of the problem is that the log message UART code is blocking the OS while sending the message - this is a separate issue which should also be looked into. The UART messages can also be disabled with the "logtype none" command. Maybe all the UART Log Messages can be disabled after Boot Complete?