### PR TITLE
Remove oneshotconfig

### DIFF
--- a/src/hal/w800/hal_wifi_w800.c
+++ b/src/hal/w800/hal_wifi_w800.c
@@ -156,7 +156,10 @@ static int connect_wifi_demo(char* ssid, char* pwd)
 
 	tls_wifi_disconnect();
 	tls_wifi_softap_destroy();
+
+	#if defined(PLATFORM_W800)
 	tls_wifi_set_oneshot_flag(0);
+	#endif
 
 	tls_param_get(TLS_PARAM_ID_WPROTOCOL, (void*)&wireless_protocol, TRUE);
 	if (TLS_PARAM_IEEE80211_INFRA != wireless_protocol)
@@ -255,7 +258,9 @@ int demo_create_softap(u8* ssid, u8* key, int chan, int encrypt, int format)
 		tls_param_set(TLS_PARAM_ID_WPROTOCOL, (void*)&wireless_protocol, FALSE);
 	}
 
+	#if defined(PLATFORM_W800)
 	tls_wifi_set_oneshot_flag(0); /*disable oneshot*/
+	#endif
 
 	tls_param_get(TLS_PARAM_ID_BRDSSID, (void*)&ssid_set, (bool)0);
 	if (0 == ssid_set)


### PR DESCRIPTION
This goes with this PR (https://github.com/openshwprojects/OpenW600/pull/6) to not use oneshotconfig at all.

We are not seeing OTA issues in W800 so I decided to keep the overall changes limited to W600.