### PR TITLE
Added a Dockerized build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ output/**
 node_modules
 Debug*/**
 libs_for_simulator/**
+
+# MacOS ignores
+.DS_Store
+

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,6 +14,7 @@ You would need `nodejs` if you plan on making JavaScript/styling changes. This i
 Gulp tasks should automatically appear in Explore pane in Visual Code. They can also be invoked from console by running `gulp`.
 
 # Building
+A Docker-ized build environment can be used to perform these builds. Instructions for doing so are [available here](./docker/README.md).
 
 ## Building for BK7231T
 

--- a/docker/Dockerfile.BK7231x_build_env
+++ b/docker/Dockerfile.BK7231x_build_env
@@ -6,11 +6,7 @@ ARG USERNAME=devuser
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y \
-                wget git python2 libc6-i386 \
+                wget git python3 python-is-python3 libc6-i386 \
                 make npm
-
-# build files expect "python", but it gets installed as "python2".
-# create symbolic link to fix this.
-RUN ln -s /usr/bin/python2 /usr/bin/python
 
 RUN useradd -m -s /bin/bash ${USERNAME}

--- a/docker/Dockerfile.build_env
+++ b/docker/Dockerfile.build_env
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG USERNAME=devuser
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+                wget git python2 libc6-i386 \
+                make npm
+
+# build files expect "python", but it gets installed as "python2".
+# create symbolic link to fix this.
+RUN ln -s /usr/bin/python2 /usr/bin/python
+
+RUN useradd -m -s /bin/bash ${USERNAME}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,21 +1,23 @@
 # Docker Files for OpenBK7231T_App
 
-## Build Environment
-The `Dockerfile.build_env` file can be used to create a consistent Linux-based environment for building OpenBK7231T_App. This allows you to build OpenBK7231T_App on any flavor of Linux and MacOS. This should also work on Windows, but is untested.
+## Build Environment for BK7231T and BK7231N
+The `Dockerfile.BK7231x_build_env` file can be used to create a consistent Linux-based environment for building OpenBK7231T_App for the `BK7231T` and `BK7231N` platforms. This allows you to build OpenBK7231T_App on any flavor of Linux and MacOS. This should also work on Windows, but is untested.
 
 To build the image, run from within this directory:
 ```sh
-docker build -t openbk7231t_build --build-arg USERNAME=$USER -f Dockerfile.build_env .
+docker build -t openbk7231x_build --build-arg USERNAME=$USER -f Dockerfile.BK7231x_build_env .
 ```
 
-The `cd` to the root of the OpenBK7231T SDK repo that has been set up [as described in the build instructions](https://github.com/michaelkamprath/OpenBK7231T_App/blob/main/BUILDING.md#building-for-bk7231t), and then start a shell prompt in the built Docker image, that binds the SDK repo as a volume in the Docker image:
+The `cd` to the root of the `OpenBK7231T` or `OpenBK7231N` SDK repo that has been set up [as described in the build instructions](https://github.com/michaelkamprath/OpenBK7231T_App/blob/main/BUILDING.md), and then start a shell prompt in the built Docker image, that binds the SDK repo as a volume in the Docker image:
 
 ```sh
-docker run -it -v "$(pwd)/":/home/$USER/OpenBK7231T --user $USER  openbk7231t_build /bin/bash
+docker run -it -v "$(pwd)/":/home/$USER/OpenBK7231T --user $USER  openbk7231x_build /bin/bash
 ```
+Change the `OpenBK7231T` directory name in the volume mount to `OpenBK7231N` if you are building for the `OpenBK7231N` platform.
+
 Finally, at the Docker image's shell prompt, execute the following to build:
 ```sh
 cd ~/OpenBK7231T/
 ./b.sh
 ```
-The last command may be changed to the advanced build's `build_app.sh` command as described in [the build instructions](https://github.com/michaelkamprath/OpenBK7231T_App/blob/main/BUILDING.md#building-for-bk7231t). The build results will be placed into the host computer's file system as described in the build instructions. To exit the Docker image's shell prompt when the build is done, use the `exit` command.
+Again, change the `OpenBK7231T` directory name to `OpenBK7231N` if you are building for that platform. Also, the last command may be changed to the advanced build's `build_app.sh` command as described in [the build instructions](https://github.com/michaelkamprath/OpenBK7231T_App/blob/main/BUILDING.md#building-for-bk7231t). The build results will be placed into the host computer's file system as described in the build instructions. To exit the Docker image's shell prompt when the build is done, use the `exit` command.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Files for OpenBK7231T_App
+
+## Build Environment
+The `Dockerfile.build_env` file can be used to create a consistent Linux-based environment for building OpenBK7231T_App. This allows you to build OpenBK7231T_App on any flavor of Linux and MacOS. This should also work on Windows, but is untested.
+
+To build the image, run from within this directory:
+```sh
+docker build -t openbk7231t_build --build-arg USERNAME=$USER -f Dockerfile.build_env .
+```
+
+The `cd` to the root of the OpenBK7231T SDK repo that has been set up [as described in the build instructions](https://github.com/michaelkamprath/OpenBK7231T_App/blob/main/BUILDING.md#building-for-bk7231t), and then start a shell prompt in the built Docker image, that binds the SDK repo as a volume in the Docker image:
+
+```sh
+docker run -it -v "$(pwd)/":/home/$USER/OpenBK7231T --user $USER  openbk7231t_build /bin/bash
+```
+Finally, at the Docker image's shell prompt, execute the following to build:
+```sh
+cd ~/OpenBK7231T/
+./b.sh
+```
+The last command may be changed to the advanced build's `build_app.sh` command as described in [the build instructions](https://github.com/michaelkamprath/OpenBK7231T_App/blob/main/BUILDING.md#building-for-bk7231t). The build results will be placed into the host computer's file system as described in the build instructions. To exit the Docker image's shell prompt when the build is done, use the `exit` command.


### PR DESCRIPTION
I wanted to build OpenBK7231T for my Mac, but the current build process doesn't support that. So I created this Dockerized build environment and documented the process for using it to build. This approach would be useful on all platforms including Windows and Linux to ensure that the build environment is consistent.