### PR TITLE
Clarification text for the pin mapping configuration.

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2079,9 +2079,9 @@ int http_fn_cfg_pins(http_request_t* request) {
 
 	http_setup(request, httpMimeTypeHTML);
 	http_html_start(request, "Pin config");
-	poststr(request, "<p>The first textfield is used to enter channel index (relay index), used to support multiple relays and buttons. ");
+	poststr(request, "<p>The first field assigns a role to the given pin. The next field is used to enter channel index (relay index), used to support multiple relays and buttons. ");
 	poststr(request, "So, first button and first relay should have channel 1, second button and second relay have channel 2, etc.</p>");
-	poststr(request, "<p>The second textfield (only for buttons) is used to enter channel to toggle when doing double click. ");
+	poststr(request, "<p>Only for button roles another field will be provided to enter channel to toggle when doing double click. ");
 	poststr(request, "It shows up when you change role to button and save.</p>");
 #if PLATFORM_BK7231N || PLATFORM_BK7231T
 	poststr(request, "<p>BK7231N/BK7231T supports PWM only on pins 6, 7, 8, 9, 24 and 26!</p>");


### PR DESCRIPTION
As a first time user I found the help text somewhat confusing. This is a suggestion to clarify things a bit.
* Dropped the reference to "textfield" as this is implementation specific. One day it could be one of those numeric up/down spinner controls. And I am not sure one can enter text value when index is expected to be numeric. Unless there's support to enter variables...
* Added a reference to the dropdown field, as this is what I see as "the first" field one needs to set. And it is a text value. The previous reference "first textfield" was actually referring to the second numeric field.

It would also be nice to link "role" to a documentation about what all these values mean. I could not find one. I don't know most of them and how are they used. I just took a guess.

tjk :)