### PR TITLE
Changing behaviour of battery driver

### DIFF
--- a/src/driver/drv_battery.c
+++ b/src/driver/drv_battery.c
@@ -15,16 +15,16 @@
 
 static int g_pin_adc = 0, channel_adc = 0, channel_rel = 0, g_pin_rel = 0, g_battcycle = 1, g_battcycleref = 10;
 static float g_battvoltage = 0.0, g_battlevel = 0.0;
-static float g_vref = 2400, g_vdivider = 2.00, g_maxbatt = 3000, g_minbatt = 2000, g_adcbits = 4096;
+static float g_vref = 2400, g_vdivider = 2.29, g_maxbatt = 3000, g_minbatt = 2000, g_adcbits = 4096;
 
 static void Batt_Measure() {
 	//this command has only been tested on CBU
 	float batt_ref, batt_res, vref;
 	ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY : Measure Battery volt en perc");
-	g_pin_adc = PIN_FindPinIndexForRole(IOR_ADC, g_pin_adc);
+	g_pin_adc = PIN_FindPinIndexForRole(IOR_BAT_ADC, g_pin_adc);
 	// if divider equal to 1 then no need for relay activation
 	if (g_vdivider > 1) {
-		g_pin_rel = PIN_FindPinIndexForRole(IOR_Relay, g_pin_rel);
+		g_pin_rel = PIN_FindPinIndexForRole(IOR_BAT_Relay, g_pin_rel);
 		channel_rel = g_cfg.pins.channels[g_pin_rel];
 	}
 	HAL_ADC_Init(g_pin_adc);

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -408,7 +408,7 @@ const char* htmlPinRoleNames[] = {
 	"SM2135CLK",
 	"BP5758D_DAT",
 	"BP5758D_CLK",
-    "BP1658CJ_DAT",
+	"BP1658CJ_DAT",
 	"BP1658CJ_CLK",
 	"PWM_n",
 	"IRRecv",
@@ -437,18 +437,18 @@ const char* htmlPinRoleNames[] = {
 	"SoftSCL",
 	"SM2235DAT",
 	"SM2235CLK",
-    "BridgeFWD",
-    "BridgeREV",
-    "Btn_SmartLED",
+	"BridgeFWD",
+	"BridgeREV",
+	"Btn_SmartLED",
 	"Btn_SmartLED_n",
 	"DoorSnsrWSleep",
 	"DoorSnsrWSleep_nPup",
-	"error",
-	"error",
+	"BAT_ADC",
+	"BAT_Relay",
 	"error",
 };
 
-const char *PIN_RoleToString(int role) {
+const char* PIN_RoleToString(int role) {
 	return htmlPinRoleNames[role];
 }
 int PIN_ParsePinRoleName(const char* name) {

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -94,6 +94,9 @@ enum IORole {
 	IOR_DoorSensorWithDeepSleep,
 	IOR_DoorSensorWithDeepSleep_NoPup,
 
+	IOR_BAT_ADC,
+	IOR_BAT_Relay,
+
 	IOR_Total_Options,
 };
 

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -925,6 +925,11 @@ void Main_Init_BeforeDelay_Unsafe(bool bAutoRunScripts) {
 				DRV_StartDriver("SHT3X");
 #endif
 			}
+			if (PIN_FindPinIndexForRole(IOR_BAT_ADC, -1) != -1 && PIN_FindPinIndexForRole(IOR_BAT_Relay, -1) != -1) {
+#ifndef OBK_DISABLE_ALL_DRIVERS
+				DRV_StartDriver("Battery");
+#endif
+			}
 		}
 	}
 


### PR DESCRIPTION
 To provide Zero configuration for End User :
  - 2 new pins BAT_ADC and BAT_Relay
  - Autostart of driver if pins associated
  - change vdivider default value to 2.29 Seems like default for 2AA battery sensor