### PR TITLE
Fix for frequent restarts of S09 device 

### DIFF
--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -166,6 +166,7 @@ static int g_sendQueryStatePackets = 0;
 // wifistate to send when not online
 // See: https://imgur.com/a/mEfhfiA
 static byte g_defaultTuyaMCUWiFiState = 0x00;
+static byte last_wifi_state = 0x00;
 
 tuyaMCUMapping_t *TuyaMCU_FindDefForID(int fnId) {
     tuyaMCUMapping_t *cur;
@@ -700,6 +701,7 @@ commandResult_t TuyaMCU_SendMCUConf(const void *context, const char *cmd, const 
 
 void Tuya_SetWifiState(uint8_t state)
 {
+    last_wifi_state = state;
     TuyaMCU_SendCommandWithData(TUYA_CMD_WIFI_STATE, &state, 1);
 }
 
@@ -1184,6 +1186,17 @@ void TuyaMCU_ProcessIncoming(const byte *data, int len) {
 			addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"TuyaMCU_ProcessIncoming: (test for TH06 calendar) received 0x24, so sending back time");
 			TuyaMCU_Send_SetTime(TuyaMCU_Get_NTP_Time());
 			break;
+
+		case 0x2B:	
+			//This is sent by S09 
+			//Info:TuyaMCU:TUYAMCU received: 55 AA 03 2B 00 00 2D 
+			//
+			if (version == 0x03 ){ 
+				addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"TuyaMCU_ProcessIncoming: (test for S09 calendar/IR device) received 0x2B, so sending back status of network status");
+    				TuyaMCU_SendCommandWithData(0x2B, &last_wifi_state, 1);
+			}
+			//
+			
         default:
             addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"TuyaMCU_ProcessIncoming: unhandled type %i",cmd);
             break;

--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -113,7 +113,6 @@ const char *TuyaMCU_GetCommandTypeLabel(int t) {
     if (t == TUYA_CMD_SET_RSSI)
         return "SetRSSI";
     return "Unknown";
-
 }
 typedef struct rtcc_s {
     uint8_t       second;
@@ -179,9 +178,6 @@ static int g_sendQueryStatePackets = 0;
 // wifistate to send when not online
 // See: https://imgur.com/a/mEfhfiA
 static byte g_defaultTuyaMCUWiFiState = 0x00;
-static byte last_wifi_state = 0x00;
-
-
 
 tuyaMCUMapping_t *TuyaMCU_FindDefForID(int fnId) {
     tuyaMCUMapping_t *cur;
@@ -718,7 +714,6 @@ commandResult_t TuyaMCU_SendMCUConf(const void *context, const char *cmd, const 
 
 void Tuya_SetWifiState(uint8_t state)
 {
-    last_wifi_state = state;
     TuyaMCU_SendCommandWithData(TUYA_CMD_WIFI_STATE, &state, 1);
 }
 
@@ -1226,7 +1221,6 @@ void TuyaMCU_ProcessIncoming(const byte *data, int len) {
                 addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"TuyaMCU_ProcessIncoming: (test for S09 calendar/IR device) received TUYA_CMD_NETWORK_STATUS 0x2B ");
                 TuyaMCU_SendNetworkStatus();
             }
-
             break;
         default:
             addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"TuyaMCU_ProcessIncoming: unhandled type %i",cmd);
@@ -1289,8 +1283,6 @@ void TuyaMCU_RunWiFiUpdateAndPackets() {
 		//addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"TuyaMCU_Wifi_State timer");
 	}
 }
-
-
 void TuyaMCU_RunFrame() {
     byte data[128];
     char buffer_for_log[256];

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -278,6 +278,7 @@ int Main_HasWiFiConnected()
 	return g_bHasWiFiConnected;
 }
 
+
 #ifdef OBK_MCU_SLEEP_METRICS_ENABLE
 extern OBK_MCU_SLEEP_METRICS OBK_Mcu_metrics;
 void Main_LogPowerSave() {
@@ -380,7 +381,7 @@ void Main_OnEverySecond()
 		}
 	}
 	if (g_newWiFiStatus != g_prevWiFiStatus) {
-		g_newWiFiStatus = g_prevWiFiStatus;
+		g_prevWiFiStatus = g_newWiFiStatus;
 		// Argument type here is HALWifiStatus_t enumeration
 		EventHandlers_FireEvent(CMD_EVENT_WIFI_STATE, g_newWiFiStatus);
 	}

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -278,7 +278,6 @@ int Main_HasWiFiConnected()
 	return g_bHasWiFiConnected;
 }
 
-
 #ifdef OBK_MCU_SLEEP_METRICS_ENABLE
 extern OBK_MCU_SLEEP_METRICS OBK_Mcu_metrics;
 void Main_LogPowerSave() {


### PR DESCRIPTION
I've got two S09 desktop thermometer / hygrometer / calendar + IR send/receiver devices .
On both I observed the same problem with frequent restarts of wifi every about 800s. 
I found that problem comes from MCU that resets WIFI module because it doesn't respond correctly on two commands  : 
0x2B - get network status 
0x24 - get RSSI 

after my changes they work fine and additionally RSSI is set automatically without adding commands to autoexec. 
Could you please take a look , check if it is correct or even check on other devices ex. TH06 .. 


ps. at the end one small fix for user_main.c 
