### PR TITLE
feat: enable docker build on non amd64 platforms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USERNAME=devuser


### PR DESCRIPTION
This PR enables a docker build on non-amd64 platforms.

Previously, the docker build would error out on other platforms because i386 architecture isn't available on these platforms, which would pull a non-amd64 image by default. This PR adds an explicit request for amd64 platform so the correct image gets built.