### PR TITLE
Allow BridgePulseLength to set to lower values

### DIFF
--- a/src/driver/drv_bridge_driver.c
+++ b/src/driver/drv_bridge_driver.c
@@ -38,9 +38,9 @@ commandResult_t Bridge_Pulse_length(const void *context, const char *cmd, const 
     }
 
     pulse_len = atoi(Tokenizer_GetArg(0));
-    if (pulse_len < 10)
+    if (pulse_len < 5)
     {
-        pulse_len = 10;   
+        pulse_len = 5;   
     } 
     else if (pulse_len > 10000) 
     {

--- a/src/driver/drv_bridge_driver.c
+++ b/src/driver/drv_bridge_driver.c
@@ -38,9 +38,9 @@ commandResult_t Bridge_Pulse_length(const void *context, const char *cmd, const 
     }
 
     pulse_len = atoi(Tokenizer_GetArg(0));
-    if (pulse_len < 50)
+    if (pulse_len < 10)
     {
-        pulse_len = 50;   
+        pulse_len = 10;   
     } 
     else if (pulse_len > 10000) 
     {

--- a/src/driver/drv_bridge_driver.c
+++ b/src/driver/drv_bridge_driver.c
@@ -70,7 +70,7 @@ void Bridge_driver_Init()
 
     if (ch_count>0)
     {
-        /* Brignde channel detected */
+        /* Bridge channel detected */
         addLogAdv(LOG_INFO, LOG_FEATURE_DRV, "Detected %i bridge channels\n", ch_count);
         if (br_ctrl != NULL)
             os_free(br_ctrl);
@@ -110,7 +110,7 @@ void Bridge_driver_Init()
                     break;                
             }
         }
-        /* Detect assigned channes */
+        /* Detect assigned channels */
         for(ch=0;ch<ch_count;ch++)
         {
             br_ctrl[ch].channel = PIN_GetPinChannelForPinIndex(br_ctrl[ch].GPIO_HLW_FWD);
@@ -121,7 +121,7 @@ void Bridge_driver_Init()
             addLogAdv(LOG_INFO, LOG_FEATURE_DRV, "BR%i New State    = %i\n", ch, br_ctrl[ch].new_state);
         }
     } else {
-        /* No Bridge drivers sefined */
+        /* No Bridge drivers defined */
         if (br_ctrl != NULL)
             os_free(br_ctrl);
         br_ctrl = NULL;


### PR DESCRIPTION
- To add support for ZMAi-90 Smart Switch (with CBU Module) Bi-Stable relay.
Tested on ZMAi-90 with BridgePulseLength set to 5.
- Fix some typos