### PR TITLE
Fixed Docker to build using Ubuntu 20.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USERNAME=devuser


### PR DESCRIPTION
Changed `docker/Dockerfile` to use Ubuntu 20.04, fixes #809