### PR TITLE
BL0942: Increased precision by using IC energy

### DIFF
--- a/src/driver/drv_bl0937.c
+++ b/src/driver/drv_bl0937.c
@@ -1,5 +1,7 @@
 #include "drv_bl0937.h"
 
+#include <math.h>
+
 #include "../cmnds/cmd_public.h"
 #include "../hal/hal_pins.h"
 #include "../logging/logging.h"
@@ -284,5 +286,5 @@ void BL0937_RunFrame(void) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,dbg);
 	}
 #endif
-	BL_ProcessUpdate(final_v, final_c, final_p, 0.0f);
+	BL_ProcessUpdate(final_v, final_c, final_p, NAN, NAN);
 }

--- a/src/driver/drv_bl0942.c
+++ b/src/driver/drv_bl0942.c
@@ -1,5 +1,8 @@
 #include "drv_bl0942.h"
 
+#include <math.h>
+#include <stdint.h>
+
 #include "../logging/logging.h"
 #include "../new_pins.h"
 #include "drv_bl_shared.h"
@@ -25,6 +28,7 @@
 #define BL0942_REG_I_RMS 0x03
 #define BL0942_REG_V_RMS 0x04
 #define BL0942_REG_WATT 0x06
+#define BL0942_REG_CF_CNT 0x7
 #define BL0942_REG_FREQ 0x08
 #define BL0942_REG_USR_WRPROT 0x1D
 #define BL0942_USR_WRPROT_DISABLE 0x55
@@ -38,30 +42,40 @@
 #define DEFAULT_CURRENT_CAL 251210
 #define DEFAULT_POWER_CAL 598
 
-static void ScaleAndUpdate(int raw_voltage, int raw_current, int raw_power,
-                           int raw_frequency) {
-    // those are not values like 230V, but unscaled
-    ADDLOG_EXTRADEBUG(LOG_FEATURE_ENERGYMETER,
-                      "Unscaled current %d, voltage %d, power %d, freq %d\n",
-                      raw_current, raw_voltage, raw_power, raw_frequency);
-    ADDLOG_EXTRADEBUG(LOG_FEATURE_ENERGYMETER,
-                      "HEX Current: %08lX; "
-                      "Voltage: %08lX; Power: %08lX;\n",
-                      (unsigned long)raw_current, (unsigned long)raw_voltage,
-                      (unsigned long)raw_power);
+#define CF_CNT_INVALID (1 << 31)
 
-    // those are final values, like 230V
+typedef struct {
+    uint32_t i_rms;
+    uint32_t v_rms;
+    int32_t watt;
+    uint32_t cf_cnt;
+    uint32_t freq;
+} bl0942_data_t;
+
+static uint32_t PrevCfCnt = CF_CNT_INVALID;
+
+static int32_t Int24ToInt32(int32_t val) {
+    return (val & (1 << 23) ? val | (0xFF << 24) : val);
+}
+
+static void ScaleAndUpdate(bl0942_data_t *data) {
     float voltage, current, power;
-    PwrCal_Scale(raw_voltage, raw_current, raw_power, &voltage, &current,
+    PwrCal_Scale(data->v_rms, data->i_rms, data->watt, &voltage, &current,
                  &power);
-    float frequency = 2 * 500000.0 / raw_frequency;
-	
-    ADDLOG_DEBUG(LOG_FEATURE_ENERGYMETER,
-                 "Real current %1.3lf, voltage %1.1lf, power %1.1lf, "
-                 "frequency %1.2lf\n",
-                 current, voltage, power, frequency);
 
-    BL_ProcessUpdate(voltage, current, power, frequency);
+    float frequency = 2 * 500000.0f / data->freq;
+
+    float energyWh = 0;
+    if (PrevCfCnt != CF_CNT_INVALID) {
+        int diff = (data->cf_cnt < PrevCfCnt
+                        ? data->cf_cnt + (0xFFFFFF - PrevCfCnt) + 1
+                        : data->cf_cnt - PrevCfCnt);
+        energyWh =
+            fabsf(PwrCal_ScalePowerOnly(diff)) * 1638.4f * 256.0f / 3600.0f;
+    }
+    PrevCfCnt = data->cf_cnt;
+
+    BL_ProcessUpdate(voltage, current, power, frequency, energyWh);
 }
 
 static int UART_TryToGetNextPacket(void) {
@@ -88,7 +102,9 @@ static int UART_TryToGetNextPacket(void) {
 		}
 	}
 	if(c_garbage_consumed > 0){
-		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"Consumed %i unwanted non-header byte in BL0942 buffer\n", c_garbage_consumed);
+        ADDLOG_WARN(LOG_FEATURE_ENERGYMETER,
+                    "Consumed %i unwanted non-header byte in BL0942 buffer\n",
+                    c_garbage_consumed);
 	}
 	if(cs < BL0942_UART_PACKET_LEN) {
 		return 0;
@@ -104,7 +120,7 @@ static int UART_TryToGetNextPacket(void) {
 	}
 	checksum ^= 0xFF;
 
-#if 1
+#if 0
     {
 		char buffer_for_log[128];
 		char buffer2[32];
@@ -113,7 +129,8 @@ static int UART_TryToGetNextPacket(void) {
 			snprintf(buffer2, sizeof(buffer2), "%02X ",UART_GetNextByte(i));
 			strcat_safe(buffer_for_log,buffer2,sizeof(buffer_for_log));
 		}
-		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"BL0942 received: %s\n", buffer_for_log);
+        ADDLOG_INFO(LOG_FEATURE_ENERGYMETER, "BL0942 received: %s\n",
+                    buffer_for_log);
 	}
 #endif
 
@@ -125,29 +142,20 @@ static int UART_TryToGetNextPacket(void) {
 		return 1;
 	}
 
-    int voltage, current, power, frequency;
-    current = (UART_GetNextByte(3) << 16) | (UART_GetNextByte(2) << 8) |
-              UART_GetNextByte(1);
-    voltage = (UART_GetNextByte(6) << 16) | (UART_GetNextByte(5) << 8) |
-              UART_GetNextByte(4);
-    power = (UART_GetNextByte(12) << 24) | (UART_GetNextByte(11) << 16) |
-            (UART_GetNextByte(10) << 8);
-    power = (power >> 8);
+    bl0942_data_t data;
+    data.i_rms = (UART_GetNextByte(3) << 16) | (UART_GetNextByte(2) << 8) |
+                 UART_GetNextByte(1);
+    data.v_rms = (UART_GetNextByte(6) << 16) | (UART_GetNextByte(5) << 8) |
+                 UART_GetNextByte(4);
+    data.watt =
+        Int24ToInt32((UART_GetNextByte(12) << 16) |
+                     (UART_GetNextByte(11) << 8) | UART_GetNextByte(10));
+    data.cf_cnt = (UART_GetNextByte(15) << 16) | (UART_GetNextByte(14) << 8) |
+                  UART_GetNextByte(13);
+    data.freq = (UART_GetNextByte(17) << 8) | UART_GetNextByte(16);
+    ScaleAndUpdate(&data);
 
-    frequency = (UART_GetNextByte(17) << 8) | UART_GetNextByte(16);
-
-    ScaleAndUpdate(voltage, current, power, frequency);
-
-#if 0
-	{
-		char res[128];
-		// V=245.107925,I=109.921143,P=0.035618
-		snprintf(res, sizeof(res),"V=%f,I=%f,P=%f\n",lastReadings[OBK_VOLTAGE],lastReadings[OBK_CURRENT],lastReadings[OBK_POWER]);
-		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,res );
-	}
-#endif
-
-	UART_ConsumeBytes(BL0942_UART_PACKET_LEN);
+    UART_ConsumeBytes(BL0942_UART_PACKET_LEN);
 	return BL0942_UART_PACKET_LEN;
 }
 
@@ -168,7 +176,7 @@ static void UART_WriteReg(uint8_t reg, uint32_t val) {
     UART_SendByte(crc ^ 0xFF);
 }
 
-static int SPI_ReadReg(uint8_t reg, uint32_t *val, uint8_t signed24) {
+static int SPI_ReadReg(uint8_t reg, uint32_t *val) {
 	uint8_t send[2];
 	uint8_t recv[4];
 	send[0] = BL0942_SPI_CMD_READ;
@@ -179,15 +187,12 @@ static int SPI_ReadReg(uint8_t reg, uint32_t *val, uint8_t signed24) {
 	checksum ^= 0xFF;
 	if (recv[3] != checksum) {
 		ADDLOG_WARN(LOG_FEATURE_ENERGYMETER,
-                    "Failed to read reg %02X: Bad checksum %02X wanted %02X",
+                    "Failed to read reg %02X: bad checksum %02X wanted %02X",
                     reg, recv[3], checksum);
 		return -1;
 	}
 
 	*val = (recv[0] << 16) | (recv[1] << 8) | recv[2];
-	if (signed24 && (recv[0] & 0x80))
-		*val |= (0xFF << 24);
-
 	return 0;
 }
 
@@ -206,7 +211,7 @@ static int SPI_WriteReg(uint8_t reg, uint32_t val) {
     SPI_WriteBytes(send, sizeof(send));
 
     uint32_t read;
-    SPI_ReadReg(reg, &read, 0);
+    SPI_ReadReg(reg, &read);
     if (read == val ||
         // REG_USR_WRPROT is read back as 0x1
         (reg == BL0942_REG_USR_WRPROT && val == BL0942_USR_WRPROT_DISABLE &&
@@ -214,12 +219,15 @@ static int SPI_WriteReg(uint8_t reg, uint32_t val) {
         return 0;
     }
 
-    ADDLOG_WARN(LOG_FEATURE_ENERGYMETER,
-                "Failed to write reg %02X val %02X: Read %02X", reg, val, read);
-    return 0;
+    ADDLOG_ERROR(LOG_FEATURE_ENERGYMETER,
+                 "Failed to write reg %02X val %02X: read %02X", reg, val,
+                 read);
+    return -1;
 }
 
 static void Init(void) {
+    PrevCfCnt = CF_CNT_INVALID;
+
     BL_Shared_Init();
 
     PwrCal_Init(PWR_CAL_DIVIDE, DEFAULT_VOLTAGE_CAL, DEFAULT_CURRENT_CAL,
@@ -232,9 +240,7 @@ void BL0942_UART_Init(void) {
 	UART_InitUART(BL0942_UART_BAUD_RATE);
 	UART_InitReceiveRingBuffer(BL0942_UART_RECEIVE_BUFFER_SIZE);
 
-    // Enable write access
     UART_WriteReg(BL0942_REG_USR_WRPROT, BL0942_USR_WRPROT_DISABLE);
-
     UART_WriteReg(BL0942_REG_MODE,
                   BL0942_MODE_DEFAULT | BL0942_MODE_RMS_UPDATE_SEL_800_MS);
 }
@@ -262,23 +268,18 @@ void BL0942_SPI_Init(void) {
 	cfg.bit_order = SPI_MSB_FIRST;
 	SPI_Init(&cfg);
 
-    // Enable write access
     SPI_WriteReg(BL0942_REG_USR_WRPROT, BL0942_USR_WRPROT_DISABLE);
-
-    uint32_t mode;
-    int err = SPI_ReadReg(BL0942_REG_MODE, &mode, 0);
-    if (!err) {
-        mode |= BL0942_MODE_RMS_UPDATE_SEL_800_MS;
-        SPI_WriteReg(BL0942_REG_MODE, mode);
-    }
+    SPI_WriteReg(BL0942_REG_MODE,
+                 BL0942_MODE_DEFAULT | BL0942_MODE_RMS_UPDATE_SEL_800_MS);
 }
 
 void BL0942_SPI_RunFrame(void) {
-    int voltage, current, power, frequency;
-    SPI_ReadReg(BL0942_REG_I_RMS, (uint32_t *)&current, 0);
-    SPI_ReadReg(BL0942_REG_V_RMS, (uint32_t *)&voltage, 0);
-    SPI_ReadReg(BL0942_REG_WATT, (uint32_t *)&power, 1);
-    SPI_ReadReg(BL0942_REG_FREQ, (uint32_t *)&frequency, 0);
-
-    ScaleAndUpdate(voltage, current, power, frequency);
+    bl0942_data_t data;
+    SPI_ReadReg(BL0942_REG_I_RMS, &data.i_rms);
+    SPI_ReadReg(BL0942_REG_V_RMS, &data.v_rms);
+    SPI_ReadReg(BL0942_REG_WATT, (uint32_t *)&data.watt);
+    data.watt = Int24ToInt32(data.watt);
+    SPI_ReadReg(BL0942_REG_CF_CNT, &data.cf_cnt);
+    SPI_ReadReg(BL0942_REG_FREQ, &data.freq);
+    ScaleAndUpdate(&data);
 }

--- a/src/driver/drv_bl_shared.h
+++ b/src/driver/drv_bl_shared.h
@@ -4,10 +4,9 @@
 
 void BL_Shared_Init(void);
 void BL_ProcessUpdate(float voltage, float current, float power,
-                      float frequency);
+                      float frequency, float energyWh);
 void BL09XX_AppendInformationToHTTPIndexPage(http_request_t *request);
 
 extern float g_apparentPower;
 extern float g_powerFactor;
 extern float g_reactivePower;
-

--- a/src/driver/drv_cse7766.c
+++ b/src/driver/drv_cse7766.c
@@ -1,6 +1,8 @@
 // NOTE: this is the same as HLW8032
 #include "drv_cse7766.h"
 
+#include <math.h>
+
 #include "../logging/logging.h"
 #include "../new_pins.h"
 #include "drv_bl_shared.h"
@@ -181,7 +183,7 @@ int CSE7766_TryToGetNextCSE7766Packet() {
         float voltage, current, power;
         PwrCal_Scale(raw_unscaled_voltage, raw_unscaled_current,
                      raw_unscaled_power, &voltage, &current, &power);
-        BL_ProcessUpdate(voltage, current, power, 0.0f);
+        BL_ProcessUpdate(voltage, current, power, NAN, NAN);
     }
 
 #if 0

--- a/src/driver/drv_pwrCal.c
+++ b/src/driver/drv_pwrCal.c
@@ -100,3 +100,7 @@ void PwrCal_Scale(int raw_voltage, int raw_current, int raw_power,
     *real_current = Scale(raw_current, current_cal);
     *real_power = Scale(raw_power, power_cal);
 }
+
+float PwrCal_ScalePowerOnly(int raw_power) {
+    return Scale(raw_power, power_cal);
+}

--- a/src/driver/drv_pwrCal.h
+++ b/src/driver/drv_pwrCal.h
@@ -10,3 +10,4 @@ void PwrCal_Init(pwr_cal_type_t type, float default_voltage_cal,
                  float default_current_cal, float default_power_cal);
 void PwrCal_Scale(int raw_voltage, int raw_current, int raw_power,
                   float *real_voltage, float *real_current, float *real_power);
+float PwrCal_ScalePowerOnly(int raw_power);

--- a/src/driver/drv_test_drivers.c
+++ b/src/driver/drv_test_drivers.c
@@ -1,5 +1,7 @@
 #include "drv_test_drivers.h"
 
+#include <math.h>
+
 #include "../cmnds/cmd_public.h"
 #include "drv_bl_shared.h"
 
@@ -46,7 +48,7 @@ void Test_Power_RunFrame(void) {
 		final_v += (rand() % 100) * 0.1f;
 		final_p += (rand() % 100) * 0.1f;
 	}
-	BL_ProcessUpdate(final_v, final_c, final_p, 0.0f);
+	BL_ProcessUpdate(final_v, final_c, final_p, NAN, NAN);
 }
 
 //Test LED driver


### PR DESCRIPTION
As mentioned before, the the BL0942 is now summing up the power for 800 ms, but we read out the power only every second. The IC has an build in energy counter. This commit makes use of the energy counter (read out energy) instead of calculating the energy from the power. This improves the precision.

Tested for both, UART and SPI device. For my devices the resolution of the energy is 0.18 Wh (UART) and 0.34 Wh (SPI). The precision depends on the circuit connected to the BL0942. I.e. it can be with current shunt (resistance value) and current coil (windings).

The energy counter of the IC is correlated to the power. Thus the energy counter uses the power calibration. No additional calibration is needed.