### PR TITLE
Bugfixes in UART: No more corrupted packages

### DIFF
--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -380,7 +380,7 @@ void CMD_UARTConsole_Run() {
 
 	totalSize = UART_GetDataSize();
 	while (totalSize) {
-		a = UART_GetNextByte(0);
+		a = UART_GetByte(0);
 		if (a == '\n' || a == '\r' || a == ' ' || a == '\t') {
 			UART_ConsumeBytes(1);
 			totalSize = UART_GetDataSize();
@@ -394,7 +394,7 @@ void CMD_UARTConsole_Run() {
 	}
 	// skip garbage data (should not happen)
 	for (i = 0; i < totalSize; i++) {
-		a = UART_GetNextByte(i);
+		a = UART_GetByte(i);
 		if (i + 1 < sizeof(tmp)) {
 			tmp[i] = a;
 			tmp[i + 1] = 0;

--- a/src/debug_tuyaMCUsimulator.c
+++ b/src/debug_tuyaMCUsimulator.c
@@ -153,7 +153,7 @@ void NewTuyaMCUSimulator_RunQuickTick(int deltaMS) {
 			break;
 		}
 		b = hexbyte(curP);
-		UART_AppendByteToCircularBuffer(b);
+		UART_AppendByteToReceiveRingBuffer(b);
 		curP += 2;
 	}
 	if (*curP == 0) {

--- a/src/driver/drv_cse7766.c
+++ b/src/driver/drv_cse7766.c
@@ -30,11 +30,11 @@ int CSE7766_TryToGetNextCSE7766Packet() {
 	if(cs < CSE7766_PACKET_LEN) {
 		return 0;
 	}
-	header = UART_GetNextByte(0);
-	// skip garbage data (should not happen)
+    header = UART_GetByte(0);
+    // skip garbage data (should not happen)
 	while(cs > 0) {
-		a = UART_GetNextByte(1);
-		if(a != 0x5A) {
+        a = UART_GetByte(1);
+        if(a != 0x5A) {
 			UART_ConsumeBytes(1);
 			c_garbage_consumed++;
 			cs--;
@@ -48,15 +48,15 @@ int CSE7766_TryToGetNextCSE7766Packet() {
 	if(cs < CSE7766_PACKET_LEN) {
 		return 0;
 	}
-	a = UART_GetNextByte(1);
-	if(a != 0x5A) {
+    a = UART_GetByte(1);
+    if(a != 0x5A) {
 		return 0;
 	}
 	checksum = 0;
 
 	for(i = 2; i < CSE7766_PACKET_LEN-1; i++) {
-		checksum += UART_GetNextByte(i);
-	}
+        checksum += UART_GetByte(i);
+    }
 
 #if 1
 	{
@@ -64,15 +64,17 @@ int CSE7766_TryToGetNextCSE7766Packet() {
 		char buffer2[32];
 		buffer_for_log[0] = 0;
 		for(i = 0; i < CSE7766_PACKET_LEN; i++) {
-			snprintf(buffer2, sizeof(buffer2), "%02X ",UART_GetNextByte(i));
-			strcat_safe(buffer_for_log,buffer2,sizeof(buffer_for_log));
+            snprintf(buffer2, sizeof(buffer2), "%02X ", UART_GetByte(i));
+            strcat_safe(buffer_for_log,buffer2,sizeof(buffer_for_log));
 		}
 		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"CSE7766 received: %s\n", buffer_for_log);
 	}
 #endif
-	if(checksum != UART_GetNextByte(CSE7766_PACKET_LEN-1)) {
-		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"Skipping packet with bad checksum %02X wanted %02X\n",checksum,UART_GetNextByte(CSE7766_PACKET_LEN-1));
-		UART_ConsumeBytes(CSE7766_PACKET_LEN);
+	if(checksum != UART_GetByte(CSE7766_PACKET_LEN-1)) {
+        ADDLOG_INFO(LOG_FEATURE_ENERGYMETER,
+                    "Skipping packet with bad checksum %02X wanted %02X\n",
+                    checksum, UART_GetByte(CSE7766_PACKET_LEN - 1));
+        UART_ConsumeBytes(CSE7766_PACKET_LEN);
 		return 1;
 	}
 	//addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"CSE checksum ok");
@@ -130,25 +132,23 @@ int CSE7766_TryToGetNextCSE7766Packet() {
 
 		backlog startDriver CSE7766; uartFakeHex 555A02FCD800062F00413200D7F2537B18023E9F7171FEEC
 		*/
-		
-		
 
-		adjustement = UART_GetNextByte(20);
-		int vol_par = UART_GetNextByte(2) << 16 | UART_GetNextByte(3) << 8 | UART_GetNextByte(4);
-		int cur_par = UART_GetNextByte(8) << 16 | UART_GetNextByte(9) << 8 | UART_GetNextByte(10);
-		int pow_par = UART_GetNextByte(14) << 16 | UART_GetNextByte(15) << 8 | UART_GetNextByte(16);
-        float raw_unscaled_voltage = UART_GetNextByte(5) << 16 |
-                                     UART_GetNextByte(6) << 8 |
-                                     UART_GetNextByte(7);
-        float raw_unscaled_current = UART_GetNextByte(11) << 16 |
-                                     UART_GetNextByte(12) << 8 |
-                                     UART_GetNextByte(13);
-        float raw_unscaled_power = UART_GetNextByte(17) << 16 |
-                                   UART_GetNextByte(18) << 8 |
-                                   UART_GetNextByte(19);
-        cf_pulses = UART_GetNextByte(21) << 8 | UART_GetNextByte(22);
+        adjustement = UART_GetByte(20);
+        int vol_par =
+            UART_GetByte(2) << 16 | UART_GetByte(3) << 8 | UART_GetByte(4);
+        int cur_par =
+            UART_GetByte(8) << 16 | UART_GetByte(9) << 8 | UART_GetByte(10);
+        int pow_par =
+            UART_GetByte(14) << 16 | UART_GetByte(15) << 8 | UART_GetByte(16);
+        float raw_unscaled_voltage =
+            UART_GetByte(5) << 16 | UART_GetByte(6) << 8 | UART_GetByte(7);
+        float raw_unscaled_current =
+            UART_GetByte(11) << 16 | UART_GetByte(12) << 8 | UART_GetByte(13);
+        float raw_unscaled_power =
+            UART_GetByte(17) << 16 | UART_GetByte(18) << 8 | UART_GetByte(19);
+        cf_pulses = UART_GetByte(21) << 8 | UART_GetByte(22);
 
-		// i am not sure about these flags
+        // i am not sure about these flags
 		if (adjustement & 0x40) {  // Voltage valid
 		
 		} else {

--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -265,8 +265,8 @@ int UART_TryToGetNextTuyaPacket(byte* out, int maxSize) {
 	}
 	// skip garbage data (should not happen)
 	while (cs > 0) {
-		a = UART_GetNextByte(0);
-		b = UART_GetNextByte(1);
+		a = UART_GetByte(0);
+		b = UART_GetByte(1);
 		if (a != 0x55 || b != 0xAA) {
 			UART_ConsumeBytes(1);
 			if (c_garbage_consumed + 2 < sizeof(printfSkipDebug)) {
@@ -287,15 +287,15 @@ int UART_TryToGetNextTuyaPacket(byte* out, int maxSize) {
 	if (cs < MIN_TUYAMCU_PACKET_SIZE) {
 		return 0;
 	}
-	a = UART_GetNextByte(0);
-	b = UART_GetNextByte(1);
+	a = UART_GetByte(0);
+	b = UART_GetByte(1);
 	if (a != 0x55 || b != 0xAA) {
 		return 0;
 	}
-	version = UART_GetNextByte(2);
-	command = UART_GetNextByte(3);
-	lena = UART_GetNextByte(4); // hi
-	lenb = UART_GetNextByte(5); // lo
+	version = UART_GetByte(2);
+	command = UART_GetByte(3);
+	lena = UART_GetByte(4); // hi
+	lenb = UART_GetByte(5); // lo
 	len = lenb | lena >> 8;
 	// now check if we have received whole packet
 	len += 2 + 1 + 1 + 2 + 1; // header 2 bytes, version, command, lenght, chekcusm
@@ -304,7 +304,7 @@ int UART_TryToGetNextTuyaPacket(byte* out, int maxSize) {
 		// can packet fit into the buffer?
 		if (len <= maxSize) {
 			for (i = 0; i < len; i++) {
-				out[i] = UART_GetNextByte(i);
+				out[i] = UART_GetByte(i);
 			}
 			ret = len;
 		}

--- a/src/driver/drv_uart.c
+++ b/src/driver/drv_uart.c
@@ -6,7 +6,6 @@
 #include "../cmnds/cmd_local.h"
 #include "../logging/logging.h"
 
-
 #if PLATFORM_BK7231T | PLATFORM_BK7231N
 #include "../../beken378/func/user_driver/BkDriverUart.h"
 #endif
@@ -19,7 +18,6 @@
 #include <cli.h>
 #include <aos/kernel.h>
 #include <aos/yloop.h>
-
 
 #include <FreeRTOS.h>
 #include <task.h>
@@ -87,7 +85,7 @@ extern void bk_send_byte(UINT8 uport, UINT8 data);
 int g_chosenUART = BK_UART_1;
 #elif WINDOWS
 
-#elif PLATFORM_BL602 
+#elif PLATFORM_BL602
 //int g_fd;
 uint8_t g_id = 1;
 int fd_console = -1;
@@ -105,57 +103,43 @@ int g_uart_manualInitCounter = -1;
 
 void UART_InitReceiveRingBuffer(int size){
 	if(g_recvBuf!=0)
-		free(g_recvBuf);
+        free(g_recvBuf);
 	g_recvBuf = (byte*)malloc(size);
 	memset(g_recvBuf,0,size);
-	g_recvBufSize = size;
-	g_recvBufIn = 0;
-	g_recvBufOut = 0;
+    g_recvBufSize = size;
+    g_recvBufIn = 0;
+    g_recvBufOut = 0;
 }
-int UART_GetDataSize()
-{
-    int remain_buf_size = 0;
 
-    if(g_recvBufIn >= g_recvBufOut) {
-        remain_buf_size = g_recvBufIn - g_recvBufOut;
-    }else {
-        remain_buf_size = g_recvBufIn + g_recvBufSize - g_recvBufOut;
-    }
-
-    return remain_buf_size;
+int UART_GetDataSize() {
+    return (g_recvBufIn >= g_recvBufOut
+                ? g_recvBufIn - g_recvBufOut
+                : g_recvBufIn + (g_recvBufSize - g_recvBufOut) + 1);
 }
-byte UART_GetNextByte(int index) {
-	int realIndex = g_recvBufOut + index;
-	if(realIndex > g_recvBufSize)
-		realIndex -= g_recvBufSize;
 
-	return g_recvBuf[realIndex];
+byte UART_GetByte(int idx) {
+    return g_recvBuf[(g_recvBufOut + idx) % g_recvBufSize];
 }
+
 void UART_ConsumeBytes(int idx) {
-	g_recvBufOut += idx;
-	if(g_recvBufOut > g_recvBufSize)
-		g_recvBufOut -= g_recvBufSize;
+    g_recvBufOut += idx;
+	g_recvBufOut %= g_recvBufSize;
 }
 
-void UART_AppendByteToCircularBuffer(int rc) {
-    if(UART_GetDataSize() < (g_recvBufSize-1))
-    {
+void UART_AppendByteToReceiveRingBuffer(int rc) {
+    if (UART_GetDataSize() < (g_recvBufSize - 1)) {
         g_recvBuf[g_recvBufIn++] = rc;
-        if(g_recvBufIn >= g_recvBufSize){
-            g_recvBufIn = 0;
-        }
-   }
+        g_recvBufIn %= g_recvBufSize;
+    }
 }
+
 #if PLATFORM_BK7231T | PLATFORM_BK7231N
 void test_ty_read_uart_data_to_buffer(int port, void* param)
 {
     int rc = 0;
 
     while((rc = uart_read_byte(port)) != -1)
-    {
-		UART_AppendByteToCircularBuffer(rc);
-    }
-
+		UART_AppendByteToReceiveRingBuffer(rc);
 }
 #endif
 
@@ -168,101 +152,97 @@ void test_ty_read_uart_data_to_buffer(int port, void* param)
 //	byte buffer[16];
 //	//length = aos_read(g_fd, buffer, 1);
 //	//if (length > 0) {
-//	//	UART_AppendByteToCircularBuffer(buffer[0]);
+//	//	UART_AppendByteToReceiveRingBuffer(buffer[0]);
 //	//}
 //	int res = bl_uart_data_recv(g_id);
 //	if (res >= 0) {
 //		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "UART received: %i\n", res);
-//		UART_AppendByteToCircularBuffer(res);
+//		UART_AppendByteToReceiveRingBuffer(res);
 //	}
 //}
 
 static void console_cb_read(int fd, void *param)
 {
 	char buffer[64];  /* adapt to usb cdc since usb fifo is 64 bytes */
-	int ret;
-	int i;
+    int ret;
+    int i;
 
-	ret = aos_read(fd, buffer, sizeof(buffer));
-	if (ret > 0) {
-		if (ret < sizeof(buffer)) {
-			fd_console = fd;
-			buffer[ret] = 0;
+    ret = aos_read(fd, buffer, sizeof(buffer));
+    if (ret > 0) {
+        if (ret < sizeof(buffer)) {
+            fd_console = fd;
+            buffer[ret] = 0;
 			addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "BL602 received: %s\n", buffer);
-			for (i = 0; i < ret; i++) {
-				UART_AppendByteToCircularBuffer(buffer[i]);
-			}
+            for (i = 0; i < ret; i++) {
+				UART_AppendByteToReceiveRingBuffer(buffer[i]);
+            }
 		}
 		else {
-			printf("-------------BUG from aos_read for ret\r\n");
-		}
-	}
+            printf("-------------BUG from aos_read for ret\r\n");
+        }
+    }
 }
-
 #endif
+
 void UART_SendByte(byte b) {
 #if PLATFORM_BK7231T | PLATFORM_BK7231N
-	// BK_UART_1 is defined to 0
-	bk_send_byte(g_chosenUART, b);
+    // BK_UART_1 is defined to 0
+    bk_send_byte(g_chosenUART, b);
 #elif WINDOWS
-void SIM_AppendUARTByte(byte b);
-	// STUB - for testing
-	SIM_AppendUARTByte(b);
+    void SIM_AppendUARTByte(byte b);
+    // STUB - for testing
+    SIM_AppendUARTByte(b);
 #if 1
-	printf("%02X", b);
+    printf("%02X", b);
 #endif
     //addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU,"%02X", b);
 #elif PLATFORM_BL602
-	aos_write(fd_console, &b, 1);
+    aos_write(fd_console, &b, 1);
 	//bl_uart_data_send(g_id, b);
-#else
-
-
 #endif
 }
 
 commandResult_t CMD_UART_Send_Hex(const void *context, const char *cmd, const char *args, int cmdFlags) {
-	byte b;
-	float val;
-	const char *stop;
+    byte b;
+    float val;
+    const char *stop;
 
 	//const char *args = CMD_GetArg(1);
-	if (!(*args)) {
+    if (!(*args)) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "CMD_UART_Send_Hex: requires 1 argument (hex string, like FFAABB00CCDD\n");
-		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
-	}
-	while (*args) {
-		if (*args == ' ') {
-			args++;
-			continue;
-		}
-		if (*args == '$') {
-			stop = args + 1;
-			while (*stop && *stop != '$') {
-				stop++;
-			}
-			CMD_ExpandConstant(args, stop, &val);
-			b = (int)val;
-			UART_SendByte(b);
+        return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+    }
+    while (*args) {
+        if (*args == ' ') {
+            args++;
+            continue;
+        }
+        if (*args == '$') {
+            stop = args + 1;
+            while (*stop && *stop != '$') {
+                stop++;
+            }
+            CMD_ExpandConstant(args, stop, &val);
+            b = (int)val;
+            UART_SendByte(b);
 
-			if (*stop == 0)
-				break;
-			args = stop + 1;
-			continue;
-		}
-		b = hexbyte(args);
+            if (*stop == 0)
+                break;
+            args = stop + 1;
+            continue;
+        }
+        b = hexbyte(args);
 
-		UART_SendByte(b);
+        UART_SendByte(b);
 
-		args += 2;
-	}
-	return CMD_RES_OK;
+        args += 2;
+    }
+    return CMD_RES_OK;
 }
-
 
 // This is a tool for debugging.
 // It simulates OpenBeken receiving packet from UART.
-// For example, you can do: 
+// For example, you can do:
 /*
 1. You can simulate TuyaMCU battery powered device packet:
 
@@ -271,25 +251,25 @@ uartFakeHex 55 AA 00 05 00 05 01 04 00 01 01 10 55
 HEADER	VER=00	Unk		LEN	fnId=1 Enum V=1	CHK
 
 backlog startDriver TuyaMCU; uartFakeHex 55 AA 00 05 00 05 01 04 00 01 01 10 55
-
 */
+
 commandResult_t CMD_UART_FakeHex(const void *context, const char *cmd, const char *args, int cmdFlags) {
 	//const char *args = CMD_GetArg(1);
 	//byte rawData[128];
 	//int curCnt;
 
 	//curCnt = 0;
-	if (!(*args)) {
+    if (!(*args)) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "CMD_UART_FakeHex: requires 1 argument (hex string, like FFAABB00CCDD\n");
-		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
-	}
-	while (*args) {
-		byte b;
-		if (*args == ' ') {
-			args++;
-			continue;
-		}
-		b = hexbyte(args);
+        return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+    }
+    while (*args) {
+        byte b;
+        if (*args == ' ') {
+            args++;
+            continue;
+        }
+        b = hexbyte(args);
 
 		//rawData[curCnt] = b;
 		//curCnt++;
@@ -298,54 +278,57 @@ commandResult_t CMD_UART_FakeHex(const void *context, const char *cmd, const cha
 		//  return -1;
 		//}
 
-		UART_AppendByteToCircularBuffer(b);
+        UART_AppendByteToReceiveRingBuffer(b);
 
-		args += 2;
-	}
-	return 1;
+        args += 2;
+    }
+    return 1;
 }
+
 // uartSendASCII test123
 commandResult_t CMD_UART_Send_ASCII(const void *context, const char *cmd, const char *args, int cmdFlags) {
 	//const char *args = CMD_GetArg(1);
-	if (!(*args)) {
+    if (!(*args)) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "CMD_UART_Send_ASCII: requires 1 argument (hex string, like hellp world\n");
-		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
-	}
-	while (*args) {
+        return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+    }
+    while (*args) {
 
-		UART_SendByte(*args);
+        UART_SendByte(*args);
 
-		args++;
-	}
-	return CMD_RES_OK;
+        args++;
+    }
+    return CMD_RES_OK;
 }
+
 void UART_ResetForSimulator() {
 	g_uart_init_counter = 0;
 }
-int UART_InitUART(int baud) {
-	g_uart_init_counter++;
-#if PLATFORM_BK7231T | PLATFORM_BK7231N
-	bk_uart_config_t config;
 
-	config.baud_rate = baud;
-	config.data_width = 0x03;
+int UART_InitUART(int baud) {
+    g_uart_init_counter++;
+#if PLATFORM_BK7231T | PLATFORM_BK7231N
+    bk_uart_config_t config;
+
+    config.baud_rate = baud;
+    config.data_width = 0x03;
 	config.parity = 0;    //0:no parity,1:odd,2:even
 	config.stop_bits = 0;   //0:1bit,1:2bit
 	config.flow_control = 0;   //FLOW_CTRL_DISABLED
-	config.flags = 0;
+    config.flags = 0;
 
 
-	// BK_UART_1 is defined to 0
-	if (CFG_HasFlag(OBK_FLAG_USE_SECONDARY_UART)) {
-		g_chosenUART = BK_UART_2;
+    // BK_UART_1 is defined to 0
+    if (CFG_HasFlag(OBK_FLAG_USE_SECONDARY_UART)) {
+        g_chosenUART = BK_UART_2;
 	}
 	else {
-		g_chosenUART = BK_UART_1;
-	}
-	bk_uart_initialize(g_chosenUART, &config, NULL);
+        g_chosenUART = BK_UART_1;
+    }
+    bk_uart_initialize(g_chosenUART, &config, NULL);
 	bk_uart_set_rx_callback(g_chosenUART, test_ty_read_uart_data_to_buffer, NULL);
 #elif PLATFORM_BL602
-	if (fd_console < 0) {
+    if (fd_console < 0) {
 		//uint8_t tx_pin = 16;
 		//uint8_t rx_pin = 7;
 		//bl_uart_init(g_id, tx_pin, rx_pin, 0, 0, baud);
@@ -355,100 +338,95 @@ int UART_InitUART(int baud) {
 		//bl_irq_enable(UART1_IRQn);
 		//vfs_uart_init_simple_mode(0, 7, 16, baud, "/dev/ttyS0");
 
-		if (CFG_HasFlag(OBK_FLAG_USE_SECONDARY_UART)) {
-			fd_console = aos_open("/dev/ttyS1", 0);
+        if (CFG_HasFlag(OBK_FLAG_USE_SECONDARY_UART)) {
+            fd_console = aos_open("/dev/ttyS1", 0);
 		}
 		else {
-			fd_console = aos_open("/dev/ttyS0", 0);
-		}
-		if (fd_console >= 0) {
-			aos_ioctl(fd_console, IOCTL_UART_IOC_BAUD_MODE, baud);
+            fd_console = aos_open("/dev/ttyS0", 0);
+        }
+        if (fd_console >= 0) {
+            aos_ioctl(fd_console, IOCTL_UART_IOC_BAUD_MODE, baud);
 			addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "Init CLI with event Driven\r\n");
-			aos_cli_init(0);
+            aos_cli_init(0);
 			aos_poll_read_fd(fd_console, console_cb_read, (void*)0x12345678);
 		}
 		else {
 			addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER, "failed CLI with event Driven\r\n");
-		}
-	}
-#else
-
-
+        }
+    }
 #endif
-	return g_uart_init_counter;
+    return g_uart_init_counter;
 }
+
 void UART_DebugTool_Run() {
-	int totalSize;
-	byte b;
-	char tmp[128];
-	char *p = tmp;
-	int i;
+    int totalSize;
+    byte b;
+    char tmp[128];
+    char *p = tmp;
+    int i;
 
-	for (i = 0; i < sizeof(tmp) - 4; i++) {
+    for (i = 0; i < sizeof(tmp) - 4; i++) {
 		if (UART_GetDataSize()==0) {
-			break;
-		}
-		b = UART_GetNextByte(0);
-		if (i) {
-			*p = ' ';
-			p++;
-		}
-		sprintf(p, "%02X", b);
-		p += 2;
-		UART_ConsumeBytes(1);
-	}
-	*p = 0;
-	addLogAdv(LOG_INFO, LOG_FEATURE_CMD, "UART received: %s\n", tmp);
+            break;
+        }
+        b = UART_GetByte(0);
+        if (i) {
+            *p = ' ';
+            p++;
+        }
+        sprintf(p, "%02X", b);
+        p += 2;
+        UART_ConsumeBytes(1);
+    }
+    *p = 0;
+    addLogAdv(LOG_INFO, LOG_FEATURE_CMD, "UART received: %s\n", tmp);
 }
+
 void UART_RunEverySecond() {
-	if (g_uart_manualInitCounter == g_uart_init_counter) {
-		UART_DebugTool_Run();
-	}
+    if (g_uart_manualInitCounter == g_uart_init_counter) {
+        UART_DebugTool_Run();
+    }
 }
+
 commandResult_t CMD_UART_Init(const void *context, const char *cmd, const char *args, int cmdFlags) {
-	int baud;
+    int baud;
 
-	Tokenizer_TokenizeString(args, 0);
-	// following check must be done after 'Tokenizer_TokenizeString',
-	// so we know arguments count in Tokenizer. 'cmd' argument is
-	// only for warning display
-	if (Tokenizer_CheckArgsCountAndPrintWarning(cmd, 1)) {
-		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
-	}
+    Tokenizer_TokenizeString(args, 0);
+    // following check must be done after 'Tokenizer_TokenizeString',
+    // so we know arguments count in Tokenizer. 'cmd' argument is
+    // only for warning display
+    if (Tokenizer_CheckArgsCountAndPrintWarning(cmd, 1)) {
+        return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+    }
 
-	baud = Tokenizer_GetArgInteger(0);
+    baud = Tokenizer_GetArgInteger(0);
 
-	UART_InitUART(baud);
-	g_uart_manualInitCounter = g_uart_init_counter;
-	UART_InitReceiveRingBuffer(512);
+    UART_InitUART(baud);
+    g_uart_manualInitCounter = g_uart_init_counter;
+    UART_InitReceiveRingBuffer(512);
 
-	return CMD_RES_OK;
+    return CMD_RES_OK;
 }
+
 void UART_AddCommands() {
 	//cmddetail:{"name":"uartSendHex","args":"[HexString]",
 	//cmddetail:"descr":"Sends raw data by UART, can be used to send TuyaMCU data, but you must write whole packet with checksum yourself",
 	//cmddetail:"fn":"CMD_UART_Send_Hex","file":"driver/drv_tuyaMCU.c","requires":"",
 	//cmddetail:"examples":""}
-	CMD_RegisterCommand("uartSendHex", CMD_UART_Send_Hex, NULL);
+    CMD_RegisterCommand("uartSendHex", CMD_UART_Send_Hex, NULL);
 	//cmddetail:{"name":"uartSendASCII","args":"[AsciiString]",
 	//cmddetail:"descr":"Sends given string by UART.",
 	//cmddetail:"fn":"CMD_UART_Send_ASCII","file":"driver/drv_uart.c","requires":"",
 	//cmddetail:"examples":""}
-	CMD_RegisterCommand("uartSendASCII", CMD_UART_Send_ASCII, NULL);
+    CMD_RegisterCommand("uartSendASCII", CMD_UART_Send_ASCII, NULL);
 	//cmddetail:{"name":"uartFakeHex","args":"[HexString]",
 	//cmddetail:"descr":"Spoofs a fake hex packet so it looks like TuyaMCU send that to us. Used for testing.",
 	//cmddetail:"fn":"CMD_UART_FakeHex","file":"driver/drv_uart.c","requires":"",
 	//cmddetail:"examples":""}
-	CMD_RegisterCommand("uartFakeHex", CMD_UART_FakeHex, NULL);
+    CMD_RegisterCommand("uartFakeHex", CMD_UART_FakeHex, NULL);
 	//cmddetail:{"name":"uartInit","args":"[BaudRate]",
 	//cmddetail:"descr":"Manually starts UART1 port. Keep in mind that you don't need to do it for TuyaMCU and BL0942, those drivers do it automatically.",
 	//cmddetail:"fn":"CMD_UART_Init","file":"driver/drv_uart.c","requires":"",
 	//cmddetail:"examples":""}
-	CMD_RegisterCommand("uartInit", CMD_UART_Init, NULL);
+    CMD_RegisterCommand("uartInit", CMD_UART_Init, NULL);
 }
-
-
-
-
-
-

--- a/src/driver/drv_uart.h
+++ b/src/driver/drv_uart.h
@@ -1,11 +1,10 @@
-
-
+#pragma once
 
 void UART_InitReceiveRingBuffer(int size);
 int UART_GetDataSize();
-byte UART_GetNextByte(int index);
+byte UART_GetByte(int idx);
 void UART_ConsumeBytes(int idx);
-void UART_AppendByteToCircularBuffer(int rc);
+void UART_AppendByteToReceiveRingBuffer(int rc);
 void UART_SendByte(byte b);
 void UART_InitUART(int baud);
 void UART_AddCommands();
@@ -13,7 +12,3 @@ void UART_RunEverySecond();
 
 // used to detect uart reinit/takeover by driver
 extern int g_uart_init_counter;
-
-
-
-

--- a/src/selftest/selftest_local.h
+++ b/src/selftest/selftest_local.h
@@ -144,7 +144,7 @@ void SIM_SimulateUserClickOnPin(int pin);
 // simulated UART
 void SIM_UART_InitReceiveRingBuffer(int size);
 int SIM_UART_GetDataSize();
-byte SIM_UART_GetNextByte(int index);
+byte SIM_UART_GetByte(int index);
 void SIM_UART_ConsumeBytes(int idx);
 void SIM_AppendUARTByte(byte rc);
 bool SIM_UART_ExpectAndConsumeHByte(byte b);

--- a/src/sim/sim_local.h
+++ b/src/sim/sim_local.h
@@ -48,7 +48,7 @@ extern int gridSize;
 extern "C" {
 	void CMD_ExpandConstantsWithinString(const char *in, char *out, int outLen);
 	int UART_GetDataSize();
-	void UART_AppendByteToCircularBuffer(int rc);
+	void UART_AppendByteToReceiveRingBuffer(int rc);
 	int CMD_ExecuteCommand(const char* s, int cmdFlags);
 }
 

--- a/src/sim/sim_uart.c
+++ b/src/sim/sim_uart.c
@@ -1,7 +1,5 @@
 #include "../new_common.h"
 
-
-
 static byte *g_recvBuf = 0;
 static int g_recvBufSize = 0;
 static int g_recvBufIn = 0;
@@ -16,60 +14,47 @@ void SIM_UART_InitReceiveRingBuffer(int size) {
 	g_recvBufIn = 0;
 	g_recvBufOut = 0;
 }
+
 void SIM_ClearUART() {
 	g_recvBufIn = 0;
 	g_recvBufOut = 0;
 }
+
 int SIM_UART_GetDataSize()
 {
-	int remain_buf_size = 0;
-
-	if (g_recvBufIn >= g_recvBufOut) {
-		remain_buf_size = g_recvBufIn - g_recvBufOut;
-	}
-	else {
-		remain_buf_size = g_recvBufIn + g_recvBufSize - g_recvBufOut;
-	}
-
-	return remain_buf_size;
+    return (g_recvBufIn >= g_recvBufOut
+                ? g_recvBufIn - g_recvBufOut
+                : g_recvBufIn + (g_recvBufSize - g_recvBufOut) + 1);
 }
-byte SIM_UART_GetNextByte(int index) {
-	int realIndex = g_recvBufOut + index;
-	if (realIndex > g_recvBufSize)
-		realIndex -= g_recvBufSize;
 
-	return g_recvBuf[realIndex];
+byte SIM_UART_GetByte(int idx) {
+    return g_recvBuf[(g_recvBufOut + idx) % g_recvBufSize];
 }
+
 void SIM_UART_ConsumeBytes(int idx) {
-	g_recvBufOut += idx;
-	if (g_recvBufOut > g_recvBufSize)
-		g_recvBufOut -= g_recvBufSize;
+    g_recvBufOut += idx;
+    g_recvBufOut %= g_recvBufSize;
 }
 
 void SIM_AppendUARTByte(byte rc) {
-	int curDataSize = SIM_UART_GetDataSize();
-
-	if (curDataSize < (g_recvBufSize - 1))
-	{
-		g_recvBuf[g_recvBufIn++] = rc;
-		if (g_recvBufIn >= g_recvBufSize) {
-			g_recvBufIn = 0;
-		}
-	}
+    if (SIM_UART_GetDataSize() < (g_recvBufSize - 1)) {
+        g_recvBuf[g_recvBufIn++] = rc;
+        g_recvBufIn %= g_recvBufSize;
+    }
 }
-
 
 bool SIM_UART_ExpectAndConsumeHByte(byte b) {
 	byte nextB;
 	if (SIM_UART_GetDataSize() == 0)
 		return false;
-	nextB = SIM_UART_GetNextByte(0);
+	nextB = SIM_UART_GetByte(0);
 	if (nextB == b) {
 		SIM_UART_ConsumeBytes(1);
 		return true;
 	}
 	return false;
 }
+
 bool SIM_UART_ExpectAndConsumeHexStr(const char *hexString) {
 	const char *p;
 	byte b;


### PR DESCRIPTION
- Fixed bugs in uart_driver which caused corrupted uart reads, when the ring buffer came to its "overflow".
- Renamed two functions to clearer names:
    - UART_GetNextByte -> UART_GetByte (no index is moved to a "next" position)
    - UART_AppendByteToCircularBuffer -> UART_AppendByteToReceiveRingBuffer (there is already UART_InitReceiveRingBuffer)
- Tested with BL0942, which produced checksum errors before the commit. After commit everything works fine, and no more checksum errors occur.