### PR TITLE
Set only first channel by type in VCP tuyaMCU

### DIFF
--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -1145,13 +1145,13 @@ void TuyaMCU_ParseStateMessage(const byte* data, int len) {
 					if (sectorLen == 8 || sectorLen == 10) {
 						// voltage
 						iVal = data[ofs + 0 + 4] << 8 | data[ofs + 1 + 4];
-						CHANNEL_SetAllChannelsByType(ChType_Voltage_div10, iVal);
+						CHANNEL_SetFirstChannelByType(ChType_Voltage_div10, iVal);
 						// current
 						iVal = data[ofs + 3 + 4] << 8 | data[ofs + 4 + 4];
-						CHANNEL_SetAllChannelsByType(ChType_Current_div1000, iVal);
+						CHANNEL_SetFirstChannelByType(ChType_Current_div1000, iVal);
 						// power
 						iVal = data[ofs + 6 + 4] << 8 | data[ofs + 7 + 4];
-						CHANNEL_SetAllChannelsByType(ChType_Power, iVal);
+						CHANNEL_SetFirstChannelByType(ChType_Power, iVal);
 					}
 					else {
 
@@ -1166,13 +1166,13 @@ void TuyaMCU_ParseStateMessage(const byte* data, int len) {
 					else {
 						// FREQ??
 						iVal = data[ofs + 8 + 4] << 8 | data[ofs + 9 + 4];
-						//CHANNEL_SetAllChannelsByType(QQQQQQ, iVal);
+						//CHANNEL_SetFirstChannelByType(QQQQQQ, iVal);
 						// 06 46 = 1606 => A x 100? ?
 						iVal = data[ofs + 11 + 4] << 8 | data[ofs + 12 + 4];
-						CHANNEL_SetAllChannelsByType(ChType_Current_div1000, iVal);
+						CHANNEL_SetFirstChannelByType(ChType_Current_div1000, iVal);
 						// Voltage?
 						iVal = data[ofs + 13 + 4] << 8 | data[ofs + 14 + 4];
-						CHANNEL_SetAllChannelsByType(ChType_Voltage_div10, iVal);
+						CHANNEL_SetFirstChannelByType(ChType_Voltage_div10, iVal);
 					}
 				}
 				break;

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -526,12 +526,13 @@ void NEW_button_init(pinButton_s* handle, uint8_t(*pin_level)(void* self), uint8
 	handle->button_level = handle->hal_button_Level(handle);
 	handle->active_level = active_level;
 }
-void CHANNEL_SetAllChannelsByType(int requiredType, int newVal) {
+void CHANNEL_SetFirstChannelByType(int requiredType, int newVal) {
 	int i;
 
 	for (i = 0; i < CHANNEL_MAX; i++) {
 		if (CHANNEL_GetType(i) == requiredType) {
 			CHANNEL_Set(i, newVal, 0);
+			return;
 		}
 	}
 }

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1193,7 +1193,7 @@ bool CHANNEL_IsPowerRelayChannel(int ch);
 // See: enum channelType_t
 void CHANNEL_SetType(int ch, int type);
 int CHANNEL_GetType(int ch);
-void CHANNEL_SetAllChannelsByType(int requiredType, int newVal);
+void CHANNEL_SetFirstChannelByType(int requiredType, int newVal);
 // CHANNEL_SET_FLAG_*
 void CHANNEL_SetAll(int iVal, int iFlags);
 void CHANNEL_SetStateOnly(int iVal);


### PR DESCRIPTION
My energy meter with tuyaMCU exposes current and leakage current, so both Current_div100. When I linkTuyaMCUOutputToChannel RAW_TAC2121C_VCP it sets both channels.
I prefer to set only the first channel by RAW_TAC2121C_VCP but other "currents" can be set by different outputs.