### PR TITLE
Respond to POSTs as well as GETs in /cm handler

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2253,13 +2253,23 @@ int http_fn_cm(http_request_t* request) {
 
 	http_setup(request, httpMimeTypeJson);
 	// exec command
-	commandLen = http_getArg(request->url, "cmnd", tmpA, sizeof(tmpA));
+	if (request->method == HTTP_GET) {
+		commandLen = http_getArg(request->url, "cmnd", tmpA, sizeof(tmpA));
+		//ADDLOG_INFO(LOG_FEATURE_HTTP, "Got here (GET) %s;%s;%d\n", request->url, tmpA, commandLen);
+        } else if (request->method == HTTP_POST || request->method == HTTP_PUT) {
+		commandLen = http_getRawArg(request->bodystart, "cmnd", tmpA, sizeof(tmpA));
+		//ADDLOG_INFO(LOG_FEATURE_HTTP, "Got here (POST) %s;%s;%d\n", request->bodystart, tmpA, commandLen);
+        }
 	if (commandLen) {
 		if (commandLen > (sizeof(tmpA) - 5)) {
 			commandLen += 8;
 			long_str_alloced = (char*)malloc(commandLen);
 			if (long_str_alloced) {
-				http_getArg(request->url, "cmnd", long_str_alloced, commandLen);
+				if (request->method == HTTP_GET) {
+					http_getArg(request->url, "cmnd", long_str_alloced, commandLen);
+				} else if (request->method == HTTP_POST || request->method == HTTP_PUT) {
+					http_getRawArg(request->bodystart, "cmnd", long_str_alloced, commandLen);
+				}
 				CMD_ExecuteCommand(long_str_alloced, COMMAND_FLAG_SOURCE_HTTP);
 				JSON_ProcessCommandReply(long_str_alloced, skipToNextWord(long_str_alloced), request, (jsonCb_t)hprintf255, COMMAND_FLAG_SOURCE_HTTP);
 				free(long_str_alloced);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2249,7 +2249,7 @@ int http_fn_ha_cfg(http_request_t* request) {
 int http_fn_cm(http_request_t* request) {
 	char tmpA[128];
 	char* long_str_alloced = 0;
-	int commandLen;
+	int commandLen = 0;
 
 	http_setup(request, httpMimeTypeJson);
 	// exec command

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -351,14 +351,9 @@ int http_copyCarg(const char* atin, char* to, int maxSize) {
 	return realSize;
 }
 
-int http_getArg(const char* base, const char* name, char* o, int maxSize) {
+int http_getRawArg(const char* base, const char* name, char* o, int maxSize) {
 	*o = '\0';
-	while (*base != '?') {
-		if (*base == 0)
-			return 0;
-		base++;
-	}
-	base++;
+
 	while (*base) {
 		const char* at = http_checkArg(base, name);
 		if (at) {
@@ -374,6 +369,17 @@ int http_getArg(const char* base, const char* name, char* o, int maxSize) {
 		base++;
 	}
 	return 0;
+}
+int http_getArg(const char* base, const char* name, char* o, int maxSize) {
+	*o = '\0';
+	while (*base != '?') {
+		if (*base == '\0')
+			return 0;
+		base++;
+	}
+	base++;
+
+	return http_getRawArg(base, name, o, maxSize);
 }
 int http_getArgInteger(const char* base, const char* name) {
 	char tmp[16];

--- a/src/httpserver/new_http.h
+++ b/src/httpserver/new_http.h
@@ -67,6 +67,7 @@ int postany(http_request_t* request, const char* str, int len);
 void misc_formatUpTimeString(int totalSeconds, char* o);
 // void HTTP_AddBuildFooter(http_request_t *request);
 // void HTTP_AddHeader(http_request_t *request);
+int http_getRawArg(const char* base, const char* name, char* o, int maxSize);
 int http_getArg(const char* base, const char* name, char* o, int maxSize);
 int http_getArgInteger(const char* base, const char* name);
 


### PR DESCRIPTION
Not sure my adding a new http_getRawArg method is the best way to go about ignoring the initial "?" when parsing the data within the body of a POST request, but otherwise this does seem to fix #872 for me.

Fixes #872