### PR TITLE
Add cht8310 support

### DIFF
--- a/src/driver/drv_cht8305.c
+++ b/src/driver/drv_cht8305.c
@@ -20,11 +20,22 @@ static byte channel_temp = 0, channel_humid = 0;
 static float g_temp = 0.0, g_humid = 0.0;
 static softI2C_t g_softI2C;
 static float g_calTemp = 0, g_calHum = 0;
+static uint16_t sensor_id=0;
 
 
 static void CHT8305_ReadEnv(float* temp, float* hum) {
 	uint8_t buff[4];
 	unsigned int th, tl, hh, hl;
+
+	if(sensor_id!=0x8305)
+	{
+		//Make dymmy write to Oneshot register to trigger a measurement, sensor is otherwise sleeping
+		Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR);
+		Soft_I2C_WriteByte(&g_softI2C, 0x0F);			
+		Soft_I2C_WriteByte(&g_softI2C, 0x00);			
+		Soft_I2C_WriteByte(&g_softI2C, 0x00);
+		Soft_I2C_Stop(&g_softI2C);
+	}
 
 	Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR);
 	Soft_I2C_WriteByte(&g_softI2C, 0x00);
@@ -41,10 +52,16 @@ static void CHT8305_ReadEnv(float* temp, float* hum) {
 	hh = buff[2];
 	hl = buff[3];
 
-	(*temp) = ((th << 8 | tl) * 165.0 / 65535.0 - 40.0)+ g_calTemp;
-
-	(*hum) = ((hh << 8 | hl) * 100.0 / 65535.0)+ g_calHum;
-
+	if(sensor_id==8305)
+	{
+		(*temp) = ((th << 8 | tl) * 165.0 / 65535.0 - 40.0)+ g_calTemp;
+		(*hum) = ((hh << 8 | hl) * 100.0 / 65535.0)+ g_calHum;
+	}
+	else
+	{
+		(*temp)=((th << 8 | tl)>>1)/128.0+g_calTemp;
+		(*hum) = (((hh << 8 | hl)&0x7fff)/32768.0*100)+ g_calHum;
+	}
 }
 
 commandResult_t CHT_Calibrate(const void* context, const char* cmd, const char* args, int cmdFlags) {
@@ -90,13 +107,30 @@ void CHT8305_Init() {
 	Soft_I2C_PreInit(&g_softI2C);
 
 	Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR);
-	Soft_I2C_WriteByte(&g_softI2C, 0xfe);			//manufacturer ID
+	Soft_I2C_WriteByte(&g_softI2C, 0xfe);			//manufacturer ID 2 bytes + sensor version 2 bytes from 0xff
 	Soft_I2C_Stop(&g_softI2C);
 	Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR | 1);
-	Soft_I2C_ReadBytes(&g_softI2C, buff, 2);
+	Soft_I2C_ReadBytes(&g_softI2C, buff, 4);
 	Soft_I2C_Stop(&g_softI2C);
 
-	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "DRV_CHT8304_init: ID: %02X %02X", buff[0], buff[1]);
+	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "DRV_CHT8304_init: ID: %02X %02X %02X %02X", buff[0], buff[1],buff[2],buff[3]);
+
+	//Identify chip ID and keep if for later use
+	sensor_id=(buff[3] << 8 | buff[4]);
+	if(sensor_id!=0x8305)
+	{//it should be 8310, we enable low power mode, so only 50uA are drawn from sensor, 
+	//but need to write something to one shot register to trigger new measurement
+
+
+		Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR);
+		Soft_I2C_WriteByte(&g_softI2C, 0x03);			//config register
+		Soft_I2C_WriteByte(&g_softI2C, 0x48);			//enable shutdown default is 0x08 
+														//setting bit 6 enables low power mode, 
+														//to get new measurement need to write to one shot register
+		Soft_I2C_WriteByte(&g_softI2C, 0x80);			//as default 0x80
+		Soft_I2C_Stop(&g_softI2C);
+
+	}
 
 	//cmddetail:{"name":"CHT_Calibrate","args":"[DeltaTemp][DeltaHumidity]",
 	//cmddetail:"descr":"Calibrate the CHT Sensor as Tolerance is +/-2 degrees C.",

--- a/src/driver/drv_cht8305.c
+++ b/src/driver/drv_cht8305.c
@@ -108,9 +108,7 @@ commandResult_t CHT_cycle(const void* context, const char* cmd, const char* args
 }
 // startDriver CHT8305
 void CHT8305_Init() {
-
 	uint8_t buff[4];
-
 
 	g_softI2C.pin_clk = 9;
 	g_softI2C.pin_data = 14;
@@ -120,7 +118,7 @@ void CHT8305_Init() {
 	Soft_I2C_PreInit(&g_softI2C);
 
 	Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR);
-	Soft_I2C_WriteByte(&g_softI2C, 0xfe);			//manufacturer ID 2 bytes + sensor version 2 bytes from 0xff
+	Soft_I2C_WriteByte(&g_softI2C, 0xfe);			//manufacturer ID 2 bytes
 	Soft_I2C_Stop(&g_softI2C);
 	Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR | 1);
 	Soft_I2C_ReadBytes(&g_softI2C, buff, 2);
@@ -136,16 +134,15 @@ void CHT8305_Init() {
 	Soft_I2C_ReadBytes(&g_softI2C, buff+2, 2);
 	Soft_I2C_Stop(&g_softI2C);
 
-
-	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "DRV_CHT8305_init: ID: %02X %02X %02X %02X", buff[0], buff[1],buff[2],buff[3]);
-
 	//Identify chip ID and keep if for later use
-	sensor_id=(buff[3] << 8 | buff[4]);
+	sensor_id=(buff[2] << 8 | buff[3]);
+
+	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "DRV_CHT8305_init: ID: %02X %02X %04X", buff[0], buff[1], sensor_id);
+
 
 	if(sensor_id==0x8215)
 	{//it should be 8310 id is 0x8215, we enable low power mode, so only 50nA are drawn from sensor, 
 	//but need to write something to one shot register to trigger new measurement
-
 
 		Soft_I2C_Start(&g_softI2C, CHT8305_I2C_ADDR);
 		Soft_I2C_WriteByte(&g_softI2C, 0x03);			//config register


### PR DESCRIPTION
Added support for the new SensyLink sendor CHT8310 and this should fix [ISSUE-983](https://github.com/openshwprojects/OpenBK7231T_App/issues/983)

I have the sensor and tested it. Compatibility with the old sensor shold be maintained, but I don't have it to test. Please confirm If you have the hardware to test, before merge. 

The new sensor has more features and the way to calculate measurement results is different. I put an if there depending on the sensor type. On the old one if can be confirmed reading a sensor ID from the IC. If it is not 8305, the code assumes it is the new one.  

I have utilised the low power mode of the IC where it only draws 50nA, and makes measurements on request. This is accomplished writing anything to the "Oneshot" register. If the sensor is the old one this is skipped, as well as the configuration on init. 

Another major difference is that if you read 4 bytes from 0x00 to get the two 16 bit registers in one go there is parity byte and 0xff as bytes 3 and 4. To read the humidity data from 0x01 a second read needs to be made moving the pointer to it and reading 2 bytes. Again if it is the new sensor the code overwrites bytes 3 and 4 with the humidity data as expected. 

Before merge needs to be confirmed that sensor identification logic is working and reading from the old sensor is not broken. I dont have the hardware to test. 

