### PR TITLE
addClockEvent - allow TimerSeconds

### DIFF
--- a/docs/autoexecs/automatic_day_and_night_lights_v3.bat
+++ b/docs/autoexecs/automatic_day_and_night_lights_v3.bat
@@ -1,8 +1,12 @@
 PowerSave 1
-ntp_setServer 192.168.1.12
 startDriver ntp
+ntp_setServer 192.168.1.12
 ntp_timeZoneOfs 11
-ntp_setLatlong -33.729720 151.160990
+ntp_setLatlong -33.868820 151.209290
+
+// Use channel 10 to maintain sunset time (The time when the light should turn on)
+setChannelLabel 10  "<b><span style='color:orange'\>Light ON (Civil Sunset)</span></b>"
+setChannelType 10 TimerSeconds
 
 // Use channel 11 as a hidden register to store current time as TimerSeconds
 setChannelType 11 TimerSeconds
@@ -13,11 +17,15 @@ alias high_lights backlog led_temperature 300; led_dimmer 30; led_enableAll 1; e
 alias low_lights backlog led_temperature 500; led_dimmer 5; led_enableAll 1; echo lights_set_low
 alias off_lights backlog led_enableAll 0; echo lights_set_off
 
-addClockEvent sunset 0xff 1 high_lights
+alias calc_sunset backlog setChannel 10 $sunset+1800; removeClockEvent 4; addClockEvent $CH10 0xff 4 high_lights; echo Lights will turn on at $CH10
+
+addClockEvent 3:30 0xff 1 calc_sunset
 addClockEvent 21:00 0xff 2 low_lights
 addClockEvent 23:00 0xff 3 off_lights
 
 waitFor NTPState 1
+
+calc_sunset
 
 // set the current time as TimerSeconds in register for checks below
 setChannel 11 $hour*3600+$minute*60
@@ -26,6 +34,6 @@ setChannel 11 $hour*3600+$minute*60
 // sunset - 21:00   lights set to high (evening activities)
 // 21:00 - 23:00    lights set to low (sleepy mode: warmest temperature and very dim)
 // 23:00 - sunset   lights turned off (bedtime and day time the lights should be off)
-if $CH11>=$sunset&&$hour<21 then high_lights
+if $CH11>=$CH10&&$hour<21 then high_lights
 if $hour>=21&&$hour<23 then low_lights
-if $hour>=23||$CH11<$sunset then off_lights
+if $hour>=23||$CH11<$CH10 then off_lights

--- a/src/driver/drv_ntp_events.c
+++ b/src/driver/drv_ntp_events.c
@@ -307,6 +307,7 @@ int NTP_RemoveClockEvent(int id) {
 commandResult_t CMD_NTP_AddClockEvent(const void *context, const char *cmd, const char *args, int cmdFlags) {
 	int hour, minute = 0, second = 0;
 	const char *s;
+	int timeComponentsParsed;
 	int flags;
 	int id;
 #if ENABLE_NTP_SUNRISE_SUNSET
@@ -324,23 +325,28 @@ commandResult_t CMD_NTP_AddClockEvent(const void *context, const char *cmd, cons
 	}
 	s = Tokenizer_GetArg(0);
 	flags = Tokenizer_GetArgInteger(1);
-	if (sscanf(s, "%i:%i:%i", &hour, &minute, &second) <= 1) {
+
+	timeComponentsParsed = sscanf(s, "%i:%i:%i", &hour, &minute, &second);
+	if (timeComponentsParsed == 1) {
+		// single integer value indicates the clock value is TimerSeconds from midnight
+		second = hour % 60;
+		minute = (hour / 60) % 60;
+		hour = (hour / 3600) % 24;
+	}
+	else if (timeComponentsParsed > 1) {
+	}
 #if ENABLE_NTP_SUNRISE_SUNSET
-		if (strcasestr(s, "sunrise")) {
-			sunflags |= SUNRISE_FLAG;
-			}
-		else {
-			if (strcasestr(s, "sunset")) {
-				sunflags |= SUNSET_FLAG;
-				}
-			else {
-				return CMD_RES_BAD_ARGUMENT;
-				}
-			}
-#else
-		return CMD_RES_BAD_ARGUMENT;
+	else if (strcasestr(s, "sunrise")) {
+		sunflags |= SUNRISE_FLAG;
+	}
+	else if (strcasestr(s, "sunset")) {
+		sunflags |= SUNSET_FLAG;
+	}
 #endif
-		}
+	else {
+		return CMD_RES_BAD_ARGUMENT;
+	}
+
 	id = Tokenizer_GetArgInteger(2);
 	s = Tokenizer_GetArgFrom(3);
 #if ENABLE_NTP_SUNRISE_SUNSET
@@ -348,7 +354,7 @@ commandResult_t CMD_NTP_AddClockEvent(const void *context, const char *cmd, cons
 		dusk2Dawn(&sun_data, sunflags, &hour_b, &minute_b, calc_day_offset(ltm->tm_wday, flags));
 		hour = hour_b;
 		minute = minute_b;
-		}
+	}
 
 	NTP_AddClockEvent(hour, minute, second, flags, id, sunflags, s);
 #else
@@ -463,8 +469,8 @@ commandResult_t CMD_NTP_ClearEvents(const void* context, const char* cmd, const 
 }
 void NTP_Init_Events() {
 
-	//cmddetail:{"name":"addClockEvent","args":"[Time or sunrise or sunset] [WeekDayFlags] [UniqueIDForRemoval][Command]",
-	//cmddetail:"descr":"Schedule command to run on given time in given day of week. NTP must be running. Time is a time like HH:mm or HH:mm:ss, WeekDayFlag is a bitflag on which day to run, 0xff mean all days, 0x01 means sunday, 0x02 monday, 0x03 sunday and monday, etc, id is an unique id so event can be removed later. (NOTE: Use of sunrise/sunset requires compiling with ENABLE_NTP_SUNRISE_SUNSET set which adds about 11k of code",
+	//cmddetail:{"name":"addClockEvent","args":"[TimerSeconds or Time or sunrise or sunset] [WeekDayFlags] [UniqueIDForRemoval][Command]",
+	//cmddetail:"descr":"Schedule command to run on given time in given day of week. NTP must be running. TimerSeconds is seconds from midnight, Time is a time like HH:mm or HH:mm:ss, WeekDayFlag is a bitflag on which day to run, 0xff mean all days, 0x01 means sunday, 0x02 monday, 0x03 sunday and monday, etc, id is an unique id so event can be removed later. (NOTE: Use of sunrise/sunset requires compiling with ENABLE_NTP_SUNRISE_SUNSET set which adds about 11k of code)",
 	//cmddetail:"fn":"CMD_NTP_AddClockEvent","file":"driver/drv_ntp_events.c","requires":"",
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("addClockEvent",CMD_NTP_AddClockEvent, NULL);

--- a/src/selftest/selftest_clockEvents.c
+++ b/src/selftest/selftest_clockEvents.c
@@ -3,13 +3,24 @@
 #include "selftest_local.h"
 #include "../driver/drv_ntp.h"
 
+static void ResetEventsAndChannels(int eventsCleared) {
+	SELFTEST_ASSERT(NTP_ClearEvents() == eventsCleared);
+	SELFTEST_ASSERT(NTP_PrintEventList() == 0);
+
+	CMD_ExecuteCommand("setChannel 1 0", 0);
+	CMD_ExecuteCommand("setChannel 2 0", 0);
+	CMD_ExecuteCommand("setChannel 3 0", 0);
+	SELFTEST_ASSERT_CHANNEL(1, 0);
+	SELFTEST_ASSERT_CHANNEL(2, 0);
+	SELFTEST_ASSERT_CHANNEL(3, 0);
+}
+
 void Test_ClockEvents() {
 	// reset whole device
 	SIM_ClearOBK(0);
 
 	CMD_ExecuteCommand("startDriver NTP", 0);
 	
-
 	SELFTEST_ASSERT(NTP_PrintEventList() == 0);
 	CMD_ExecuteCommand("addClockEvent 15:30:00 0xff 123 POWER0 ON", 0);
 	// now there is 1
@@ -64,18 +75,8 @@ void Test_ClockEvents() {
 	CMD_ExecuteCommand("addClockEvent 15:30:00 0xff 1008 POWER0 ON", 0);
 	// now there is 3
 	SELFTEST_ASSERT(NTP_PrintEventList() == 3);
-	// removed all 3
-	SELFTEST_ASSERT(NTP_ClearEvents() == 3);
-	// now there is 0
-	SELFTEST_ASSERT(NTP_PrintEventList() == 0);
 
-
-	CMD_ExecuteCommand("setChannel 1 0", 0);
-	CMD_ExecuteCommand("setChannel 2 0", 0);
-	CMD_ExecuteCommand("setChannel 3 0", 0);
-	SELFTEST_ASSERT_CHANNEL(1, 0);
-	SELFTEST_ASSERT_CHANNEL(2, 0);
-	SELFTEST_ASSERT_CHANNEL(3, 0);
+	ResetEventsAndChannels(3);
 
 	CMD_ExecuteCommand("addClockEvent 13:54:59 0xff 4 backlog setChannel 1 10; echo test event for 4", 0);
 	CMD_ExecuteCommand("addClockEvent 13:55 0xff 5 backlog setChannel 2 20; echo test event for 5", 0);
@@ -91,17 +92,7 @@ void Test_ClockEvents() {
 
 
 	for (int test = 0; test < 10; test++) {
-		// removed all 3
-		SELFTEST_ASSERT(NTP_ClearEvents() == 3);
-		// now there is 0
-		SELFTEST_ASSERT(NTP_PrintEventList() == 0);
-
-		CMD_ExecuteCommand("setChannel 1 0", 0);
-		CMD_ExecuteCommand("setChannel 2 0", 0);
-		CMD_ExecuteCommand("setChannel 3 0", 0);
-		SELFTEST_ASSERT_CHANNEL(1, 0);
-		SELFTEST_ASSERT_CHANNEL(2, 0);
-		SELFTEST_ASSERT_CHANNEL(3, 0);
+		ResetEventsAndChannels(3);
 
 		CMD_ExecuteCommand("addClockEvent 13:54:59 0xff 4 backlog addChannel 1 10; echo test event for 4", 0);
 		CMD_ExecuteCommand("addClockEvent 13:55 0xff 5 backlog addChannel 2 20; echo test event for 5", 0);
@@ -119,6 +110,25 @@ void Test_ClockEvents() {
 		SELFTEST_ASSERT_CHANNEL(2, 20);
 		SELFTEST_ASSERT_CHANNEL(3, 30);
 	}
+
+	// Test with calculated times
+	ResetEventsAndChannels(3);
+
+	CMD_ExecuteCommand("setChannel 4 13", 0);
+	CMD_ExecuteCommand("setChannel 5 55", 0);
+	CMD_ExecuteCommand("setChannel 6 $CH4*3600+54*60+59", 0);
+
+	CMD_ExecuteCommand("addClockEvent $CH6 0xff 4 backlog addChannel 1 10; echo test event for 4", 0);
+	//CMD_ExecuteCommand("addClockEvent $CH4:$CH5 0xff 5 backlog addChannel 2 20; echo test event for 5", 0);
+	//CMD_ExecuteCommand("addClockEvent $CH4:$CH5:01 0xff 6 backlog addChannel 3 30; echo test event for 6", 0);
+
+	simTime = 1681998870;
+	for (int i = 0; i < 100; i++) {
+		NTP_RunEvents(simTime + i, true);
+	}
+	SELFTEST_ASSERT_CHANNEL(1, 10);
+	//SELFTEST_ASSERT_CHANNEL(2, 20);
+	//SELFTEST_ASSERT_CHANNEL(3, 30);
 }
 
 


### PR DESCRIPTION
Or allow single integer value for the time parameter that would represent a TimerSeconds type from midnight. This would allow a script like: 

```
setChannel 10 $sunset+1800
addClockEvent $CH10 0xff 5 echo timeExpanded
```