### PR TITLE
fix backwards binary sensor payload on/off values

### DIFF
--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -395,8 +395,8 @@ HassDeviceInfo* hass_init_binary_sensor_device_info(int index, bool bInverse) {
 	const char *payload_on;
 	const char *payload_off;
 	if (bInverse) {
-		payload_on = "0";
 		payload_off = "1";
+		payload_on = "0";
 	} else {
 		payload_off = "0";
 		payload_on = "1";

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -395,11 +395,11 @@ HassDeviceInfo* hass_init_binary_sensor_device_info(int index, bool bInverse) {
 	const char *payload_on;
 	const char *payload_off;
 	if (bInverse) {
-		payload_on = "1";
-		payload_off = "0";
-	} else {
-		payload_off = "1";
 		payload_on = "0";
+		payload_off = "1";
+	} else {
+		payload_off = "0";
+		payload_on = "1";
 	}
 	HassDeviceInfo* info = hass_init_device_info(BINARY_SENSOR, index, payload_on, payload_off);
 


### PR DESCRIPTION
I noticed that when I configured a binary motion sensor on my BK7231T device, it was showing up inverted in Home Assistant when I used MQTT Discovery. I checked the discovery payload and found that the `pl_on` and `pl_off` values were inverted, even though the binary motion sensor on my device was not configured to be inverted. I checked the code and it looks like it is set up backwards.

Thanks for this great project!