### PR TITLE
Add SK6812 support to SM16703P driver

### DIFF
--- a/src/driver/drv_sm16703P.c
+++ b/src/driver/drv_sm16703P.c
@@ -156,7 +156,7 @@ commandResult_t SM16703P_Start(const void *context, const char *cmd, const char 
 	pixel_count = Tokenizer_GetArgIntegerRange(0, 0, 255);
 	if (Tokenizer_GetArgsCount() > 1) {
 		const char *format = Tokenizer_GetArg(1);
-		if (!strcmp(format, "SK6812") || !strcmp(format, "sk6812") || !strcmp(format, "GRB") || !strcmp(format, "grb")) {
+		if (!stricmp(format, "GRB")) {
 			format_grb = true;
 		}
 	}


### PR DESCRIPTION
This is adds code to support SK6812 strips which swap the red and green colors with respect to SM16703P.

The init command is enhanced to accept e.g. `SM16703P_Init 16 SK6812`. Allowed chip type strings are "SK6812", "sk6812", "GRB", "grb".