### PR TITLE
addClockEvent fix time parsing

### DIFF
--- a/src/driver/drv_ntp.h
+++ b/src/driver/drv_ntp.h
@@ -24,6 +24,7 @@ int NTP_GetSunset();
 void NTP_SetSimulatedTime(unsigned int timeNow);
 // drv_ntp_events.c
 int NTP_PrintEventList();
+int NTP_GetEventTime(int id);
 int NTP_RemoveClockEvent(int id);
 int NTP_ClearEvents();
 

--- a/src/driver/drv_ntp_events.c
+++ b/src/driver/drv_ntp_events.c
@@ -325,7 +325,7 @@ commandResult_t CMD_NTP_AddClockEvent(const void *context, const char *cmd, cons
 	s = Tokenizer_GetArg(0);
 	flags = Tokenizer_GetArgInteger(1);
 
-	if (sscanf(s, "%i:%i:%i", &hour, &minute, &second) >= 2) {
+	if (sscanf(s, "%2d:%2d:%2d", &hour, &minute, &second) >= 2) {
 		// hour, minute and second has correct value parsed
 	}
 #if ENABLE_NTP_SUNRISE_SUNSET
@@ -415,6 +415,19 @@ commandResult_t CMD_NTP_RemoveClockEvent(const void* context, const char* cmd, c
 
 	return CMD_RES_OK;
 }
+
+int NTP_GetEventTime(int id) {
+	for (ntpEvent_t* e = ntp_events; e; e = e->next)
+	{
+		if (e->id == id)
+		{
+			return (int)e->hour * 3600 + (int)e->minute * 60 + (int)e->second;
+		}
+	}
+
+	return -1;
+}
+
 int NTP_PrintEventList() {
 	ntpEvent_t* e;
 	int t;

--- a/src/selftest/selftest_clockEvents.c
+++ b/src/selftest/selftest_clockEvents.c
@@ -72,9 +72,13 @@ void Test_ClockEvents() {
 	CMD_ExecuteCommand("addClockEvent 15:30:00 0xff 1007 POWER0 ON", 0);
 	// now there is 2
 	SELFTEST_ASSERT(NTP_PrintEventList() == 2);
-	CMD_ExecuteCommand("addClockEvent 15:30:00 0xff 1008 POWER0 ON", 0);
+	CMD_ExecuteCommand("addClockEvent 09:08:07 0xff 1008 POWER0 ON", 0);
 	// now there is 3
 	SELFTEST_ASSERT(NTP_PrintEventList() == 3);
+
+	SELFTEST_ASSERT(NTP_GetEventTime(1006) == 15 * 3600 + 30 * 60);
+	SELFTEST_ASSERT(NTP_GetEventTime(1007) == 15 * 3600 + 30 * 60);
+	SELFTEST_ASSERT(NTP_GetEventTime(1008) == 9 * 3600 + 8 * 60 + 7);
 
 	ResetEventsAndChannels(3);
 


### PR DESCRIPTION
Time parsing incorrectly parsed leading zeroes in 09:08 as octal numbers, and cause the wrong time to be used.