### PR TITLE
Properly allocate obkDevices array

### DIFF
--- a/src/driver/drv_ssdp.c
+++ b/src/driver/drv_ssdp.c
@@ -63,7 +63,7 @@ typedef struct OBK_DEVICE_tag{
     int timeout; // seconds
 } OBK_DEVICE;
 
-OBK_DEVICE obkDevices[MAX_OBK_DEVICES];
+static OBK_DEVICE obkDevices[MAX_OBK_DEVICES];
 
 static void obkDeviceTick(uint32_t ip){
     int i;


### PR DESCRIPTION
Array was not allocated, so writes were corrupting memory. Fixes time issue  #1080  on bl602 and I guess on LN882H, might be also cause of other crash. Other code needs review for similar issues.