### PR TITLE
Some more fixes to usage of gmtime

### DIFF
--- a/src/driver/drv_max72xx_clock.c
+++ b/src/driver/drv_max72xx_clock.c
@@ -70,7 +70,7 @@ void Clock_Send(int type) {
 	char *p;
 
 	// NOTE: on windows, you need _USE_32BIT_TIME_T 
-	ltm = gmtime((time_t*)&g_ntpTime);
+	ltm = gmtime(&g_ntpTime);
 
 	if (ltm == 0) {
 		return;

--- a/src/driver/drv_ntp_events.c
+++ b/src/driver/drv_ntp_events.c
@@ -16,6 +16,8 @@
 #define LOG_FEATURE LOG_FEATURE_NTP
 
 unsigned int ntp_eventsTime = 0;
+// to use time.h functions, we can't rely on time_t being unsigned int, so we need conversion to time_t in some cases
+static time_t tmptime;
 
 typedef struct ntpEvent_s {
 	byte hour;
@@ -171,7 +173,9 @@ void NTP_RunEventsForSecond(unsigned int runTime) {
 	struct tm *ltm;
 
 	// NOTE: on windows, you need _USE_32BIT_TIME_T 
-	ltm = gmtime((time_t*)&runTime);
+	// make sure to call gmtime with proper pointer to a time_t value
+	tmptime = (time_t)runTime;
+	ltm = gmtime(&tmptime);
 	
 	if (ltm == 0) {
 		return;
@@ -312,7 +316,9 @@ commandResult_t CMD_NTP_AddClockEvent(const void *context, const char *cmd, cons
 #if ENABLE_NTP_SUNRISE_SUNSET
 	uint8_t hour_b, minute_b;
 	int sunflags = 0;
-	struct tm *ltm = gmtime((time_t*) &ntp_eventsTime);
+	// make sure to call gmtime with proper pointer to a time_t value
+	tmptime = (time_t)ntp_eventsTime;
+	struct tm *ltm = gmtime(&tmptime);
 #endif
 
 	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START);

--- a/src/driver/drv_ntp_events.c
+++ b/src/driver/drv_ntp_events.c
@@ -15,9 +15,7 @@
 #define M_PI   3.14159265358979323846264338327950288
 #define LOG_FEATURE LOG_FEATURE_NTP
 
-unsigned int ntp_eventsTime = 0;
-// to use time.h functions, we can't rely on time_t being unsigned int, so we need conversion to time_t in some cases
-static time_t tmptime;
+time_t  ntp_eventsTime = 0;
 
 typedef struct ntpEvent_s {
 	byte hour;
@@ -168,14 +166,12 @@ void NTP_CalculateSunset(byte *outHour, byte *outMinute) {
 }
 #endif
 
-void NTP_RunEventsForSecond(unsigned int runTime) {
+void NTP_RunEventsForSecond(time_t runTime) {
 	ntpEvent_t *e;
 	struct tm *ltm;
 
 	// NOTE: on windows, you need _USE_32BIT_TIME_T 
-	// make sure to call gmtime with proper pointer to a time_t value
-	tmptime = (time_t)runTime;
-	ltm = gmtime(&tmptime);
+	ltm = gmtime(&runTime);
 	
 	if (ltm == 0) {
 		return;
@@ -222,17 +218,17 @@ void NTP_RunEvents(unsigned int newTime, bool bTimeValid) {
 	}
 	// old time invalid, but new one ok?
 	if (ntp_eventsTime == 0) {
-		ntp_eventsTime = newTime;
+		ntp_eventsTime = (time_t)newTime;
 		return;
 	}
 	// time went backwards
 	if (newTime < ntp_eventsTime) {
-		ntp_eventsTime = newTime;
+		ntp_eventsTime = (time_t)newTime;
 		return;
 	}
 	if (ntp_events) {
 		// NTP resynchronization could cause us to skip some seconds in some rare cases?
-		delta = newTime - ntp_eventsTime;
+		delta = (unsigned int)((time_t)newTime - ntp_eventsTime);
 		// a large shift in time is not expected, so limit to a constant number of seconds
 		if (delta > 100)
 			delta = 100;
@@ -240,7 +236,7 @@ void NTP_RunEvents(unsigned int newTime, bool bTimeValid) {
 			NTP_RunEventsForSecond(ntp_eventsTime + i);
 		}
 	}
-	ntp_eventsTime = newTime;
+	ntp_eventsTime = (time_t)newTime;
 }
 
 #if ENABLE_NTP_SUNRISE_SUNSET
@@ -316,9 +312,7 @@ commandResult_t CMD_NTP_AddClockEvent(const void *context, const char *cmd, cons
 #if ENABLE_NTP_SUNRISE_SUNSET
 	uint8_t hour_b, minute_b;
 	int sunflags = 0;
-	// make sure to call gmtime with proper pointer to a time_t value
-	tmptime = (time_t)ntp_eventsTime;
-	struct tm *ltm = gmtime(&tmptime);
+	struct tm *ltm = gmtime(&ntp_eventsTime);
 #endif
 
 	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START);

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -653,7 +653,7 @@ static int http_tasmota_json_status_generic(void* request, jsonCb_t printer) {
 	JSON_PrintKeyValue_String(request, printer, "RestartReason", "HardwareWatchdog", true);
 	JSON_PrintKeyValue_Int(request, printer, "Uptime", g_secondsElapsed, true);
 	struct tm* ltm;
-	if (NTP_IsTimeSynced()) {	// otherwise NTP_GetCurrentTimeWithoutOffset() is 0 leading to negative value if subtracting g_secondsElapsed
+	if (NTP_GetCurrentTimeWithoutOffset() > g_secondsElapsed) {	// would be negative else, leading to unwanted results when converted to (unsigned) time_t 
 		time_t ntpTime = (time_t)NTP_GetCurrentTimeWithoutOffset() - (time_t)g_secondsElapsed;
 		ltm = gmtime(&ntpTime);
 

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -653,11 +653,13 @@ static int http_tasmota_json_status_generic(void* request, jsonCb_t printer) {
 	JSON_PrintKeyValue_String(request, printer, "RestartReason", "HardwareWatchdog", true);
 	JSON_PrintKeyValue_Int(request, printer, "Uptime", g_secondsElapsed, true);
 	struct tm* ltm;
-	int ntpTime = NTP_GetCurrentTime() - g_secondsElapsed;
-	ltm = gmtime((time_t*)&ntpTime);
+	if (NTP_IsTimeSynced()) {	// otherwise NTP_GetCurrentTimeWithoutOffset() is 0 leading to negative value if subtracting g_secondsElapsed
+		time_t ntpTime = (time_t)NTP_GetCurrentTimeWithoutOffset() - (time_t)g_secondsElapsed;
+		ltm = gmtime(&ntpTime);
 
-	if (ltm != 0) {
-		printer(request, "\"StartupUTC\":\"%04d-%02d-%02dT%02d:%02d:%02d\",", ltm->tm_year + 1900, ltm->tm_mon + 1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
+		if (ltm != 0) {
+			printer(request, "\"StartupUTC\":\"%04d-%02d-%02dT%02d:%02d:%02d\",", ltm->tm_year + 1900, ltm->tm_mon + 1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
+		}
 	}
 	else {
 

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -653,16 +653,15 @@ static int http_tasmota_json_status_generic(void* request, jsonCb_t printer) {
 	JSON_PrintKeyValue_String(request, printer, "RestartReason", "HardwareWatchdog", true);
 	JSON_PrintKeyValue_Int(request, printer, "Uptime", g_secondsElapsed, true);
 	struct tm* ltm;
+	time_t ntpTime = 0; // if no NTP_time set, we will not change this value, but just stick to 0 and hence "fake" start of epoch 1970-01-01T00:00:00
 	if (NTP_GetCurrentTimeWithoutOffset() > g_secondsElapsed) {	// would be negative else, leading to unwanted results when converted to (unsigned) time_t 
-		time_t ntpTime = (time_t)NTP_GetCurrentTimeWithoutOffset() - (time_t)g_secondsElapsed;
-		ltm = gmtime(&ntpTime);
-
-		if (ltm != 0) {
-			printer(request, "\"StartupUTC\":\"%04d-%02d-%02dT%02d:%02d:%02d\",", ltm->tm_year + 1900, ltm->tm_mon + 1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
-		}
+		ntpTime = (time_t)NTP_GetCurrentTimeWithoutOffset() - (time_t)g_secondsElapsed;
+	}
+	ltm = gmtime(&ntpTime);
+	if (ltm != 0) {
+		printer(request, "\"StartupUTC\":\"%04d-%02d-%02dT%02d:%02d:%02d\",", ltm->tm_year + 1900, ltm->tm_mon + 1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
 	}
 	else {
-
 	}
 	JSON_PrintKeyValue_Int(request, printer, "Sleep", 50, true);
 	JSON_PrintKeyValue_Int(request, printer, "CfgHolder", 4617, true);


### PR DESCRIPTION
After recent changes to fix usage of time_t, there were 4 other places, which should be addressed:

```
max@max:~/LN882H/20240326/OpenBK7231T_App$ find . -name "*.[ch]" | xargs grep -C 2 -n  "gmtime((time_t"
./src/driver/drv_max72xx_clock.c-71-
./src/driver/drv_max72xx_clock.c-72-	// NOTE: on windows, you need _USE_32BIT_TIME_T 
./src/driver/drv_max72xx_clock.c:73:	ltm = gmtime((time_t*)&g_ntpTime);
./src/driver/drv_max72xx_clock.c-74-
./src/driver/drv_max72xx_clock.c-75-	if (ltm == 0) {
--
./src/driver/drv_ntp_events.c-172-
./src/driver/drv_ntp_events.c-173-	// NOTE: on windows, you need _USE_32BIT_TIME_T 
./src/driver/drv_ntp_events.c:174:	ltm = gmtime((time_t*)&runTime);
./src/driver/drv_ntp_events.c-175-	
./src/driver/drv_ntp_events.c-176-	if (ltm == 0) {
--
./src/driver/drv_ntp_events.c-313-	uint8_t hour_b, minute_b;
./src/driver/drv_ntp_events.c-314-	int sunflags = 0;
./src/driver/drv_ntp_events.c:315:	struct tm *ltm = gmtime((time_t*) &ntp_eventsTime);
./src/driver/drv_ntp_events.c-316-#endif
./src/driver/drv_ntp_events.c-317-
--
./src/httpserver/json_interface.c-655-	struct tm* ltm;
./src/httpserver/json_interface.c-656-	int ntpTime = NTP_GetCurrentTime() - g_secondsElapsed;
./src/httpserver/json_interface.c:657:	ltm = gmtime((time_t*)&ntpTime);
./src/httpserver/json_interface.c-658-
./src/httpserver/json_interface.c-659-	if (ltm != 0) {
max@max:~/LN882H/20240326/OpenBK7231T_App$ 

```

The first one (in /src/driver/drv_max72xx_clock.c) is just a forgotten removal of the (now obsolete) typecast.

The second and third in _src/driver/drv_ntp_events.c_ will need some consideration:
"runtime" is a parameter ("void NTP_RunEventsForSecond(unsigned int runTime) {") so it would need to alter the function call to use "time_t runTime" or we can just use the working typecast to a time_t var here (like in the "quick and dirty solution)

An alternate "fix" could be to define "ntp_eventsTime" as time_t, too, this will resolve both issues (since "runTime" is called with "ntp_eventsTime", so we can change both to "time_t". On the other hand, all calculations with times are based on "unsigned int", so they would need attention, to.
So I used the first approach, to cast "unsigned in" to time_t, which is of same or even larger type, so casting shold be o.k.

For the third occurrence I propose something like my "solution" from issue again:
	adding a test, if NTP is synced - this avoids calling it when NTP is not synced (resulting in a negative "ntpTime")
	define ntpTime as time_t her, too (doing the casting inside the calculation
	and we can fix using the local time instead of UTC time at the same time ;-)
	