### PR TITLE
Add LittleFS for BL602

### DIFF
--- a/bouffalo.mk
+++ b/bouffalo.mk
@@ -1,7 +1,7 @@
 # Component Makefile
 #
 ## These include paths would be exported to project level
-COMPONENT_ADD_INCLUDEDIRS += src/ src/httpserver/ src/cmnds/ src/logging/ src/hal/bl602/ src/mqtt/ src/cJSON src/base64 src/driver src/devicegroups src/bitmessage
+COMPONENT_ADD_INCLUDEDIRS += src/ src/httpserver/ src/cmnds/ src/logging/ src/hal/bl602/ src/mqtt/ src/cJSON src/base64 src/driver src/devicegroups src/bitmessage src/littlefs
 
 ## not be exported to project level
 COMPONENT_PRIV_INCLUDEDIRS :=
@@ -14,7 +14,7 @@ COMPONENT_SRCS :=
 COMPONENT_OBJS := $(patsubst %.c,%.o, $(COMPONENT_SRCS))
 COMPONENT_OBJS := $(patsubst %.S,%.o, $(COMPONENT_OBJS))
 
-COMPONENT_SRCDIRS := src/ src/jsmn src/httpserver/ src/cmnds/ src/logging/ src/hal/bl602/ src/mqtt/ src/cJSON src/base64 src/driver src/devicegroups src/bitmessage
+COMPONENT_SRCDIRS := src/ src/jsmn src/httpserver/ src/cmnds/ src/logging/ src/hal/bl602/ src/mqtt/ src/cJSON src/base64 src/driver src/devicegroups src/bitmessage src/littlefs
 
 
 

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -771,7 +771,7 @@ void CMD_Init_Early() {
 
 	CMD_RegisterCommand("TimeSize", CMD_TimeSize, NULL);
 
-#if (defined WINDOWS) || (defined PLATFORM_BEKEN)
+#if (defined WINDOWS) || (defined PLATFORM_BEKEN) || (defined PLATFORM_BL602)
 	CMD_InitScripting();
 #endif
 	if (!bSafeMode) {

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -534,6 +534,14 @@ static int http_rest_post_lfs_file(http_request_t* request) {
 	// create if it does not exist
 	init_lfs(1);
 
+	if (!lfs_present()) {
+		request->responseCode = 400;
+		http_setup(request, httpMimeTypeText);
+		poststr(request, "LittleFS is not abailable");
+		poststr(request, NULL);
+		return 0;
+	}
+
 	fpath = os_malloc(strlen(request->url) - strlen("api/lfs/") + 1);
 	file = os_malloc(sizeof(lfs_file_t));
 	memset(file, 0, sizeof(lfs_file_t));

--- a/src/littlefs/lfs_util.h
+++ b/src/littlefs/lfs_util.h
@@ -7,7 +7,12 @@
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H
 
+#if PLATFORM_BEKEN
 #include "mem_pub.h"
+#elif PLATFORM_BL602
+#define os_free free
+#define os_malloc malloc
+#endif
 
 // Users can override lfs_util.h with their own configuration by defining
 // LFS_CONFIG as a header file to include (-DLFS_CONFIG=lfs_config.h).

--- a/src/littlefs/our_lfs.c
+++ b/src/littlefs/our_lfs.c
@@ -8,14 +8,23 @@
 *****************************************************************************/
 
 #include "../new_common.h"
-#include "typedef.h"
 #include "our_lfs.h"
 #include "../logging/logging.h"
-#include "flash_pub.h"
 #include "../new_cfg.h"
 #include "../new_cfg.h"
 #include "../cmnds/cmd_public.h"
 
+#if PLATFORM_BEKEN
+
+#include "typedef.h"
+#include "flash_pub.h"
+
+#elif PLATFORM_BL602
+
+#include <bl_flash.h>
+#include <bl_mtd.h>
+
+#endif
 
 
 //https://github.com/littlefs-project/littlefs
@@ -31,9 +40,11 @@ lfs_t lfs;
 lfs_file_t file;
 
 // from flash.c
+#if PLATFORM_BEKEN
 extern UINT32 flash_read(char *user_buf, UINT32 count, UINT32 address);
 extern UINT32 flash_write(char *user_buf, UINT32 count, UINT32 address);
 extern UINT32 flash_ctrl(UINT32 cmd, void *parm);
+#endif 
 
 #ifdef LFS_BOOTCOUNT
 int boot_count = -1;
@@ -371,6 +382,27 @@ void init_lfs(int create){
             return;
         }
 
+	#if PLATFORM_BL602
+	// ensure we have media partition at correct place, because it can change depending on bldevcube version
+	// this supports 1.4.8
+	    
+	int ret;
+    	bl_mtd_info_t info;
+	bl_mtd_handle_t handle;
+
+    	ret = bl_mtd_open(BL_MTD_PARTITION_NAME_ROMFS, &handle, BL_MTD_OPEN_FLAG_BUSADDR);
+    	if (ret < 0) {
+		ADDLOGF_ERROR("LFS media partition not found %d", ret);
+		return;
+	}
+    	memset(&info, 0, sizeof(info));
+        bl_mtd_info(handle, &info);
+	if (info.offset != LFS_BLOCKS_START ){
+		ADDLOGF_ERROR("LFS media partition position 0x%X while expected is 0x%X", info.offset, LFS_BLOCKS_START);
+		return;
+	}
+	#endif
+
         LFS_Start = newstart;
         LFS_Size = newsize;
         cfg.block_count = (newsize/LFS_BLOCK_SIZE);
@@ -427,6 +459,7 @@ void release_lfs(){
 }
 
 
+#if PLATFORM_BEKEN
 // Read a region in a block. Negative error codes are propogated
 // to the user.
 static int lfs_read(const struct lfs_config *c, lfs_block_t block,
@@ -486,6 +519,50 @@ static int lfs_erase(const struct lfs_config *c, lfs_block_t block){
     GLOBAL_INT_RESTORE();
     return res;
 }
+#elif PLATFORM_BL602
+
+static int lfs_read(const struct lfs_config *c, lfs_block_t block,
+        lfs_off_t off, void *buffer, lfs_size_t size){
+    int res;
+    unsigned int startAddr = LFS_Start;
+    startAddr += block*LFS_BLOCK_SIZE;
+    startAddr += off;
+    res = bl_flash_read(startAddr, (uint8_t *)buffer, size );
+    return res;
+}
+
+// Program a region in a block. The block must have previously
+// been erased. Negative error codes are propogated to the user.
+// May return LFS_ERR_CORRUPT if the block should be considered bad.
+static int lfs_write(const struct lfs_config *c, lfs_block_t block,
+        lfs_off_t off, const void *buffer, lfs_size_t size){
+    int res;
+    unsigned int startAddr = LFS_Start;
+
+
+    startAddr += block*LFS_BLOCK_SIZE;
+    startAddr += off;
+
+	res = bl_flash_write(startAddr, (uint8_t *)buffer, size );
+
+
+    return res;
+}
+
+// Erase a block. A block must be erased before being programmed.
+// The state of an erased block is undefined. Negative error codes
+// are propogated to the user.
+// May return LFS_ERR_CORRUPT if the block should be considered bad.
+static int lfs_erase(const struct lfs_config *c, lfs_block_t block){
+    int res;
+    unsigned int startAddr = LFS_Start;
+    startAddr += block*LFS_BLOCK_SIZE;
+    res =  bl_flash_erase(startAddr, LFS_BLOCK_SIZE);
+    return res;
+}
+
+
+#endif 
 
 // Sync the state of the underlying block device. Negative error codes
 // are propogated to the user.

--- a/src/littlefs/our_lfs.h
+++ b/src/littlefs/our_lfs.h
@@ -8,6 +8,10 @@
 *
 *****************************************************************************/
 
+#ifndef __OUR_LFS_H__
+#define __OUR_LFS_H__
+
+
 #include "../obk_config.h"
 
 // we need that even if LFS is disabled
@@ -24,6 +28,13 @@
 #define LFS_BLOCKS_START_MIN 0x12B000
 // end of OTA flash
 #define LFS_BLOCKS_END 0x1D0000
+#elif PLATFORM_BL602
+// start media partition in bldevcube 1.4.8 partition config
+#define LFS_BLOCKS_START 0x192000
+#define LFS_BLOCKS_START_MIN 0x192000
+// end media partition
+#define LFS_BLOCKS_END 0x1E9000
+
 #else
 // TODO
 // start 0x1000 after OTA addr
@@ -55,4 +66,5 @@ void LFSAddCmds();
 void init_lfs(int create);
 void release_lfs();
 int lfs_present();
+#endif
 #endif

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -198,10 +198,8 @@ typedef int (*beken_thread_function_t)(void *p);
 #include <task.h>
 #include <portable.h>
 #include <semphr.h>
-
-typedef int bool;
-#define true 1
-#define false 0
+#include <stdbool.h>
+#include <stdint.h>
 
 #define ASSERT
 #define os_strcpy strcpy

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -64,6 +64,7 @@
 
 // I have enabled drivers on BL602
 #define ENABLE_TASMOTADEVICEGROUPS 1
+#define ENABLE_LITTLEFS			1
 #define ENABLE_NTP    1
 #define ENABLE_DRIVER_LED       1
 #define ENABLE_DRIVER_BL0937    1

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -824,7 +824,7 @@ void QuickTick(void* param)
 	g_last_time = g_time;
 
 
-#if (defined WINDOWS) || (defined PLATFORM_BEKEN)
+#if (defined WINDOWS) || (defined PLATFORM_BEKEN) || (defined PLATFORM_BL602)
 	SVM_RunThreads(g_deltaTimeMS);
 #endif
 	RepeatingEvents_RunUpdate(g_deltaTimeMS * 0.001f);


### PR DESCRIPTION
This adds LittleFS  support for BL602 as requested in #1117 
It is using media partition, which is defined in partition layout, but unused. Offsets are currently static, so only supports layout from BLDevCube 1.4.8. 
Scripts also work.