### PR TITLE
Make freeze less aggresive

### DIFF
--- a/src/driver/drv_freeze.c
+++ b/src/driver/drv_freeze.c
@@ -7,9 +7,7 @@ void Freeze_OnEverySecond() {
 	}
 }
 void Freeze_RunFrame() {
-	while (1) {
-		// freeze
-	}
+	//don't freeze, seems this does not allow watchdog reset to work on BL602
 }
 void Freeze_Init() {
 	// don't freeze


### PR DESCRIPTION
So that it does not stop watchdog timer from working on BL602. Maybe RunFrame disables interrupts somewhere?