### PR TITLE
Fix for Issue 808: Door/Window sensor lost data after deep sleep

### DIFF
--- a/src/driver/drv_doorSensorWithDeepSleep.c
+++ b/src/driver/drv_doorSensorWithDeepSleep.c
@@ -104,7 +104,7 @@ void DoorDeepSleep_OnEverySecond() {
 					sprintf(sChannel, "%i/get", channel); // manually adding the suffix "/get" to the topic
 					// Explanation: I manually add "/get" suffix to the sChannel, because for some reason, 
 					// when queued messages are published through PuublishQueuedItems(), the  
-					// functionality of appendding /get is disabled (inMQTT_PublishTopicToClient()), 
+					// functionality of appendding /get is disabled (in MQTT_PublishTopicToClient()), 
 					// and there is no flag to enforce it. 
 					// There is only a flag (OBK_PUBLISH_FLAG_FORCE_REMOVE_GET) to remove 
 					// suffix, but for some reason there is no flag to add it. 

--- a/src/driver/drv_doorSensorWithDeepSleep.c
+++ b/src/driver/drv_doorSensorWithDeepSleep.c
@@ -59,8 +59,9 @@ void DoorDeepSleep_Init() {
 }
 
 void DoorDeepSleep_OnEverySecond() {
-	int i, bValue;
-	char tmp[8];
+	int i;
+	char sChannel[8]; // channel as a string
+	char sValue[8];   // channel value as a string
 
 #if PLATFORM_BK7231N || PLATFORM_BK7231T
 	if (ota_progress() >= 0) {
@@ -70,27 +71,20 @@ void DoorDeepSleep_OnEverySecond() {
 		// update active
 		g_noChangeTimePassed = 0;
 		g_emergencyTimeWithNoConnection = 0;
-	} else if (Main_HasMQTTConnected() && Main_HasWiFiConnected()) {
-		if (g_initialStateSent < 3) {
+	} else if (Main_HasMQTTConnected() && Main_HasWiFiConnected()) { // executes every second when connection is established
+			
+			PublishQueuedItems(); // publish those items that were queued when device was offline
 			for (i = 0; i < PLATFORM_GPIO_MAX; i++) {
 				if (g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep ||
 					g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep_NoPup ||
 					g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep_pd) {
-					sprintf(tmp, "%i", g_cfg.pins.channels[i]);
-					bValue = BIT_CHECK(g_initialPinStates, i);
-					MQTT_PublishMain_StringInt(tmp,bValue, 0);
+
+						// publish the current state. The value for publishing is 
+						// calculated winthin MQTT_ChannelPublish()
+						MQTT_ChannelPublish(g_cfg.pins.channels[i], 0);
 				}
 			}
-			g_initialStateSent++;
-		} else {
-			for (i = 0; i < PLATFORM_GPIO_MAX; i++) {
-				if (g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep ||
-					g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep_NoPup ||
-					g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep_pd) {
-					MQTT_ChannelPublish(g_cfg.pins.channels[i], 0);
-				}
-			}
-		}
+		// }
 		g_noChangeTimePassed++;
 		if (g_noChangeTimePassed >= setting_timeRequiredUntilDeepSleep) {
 			// start deep sleep in the next loop
@@ -101,7 +95,29 @@ void DoorDeepSleep_OnEverySecond() {
 			g_bWantPinDeepSleep = true;
 		}
 	}
-	else {
+	else { // executes every second while the device is woken up, but offline
+		for (i = 0; i < PLATFORM_GPIO_MAX; i++) {
+			if (g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep ||
+				g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep_NoPup ||
+				g_cfg.pins.roles[i] == IOR_DoorSensorWithDeepSleep_pd) {
+					int channel = g_cfg.pins.channels[i];
+					sprintf(sChannel, "%i/get", channel); // manually adding the suffix "/get" to the topic
+					// Explanation: I manually add "/get" suffix to the sChannel, because for some reason, 
+					// when queued messages are published through PuublishQueuedItems(), the  
+					// functionality of appendding /get is disabled (inMQTT_PublishTopicToClient()), 
+					// and there is no flag to enforce it. 
+					// There is only a flag (OBK_PUBLISH_FLAG_FORCE_REMOVE_GET) to remove 
+					// suffix, but for some reason there is no flag to add it. 
+					// Would be great if such flag exists, so I can add it when calling
+					// MQTT_QueuePublish(), so /get is appended when published through
+					// PublishQueuedItems(). 
+
+					sprintf(sValue, "%i", CHANNEL_Get(channel)); // get the value of the channel
+					MQTT_QueuePublish(CFG_GetMQTTClientId(), sChannel, sValue, 0); // queue the publishing
+					// Current state (or state change) will be queued and published when device establishes 
+					// the connection to WiFi and MQTT Broker (300 seconds by default for that).  
+			}
+		}
 		g_emergencyTimeWithNoConnection++;
 		if (g_emergencyTimeWithNoConnection >= EMERGENCY_TIME_TO_SLEEP_WITHOUT_MQTT) {
 			g_bWantPinDeepSleep = true;
@@ -128,6 +144,7 @@ void DoorDeepSleep_AppendInformationToHTTPIndexPage(http_request_t* request)
 }
 
 void DoorDeepSleep_OnChannelChanged(int ch, int value) {
+
 	// detect door state change
 	// (only sleep when there are no changes for certain time)
 	if (CHANNEL_HasChannelPinWithRoleOrRole(ch, IOR_DoorSensorWithDeepSleep, IOR_DoorSensorWithDeepSleep_NoPup)


### PR DESCRIPTION
**DoorWindowSensor driver has a security problem**, which is registered as an issue 808: if the open/close cycle happens fully before the device has been connected to MQTT broker, the event is lost. So, if an intruder opens/closes the door within about 15 seconds, this will not be registered.

The fix has been tested on 7 of Door Sensors, and it fully fixes the issue. It had been tested also with MQTT broker being down for 300 seconds to test for the queue overflow, and the memory limit is still very far.

**Proposed change leverages the MQTT queue API:**

- MQTT_QueuePublish() to queue the event while the device is still connecting to WiFi and/or MQTT,
- PublishQueuedItems() to dump all queued events when it has connected to MQTT Broker
The rest of the behavior is left intact: the device will publish events directly (without queue) every second when it's connected, until it goes to sleep again.

A few things about the queue API itself:
I don't understand why PublishQueuedItems() calls the MQTT_PublishTopicToClient() with appendGet parameter being set to false, effectively forbidding queued messages to be published to the same channel as those that are published directly. I think this is a bug, that requires a fix. For now, to work around this behavior, I am manually adding the suffix "/get" when queueing the event.