### PR TITLE
Fix index page performance for LN882H

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -771,7 +771,8 @@ int http_fn_index(http_request_t* request) {
 	}
 	if (Main_HasWiFiConnected())
 	{
-		hprintf255(request, "<h5>Wifi RSSI: %s (%idBm)</h5>", str_rssi[wifi_rssi_scale(HAL_GetWifiStrength())], HAL_GetWifiStrength());
+		int rssi = HAL_GetWifiStrength();
+		hprintf255(request, "<h5>Wifi RSSI: %s (%idBm)</h5>", str_rssi[wifi_rssi_scale(rssi)], rssi);
 	}
 #if PLATFORM_BEKEN
 	/*


### PR DESCRIPTION
Index page takes 2 seconds to refresh LN882H, due to rssi being called twice.
![image](https://github.com/openshwprojects/OpenBK7231T_App/assets/123905703/59278d08-e9f8-4d5d-b02e-7a145354ce26)
Calling it once makes performance normal for some reason

![image](https://github.com/openshwprojects/OpenBK7231T_App/assets/123905703/4a67e881-ce2b-4ab5-bf34-6a760018443b)
