### PR TITLE
Use ISO date everywhere

### DIFF
--- a/src/driver/drv_ntp.c
+++ b/src/driver/drv_ntp.c
@@ -442,7 +442,7 @@ void NTP_CheckForReceive() {
     g_ntpTime += g_timeOffsetSeconds;
     addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"Unix time  : %u",(unsigned int)g_ntpTime);
     ltm = gmtime(&g_ntpTime);
-    addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"Local Time : %04d/%02d/%02d %02d:%02d:%02d",
+    addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"Local Time : %04d-%02d-%02d %02d:%02d:%02d",
             ltm->tm_year+1900, ltm->tm_mon+1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
 
 	if (g_synced == false) {
@@ -523,7 +523,7 @@ void NTP_AppendInformationToHTTPIndexPage(http_request_t* request)
     ltm = gmtime(&g_ntpTime);
 
     if (g_synced == true)
-        hprintf255(request, "<h5>NTP (%s): Local Time: %04d/%02d/%02d %02d:%02d:%02d </h5>",
+        hprintf255(request, "<h5>NTP (%s): Local Time: %04d-%02d-%02d %02d:%02d:%02d </h5>",
 			CFG_GetNTPServer(),ltm->tm_year+1900, ltm->tm_mon+1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
     else 
         hprintf255(request, "<h5>NTP: Syncing with %s....</h5>",CFG_GetNTPServer());

--- a/src/win_main_scriptOnly.c
+++ b/src/win_main_scriptOnly.c
@@ -89,9 +89,9 @@ int __cdecl main(void)
 	  addLogAdv(1,1, "%sTime %i, idle %i/s, free %d, MQTT %i(%i), bWifi %i, secondsWithNoPing %i, socks %i/%i\n",
 		  "[TEST]", 123, 555,95000,1, 6, 
             1, -1, 3, 64);
-    printf("Consumption Reset Time: %04d/%02d/%02d %02d:%02d:%02d",
+    printf("Consumption Reset Time: %04d-%02d-%02d %02d:%02d:%02d",
                        ltm->tm_year+1900, ltm->tm_mon+1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
-    addLogAdv(1,1, "Consumption Reset Time: %04d/%02d/%02d %02d:%02d:%02d",
+    addLogAdv(1,1, "Consumption Reset Time: %04d-%02d-%02d %02d:%02d:%02d",
                        ltm->tm_year+1900, ltm->tm_mon+1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min, ltm->tm_sec);
 
             addLogAdv(1,1, "Today: %1.1f Wh DailyStats: [", 3.145f);


### PR DESCRIPTION
This makes date consistent everywhere, because now it's two different ways on front page.
yyyy/mm/dd is very odd format, with slashes it's usually mm/dd/yyyy. But I like to use ISO time.
![image](https://github.com/openshwprojects/OpenBK7231T_App/assets/123905703/95931143-68c2-41e2-a0e8-bb52517fa2f4)
