### PR TITLE
LN882H enable or disable sleep mode while using a PowerSave

### DIFF
--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -20,6 +20,7 @@ int cmd_uartInitIndex = 0;
 #include <wifi_mgmr_ext.h>
 #elif PLATFORM_LN882H
 #include <wifi.h>
+#include <power_mgmt/ln_pm.h>
 #endif
 
 #define HASH_SIZE 128
@@ -80,15 +81,22 @@ static commandResult_t CMD_PowerSave(const void* context, const char* cmd, const
 	if (bOn) {
 		sysparam_sta_powersave_update(WIFI_MAX_POWERSAVE);
 		wifi_sta_set_powersave(WIFI_MAX_POWERSAVE);
+		if (bOn > 1) {
+			 ln_pm_sleep_mode_set(LIGHT_SLEEP);
+		}
+		else {	// to be able to switch from PowerSave from > 1 to 1 (without sleep) 
+			 ln_pm_sleep_mode_set(ACTIVE);
+		}
 	}
 	else {
 		sysparam_sta_powersave_update(WIFI_NO_POWERSAVE);
 		wifi_sta_set_powersave(WIFI_NO_POWERSAVE);
+		ln_pm_sleep_mode_set(ACTIVE);
 	}
 #else
 	ADDLOG_INFO(LOG_FEATURE_CMD, "PowerSave is not implemented on this platform");
 #endif    
-	g_powersave = bOn;
+	g_powersave = (bOn);
 	return CMD_RES_OK;
 }
 static commandResult_t CMD_DeepSleep(const void* context, const char* cmd, const char* args, int cmdFlags) {

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -76,7 +76,12 @@ static commandResult_t CMD_PowerSave(const void* context, const char* cmd, const
 	if (Tokenizer_GetArgsCount() > 0) {
 		bOn = Tokenizer_GetArgInteger(0);
 	}
+#if (PLATFORM_LN882H)	
+	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_PowerSave: will set to %i%s", bOn, Main_IsConnectedToWiFi() == 0 ? " after WiFi is connected" : "");
+#else
 	ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_PowerSave: will set to %i", bOn);
+#endif
+	
 
 #ifdef PLATFORM_BEKEN
 	extern int bk_wlan_power_save_set_level(BK_PS_LEVEL level);
@@ -102,7 +107,10 @@ static commandResult_t CMD_PowerSave(const void* context, const char* cmd, const
 	}
 #elif defined(PLATFORM_LN882H)
 	// this will be applied after WiFi connect
-	g_ln882h_pendingPowerSaveCommand = bOn;
+	if (Main_IsConnectedToWiFi() == 0){
+		g_ln882h_pendingPowerSaveCommand = bOn;
+	}
+	else LN882H_ApplyPowerSave(bOn);
 #else
 	ADDLOG_INFO(LOG_FEATURE_CMD, "PowerSave is not implemented on this platform");
 #endif    

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -281,6 +281,13 @@ void ScheduleDriverStart(const char* name, int delay) {
 	}
 }
 
+#if defined(PLATFORM_LN882H)
+// LN882H hack, maybe place somewhere else?
+// this will be applied after WiFi connect
+extern int g_ln882h_pendingPowerSaveCommand;
+void LN882H_ApplyPowerSave(int bOn);
+#endif
+
 void Main_OnWiFiStatusChange(int code)
 {
 	// careful what you do in here.
@@ -324,7 +331,14 @@ void Main_OnWiFiStatusChange(int code)
 				//DRV_SSDP_Restart(); // this kills things
 			}
 		}
-
+#if defined(PLATFORM_LN882H)
+		// LN882H hack, maybe place somewhere else?
+		// this will be applied after WiFi connect
+		if (g_ln882h_pendingPowerSaveCommand != -1) {
+			LN882H_ApplyPowerSave(g_ln882h_pendingPowerSaveCommand);
+			g_ln882h_pendingPowerSaveCommand = -1;
+		}
+#endif
 		break;
 		/* for softap mode */
 	case WIFI_AP_CONNECTED:

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -331,6 +331,15 @@ void Main_OnWiFiStatusChange(int code)
 				//DRV_SSDP_Restart(); // this kills things
 			}
 		}
+#if defined(PLATFORM_LN882H)
+		// LN882H hack, maybe place somewhere else?
+		// this will be applied only if WiFi is connected
+		if (g_ln882h_pendingPowerSaveCommand != -1) {
+			ADDLOG_INFO(LOG_FEATURE_CMD, "CMD_PowerSave: applying delayed setting. PowerSave will set to %i", g_ln882h_pendingPowerSaveCommand);
+			LN882H_ApplyPowerSave(g_ln882h_pendingPowerSaveCommand);
+			g_ln882h_pendingPowerSaveCommand = -1;
+		}
+#endif
 		break;
 		/* for softap mode */
 	case WIFI_AP_CONNECTED:
@@ -730,14 +739,6 @@ void Main_OnEverySecond()
 				}
 			}
 		}
-#if defined(PLATFORM_LN882H)
-		// LN882H hack, maybe place somewhere else?
-		// this will be applied only if WiFi is connected
-		if (g_ln882h_pendingPowerSaveCommand != -1) {
-			LN882H_ApplyPowerSave(g_ln882h_pendingPowerSaveCommand);
-			g_ln882h_pendingPowerSaveCommand = -1;
-		}
-#endif
 
 	}
 	if (g_connectToWiFi)

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -331,14 +331,6 @@ void Main_OnWiFiStatusChange(int code)
 				//DRV_SSDP_Restart(); // this kills things
 			}
 		}
-#if defined(PLATFORM_LN882H)
-		// LN882H hack, maybe place somewhere else?
-		// this will be applied after WiFi connect
-		if (g_ln882h_pendingPowerSaveCommand != -1) {
-			LN882H_ApplyPowerSave(g_ln882h_pendingPowerSaveCommand);
-			g_ln882h_pendingPowerSaveCommand = -1;
-		}
-#endif
 		break;
 		/* for softap mode */
 	case WIFI_AP_CONNECTED:
@@ -738,6 +730,15 @@ void Main_OnEverySecond()
 				}
 			}
 		}
+#if defined(PLATFORM_LN882H)
+		// LN882H hack, maybe place somewhere else?
+		// this will be applied only if WiFi is connected
+		if (g_ln882h_pendingPowerSaveCommand != -1) {
+			LN882H_ApplyPowerSave(g_ln882h_pendingPowerSaveCommand);
+			g_ln882h_pendingPowerSaveCommand = -1;
+		}
+#endif
+
 	}
 	if (g_connectToWiFi)
 	{


### PR DESCRIPTION
A slight improvement (I hope) to PR #1143

Since for me using "ln_pm_sleep_mode_set(LIGHT_SLEEP)" makes metering with  BL0937 unusable, I suggest simply using PowerSave with a number > 1 to enable this (making it possible to decide, which level of PowerSave is wanted).
Since bOn is allready an int, its just one cahnge to set the bool value g_powersave not to bOn but to the bool value of bOn.

Then its possible to set sleep mode if PowerSave has a value > 1.

A word of warning:
PoweSave on LN882H will not work as a startup command.
Using "PowerSave 1" just seems to have no effect.
But using "PowerSave 2" as autostart command prevents the device from connecting to your WiFi network!
So please only use  "PowerSave 2" as a user command!

