### PR TITLE
Add AHT10/AHT2X/AHT30 I2C driver

### DIFF
--- a/src/driver/drv_aht2x.c
+++ b/src/driver/drv_aht2x.c
@@ -1,0 +1,241 @@
+#include "../new_pins.h"
+#include "../logging/logging.h"
+#include "drv_local.h"
+#include "drv_aht2x.h"
+
+#define AHT2X_I2C_ADDR (0x38 << 1)
+
+static byte g_aht_secondsUntilNextMeasurement = 1, g_aht_secondsBetweenMeasurements = 10,
+	max_retries = 20, channel_temp = 0, channel_humid = 0;
+static float g_temp = 0.0, g_humid = 0.0, g_calTemp = 0.0, g_calHum = 0.0;
+static softI2C_t g_softI2C;
+static bool isWorking = false;
+
+void AHT2X_SoftReset()
+{
+	ADDLOG_DEBUG(LOG_FEATURE_SENSOR, "AHT2X_SoftReset: Resetting sensor");
+	Soft_I2C_Start(&g_softI2C, AHT2X_I2C_ADDR);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_CMD_RST);
+	Soft_I2C_Stop(&g_softI2C);
+	rtos_delay_milliseconds(20);
+}
+
+void AHT2X_Initialization()
+{
+	AHT2X_SoftReset();
+
+	Soft_I2C_Start(&g_softI2C, AHT2X_I2C_ADDR);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_CMD_INI);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_DAT_INI1);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_DAT_INI2);
+	Soft_I2C_Stop(&g_softI2C);
+
+	uint8_t data = AHT2X_DAT_BUSY;
+	uint8_t attempts = 0;
+
+	while(data & AHT2X_DAT_BUSY)
+	{
+		rtos_delay_milliseconds(20);
+		Soft_I2C_Start(&g_softI2C, AHT2X_I2C_ADDR | 1);
+		data = Soft_I2C_ReadByte(&g_softI2C, true);
+		Soft_I2C_Stop(&g_softI2C);
+		attempts++;
+		if(attempts > max_retries)
+		{
+			ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Initialization: Sensor timed out.");
+			isWorking = false;
+			break;
+		}
+	}
+	if((data & 0x68) != 0x08)
+	{
+		ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Initialization: Initialization failed.");
+		isWorking = false;
+	}
+	else
+	{
+		ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Initialization: Initialization successful.");
+		isWorking = true;
+	}
+}
+
+void AHT2X_StopDriver()
+{
+	AHT2X_SoftReset();
+}
+
+void AHT2X_Measure()
+{
+	uint8_t data[6] = { 0, };
+
+	Soft_I2C_Start(&g_softI2C, AHT2X_I2C_ADDR);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_CMD_TMS);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_DAT_TMS1);
+	Soft_I2C_WriteByte(&g_softI2C, AHT2X_DAT_TMS2);
+	Soft_I2C_Stop(&g_softI2C);
+
+	bool ready = false;
+
+	rtos_delay_milliseconds(80);
+
+	for(uint8_t i = 0; i < 10; i++)
+	{
+		Soft_I2C_Start(&g_softI2C, AHT2X_I2C_ADDR | 1);
+		Soft_I2C_ReadBytes(&g_softI2C, data, 6);
+		Soft_I2C_Stop(&g_softI2C);
+		if((data[0] & AHT2X_DAT_BUSY) != AHT2X_DAT_BUSY)
+		{
+			ready = true;
+			break;
+		}
+		else
+		{
+			ADDLOG_DEBUG(LOG_FEATURE_SENSOR, "AHT2X_Measure: Sensor is busy, waiting... (%ims)", i * 20);
+			rtos_delay_milliseconds(20);
+		}
+	}
+
+	if(!ready)
+	{
+		ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Measure: Measurements reading timed out.");
+		return;
+	}
+
+	if(data[1] == 0x0 && data[2] == 0x0 && (data[3] >> 4) == 0x0)
+	{
+		ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Measure: Unrealistic humidity, will not update values.");
+		return;
+	}
+	uint32_t raw_temperature = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5];
+	uint32_t raw_humidity = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4;
+
+	g_humid = ((float)raw_humidity * 100.0f / 1048576.0f) + g_calHum;
+	g_temp = (((200.0f * (float)raw_temperature) / 1048576.0f) - 50.0f) + g_calTemp;
+
+	channel_temp = g_cfg.pins.channels[g_softI2C.pin_data];
+	channel_humid = g_cfg.pins.channels2[g_softI2C.pin_data];
+	CHANNEL_Set(channel_temp, (int)(g_temp * 10), 0);
+	CHANNEL_Set(channel_humid, (int)(g_humid), 0);
+
+	ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Measure: Temperature:%fC Humidity:%f%%", g_temp, g_humid);
+}
+
+commandResult_t AHT2X_Calibrate(const void* context, const char* cmd, const char* args, int cmdFlags)
+{
+	Tokenizer_TokenizeString(args, TOKENIZER_ALLOW_QUOTES | TOKENIZER_DONT_EXPAND);
+	if(Tokenizer_CheckArgsCountAndPrintWarning(cmd, 2))
+	{
+		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+	}
+	g_calTemp = Tokenizer_GetArgFloat(0);
+	g_calHum = Tokenizer_GetArgFloat(1);
+
+	ADDLOG_INFO(LOG_FEATURE_SENSOR, "AHT2X_Calibrate: Calibration done temp %f and humidity %f", g_calTemp, g_calHum);
+
+	return CMD_RES_OK;
+}
+
+commandResult_t AHT2X_Cycle(const void* context, const char* cmd, const char* args, int cmdFlags)
+{
+	Tokenizer_TokenizeString(args, TOKENIZER_ALLOW_QUOTES | TOKENIZER_DONT_EXPAND);
+	if(Tokenizer_CheckArgsCountAndPrintWarning(cmd, 1))
+	{
+		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+	}
+
+	int seconds = Tokenizer_GetArgInteger(0);
+	if(seconds < 1)
+	{
+		ADDLOG_INFO(LOG_FEATURE_CMD, "AHT2X_Cycle: You must have at least 1 second cycle.");
+		return CMD_RES_BAD_ARGUMENT;
+	}
+	else
+	{
+		g_aht_secondsBetweenMeasurements = seconds;
+	}
+
+	ADDLOG_INFO(LOG_FEATURE_CMD, "AHT2X_Cycle: Measurement will run every %i seconds.", g_aht_secondsBetweenMeasurements);
+
+	return CMD_RES_OK;
+}
+
+commandResult_t AHT2X_Force(const void* context, const char* cmd, const char* args, int cmdFlags)
+{
+	g_aht_secondsUntilNextMeasurement = g_aht_secondsBetweenMeasurements;
+
+	AHT2X_Measure();
+
+	return CMD_RES_OK;
+}
+
+commandResult_t AHT2X_Reinit(const void* context, const char* cmd, const char* args, int cmdFlags)
+{
+	g_aht_secondsUntilNextMeasurement = g_aht_secondsBetweenMeasurements;
+
+	AHT2X_Initialization();
+
+	return CMD_RES_OK;
+}
+
+void AHT2X_Init()
+{
+	g_softI2C.pin_clk = 9;
+	g_softI2C.pin_data = 14;
+	g_softI2C.pin_clk = PIN_FindPinIndexForRole(IOR_AHT2X_CLK, g_softI2C.pin_clk);
+	g_softI2C.pin_data = PIN_FindPinIndexForRole(IOR_AHT2X_DAT, g_softI2C.pin_data);
+
+	channel_temp = g_cfg.pins.channels[g_softI2C.pin_data];
+	channel_humid = g_cfg.pins.channels2[g_softI2C.pin_data];
+
+	Soft_I2C_PreInit(&g_softI2C);
+	rtos_delay_milliseconds(100);
+
+	AHT2X_Initialization();
+
+	//cmddetail:{"name":"AHT2X_Calibrate","args":"[DeltaTemp][DeltaHumidity]",
+	//cmddetail:"descr":"Calibrate the AHT2X Sensor as Tolerance is +/-2 degrees C.",
+	//cmddetail:"fn":"AHT2X_Calibrate","file":"driver/drv_aht2x.c","requires":"",
+	//cmddetail:"examples":"AHT2X_Calibrate -4 10 <br /> meaning -4 on current temp reading and +10 on current humidity reading"}
+	CMD_RegisterCommand("AHT2X_Calibrate", AHT2X_Calibrate, NULL);
+	//cmddetail:{"name":"AHT2X_Cycle","args":"[IntervalSeconds]",
+	//cmddetail:"descr":"This is the interval between measurements in seconds, by default 1. Max is 255.",
+	//cmddetail:"fn":"AHT2X_cycle","file":"drv/drv_aht2X.c","requires":"",
+	//cmddetail:"examples":"AHT2X_Cycle 60 <br /> measurement is taken every 60 seconds"}
+	CMD_RegisterCommand("AHT2X_Cycle", AHT2X_Cycle, NULL);
+	//cmddetail:{"name":"AHT2X_Measure","args":"",
+	//cmddetail:"descr":"Retrieve OneShot measurement.",
+	//cmddetail:"fn":"AHT2X_Measure","file":"drv/drv_aht2X.c","requires":"",
+	//cmddetail:"examples":"AHT2X_Measure"}
+	CMD_RegisterCommand("AHT2X_Measure", AHT2X_Force, NULL);
+	//cmddetail:{"name":"AHT2X_Reinit","args":"",
+	//cmddetail:"descr":"Reinitialize sensor.",
+	//cmddetail:"fn":"AHT2X_Reinit","file":"drv/drv_aht2X.c","requires":"",
+	//cmddetail:"examples":"AHT2X_Reinit"}
+	CMD_RegisterCommand("AHT2X_Reinit", AHT2X_Reinit, NULL);
+}
+
+void AHT2X_OnEverySecond()
+{
+	if(g_aht_secondsUntilNextMeasurement <= 0)
+	{
+		if(isWorking) AHT2X_Measure();
+		g_aht_secondsUntilNextMeasurement = g_aht_secondsBetweenMeasurements;
+	}
+	if(g_aht_secondsUntilNextMeasurement > 0)
+	{
+		g_aht_secondsUntilNextMeasurement--;
+	}
+}
+
+void AHT2X_AppendInformationToHTTPIndexPage(http_request_t* request)
+{
+	hprintf255(request, "<h2>AHT2X Temperature=%f, Humidity=%f</h2>", g_temp, g_humid);
+	if(!isWorking)
+	{
+		hprintf255(request, "WARNING: AHT sensor appears to have failed initialization, check if configured pins are correct!");
+	}
+	if(channel_humid == channel_temp)
+	{
+		hprintf255(request, "WARNING: You don't have configured target channels for temp and humid results, set the first and second channel index in Pins!");
+	}
+}

--- a/src/driver/drv_aht2x.h
+++ b/src/driver/drv_aht2x.h
@@ -1,0 +1,8 @@
+#define AHT2X_CMD_INI	0xBE
+#define AHT2X_DAT_INI1	0x08
+#define AHT2X_DAT_INI2	0x00
+#define AHT2X_CMD_TMS	0xAC
+#define AHT2X_DAT_TMS1	0x33
+#define AHT2X_DAT_TMS2	0x00
+#define AHT2X_CMD_RST	0xBA
+#define AHT2X_DAT_BUSY	0x80

--- a/src/driver/drv_local.h
+++ b/src/driver/drv_local.h
@@ -93,6 +93,11 @@ void SHT3X_AppendInformationToHTTPIndexPage(http_request_t* request);
 void SHT3X_OnEverySecond();
 void SHT3X_StopDriver();
 
+void AHT2X_Init();
+void AHT2X_AppendInformationToHTTPIndexPage(http_request_t* request);
+void AHT2X_OnEverySecond();
+void AHT2X_StopDriver();
+
 void SGP_Init();
 void SGP_AppendInformationToHTTPIndexPage(http_request_t* request);
 void SGP_OnEverySecond();

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -315,6 +315,11 @@ static driver_t g_drivers[] = {
 	//drvdetail:"descr":"SGP Air Quality sensor with I2C interface. See [this DIY sensor](https://www.elektroda.com/rtvforum/topic3967174.html) for setup information.",
 	//drvdetail:"requires":""}
 	{ "SGP",	    SGP_Init,		SGP_OnEverySecond,		SGP_AppendInformationToHTTPIndexPage, NULL, SGP_StopDriver, NULL, false },
+	//drvdetail:{"name":"AHT2X",
+	//drvdetail:"title":"TODO",
+	//drvdetail:"descr":"AHT Humidity/temperature sensor. Supported sensors are: AHT10, AHT2X, AHT30.",
+	//drvdetail:"requires":""}
+	{ "AHT2X",	AHT2X_Init,	AHT2X_OnEverySecond,	AHT2X_AppendInformationToHTTPIndexPage,	NULL,	AHT2X_StopDriver,	NULL,	false },
 
 	//drvdetail:{"name":"ShiftRegister",
 	//drvdetail:"title":"TODO",
@@ -587,7 +592,7 @@ bool DRV_IsMeasuringBattery() {
 
 bool DRV_IsSensor() {
 #ifndef OBK_DISABLE_ALL_DRIVERS
-	return DRV_IsRunning("SHT3X") || DRV_IsRunning("CHT8305") || DRV_IsRunning("SGP");
+	return DRV_IsRunning("SHT3X") || DRV_IsRunning("CHT8305") || DRV_IsRunning("SGP") || DRV_IsRunning("AHT2X");
 #else
 	return false;
 #endif

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2532,7 +2532,8 @@ int http_fn_cfg_pins(http_request_t* request) {
 		poststr(request, "</select>");
 		// Primary linked channel
 		// Some roles do not need any channels
-		if ((si != IOR_SGP_CLK && si != IOR_SHT3X_CLK && si != IOR_CHT8305_CLK && si != IOR_Button_ToggleAll && si != IOR_Button_ToggleAll_n
+		if ((si != IOR_AHT2X_CLK && si != IOR_SGP_CLK && si != IOR_SHT3X_CLK
+			&& si != IOR_CHT8305_CLK && si != IOR_Button_ToggleAll && si != IOR_Button_ToggleAll_n
 			&& si != IOR_BL0937_CF && si != IOR_BL0937_CF1 && si != IOR_BL0937_SEL
 			&& si != IOR_LED_WIFI && si != IOR_LED_WIFI_n && si != IOR_LED_WIFI_n
 			&& !(si >= IOR_IRRecv && si <= IOR_DHT11)

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -473,8 +473,8 @@ const char* htmlPinRoleNames[] = {
 	"BAT_Relay_n",
 	"KP18058_CLK",
 	"KP18058_DAT",
-	"error",
-	"error",
+	"AHT2X_SDA",
+	"AHT2X_SCK",
 	"error",
 	"error",
 };

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -1509,8 +1509,9 @@ bool CHANNEL_ShouldBePublished(int ch) {
 		if (g_cfg.pins.channels[i] == ch) {
 			if (role == IOR_Relay || role == IOR_Relay_n
 				|| role == IOR_LED || role == IOR_LED_n
-				|| role == IOR_ADC || role == IOR_BAT_ADC 
-				|| role == IOR_CHT8305_DAT || role == IOR_SHT3X_DAT || role == IOR_SGP_DAT
+				|| role == IOR_ADC || role == IOR_BAT_ADC
+				|| role == IOR_CHT8305_DAT || role == IOR_SHT3X_DAT
+				|| role == IOR_SGP_DAT || role == IOR_AHT2X_DAT
 				|| role == IOR_DigitalInput || role == IOR_DigitalInput_n
 				|| role == IOR_DoorSensorWithDeepSleep || role == IOR_DoorSensorWithDeepSleep_NoPup
 				|| role == IOR_DoorSensorWithDeepSleep_pd
@@ -1523,8 +1524,9 @@ bool CHANNEL_ShouldBePublished(int ch) {
 			if (IS_PIN_DHT_ROLE(role)) {
 				return true;
 			}
-			// SGP, CHT8305 and SHT3X uses secondary channel for humidity
-			if (role == IOR_CHT8305_DAT || role == IOR_SHT3X_DAT || role == IOR_SGP_DAT) {
+			// SGP, CHT8305, SHT3X and AHT2X uses secondary channel for humidity
+			if (role == IOR_CHT8305_DAT || role == IOR_SHT3X_DAT
+				|| role == IOR_SGP_DAT || role == IOR_AHT2X_DAT) {
 				return true;
 			}
 		}

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -551,6 +551,20 @@ typedef enum ioRole_e {
 	//iodetail:"file":"new_pins.h",
 	//iodetail:"driver":""}
 	IOR_KP18058_DAT,
+	//iodetail:{"name":"IOR_AHT2X_DAT",
+	//iodetail:"title":"TODO",
+	//iodetail:"descr":"DAT pin of AHT sensor. Setting this pin role and saving will reveal two fields next to it. Set first field to 1 and second to 2. Those are related channel numbers to store temperature and humidity.",
+	//iodetail:"enum":"IOR_AHT2X_DAT",
+	//iodetail:"file":"new_pins.h",
+	//iodetail:"driver":""}
+	IOR_AHT2X_DAT,
+	//iodetail:{"name":"IOR_AHT2X_CLK",
+	//iodetail:"title":"TODO",
+	//iodetail:"descr":"CLK pin of AHT sensor.",
+	//iodetail:"enum":"IOR_AHT2X_CLK",
+	//iodetail:"file":"new_pins.h",
+	//iodetail:"driver":""}
+	IOR_AHT2X_CLK,
 	//iodetail:{"name":"Total_Options",
 	//iodetail:"title":"TODO",
 	//iodetail:"descr":"Current total number of available IOR roles",
@@ -561,7 +575,7 @@ typedef enum ioRole_e {
 } ioRole_t;
 
 #define IS_PIN_DHT_ROLE(role) (((role)>=IOR_DHT11) && ((role)<=IOR_DHT22))
-#define IS_PIN_TEMP_HUM_SENSOR_ROLE(role) (((role)==IOR_SHT3X_DAT) || ((role)==IOR_CHT8305_DAT))
+#define IS_PIN_TEMP_HUM_SENSOR_ROLE(role) (((role)==IOR_SHT3X_DAT) || ((role)==IOR_CHT8305_DAT) || ((role)==IOR_AHT2X_DAT))
 #define IS_PIN_AIR_SENSOR_ROLE(role) (((role)==IOR_SGP_DAT))
 
 typedef enum channelType_e {

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -1170,6 +1170,12 @@ void Main_Init_BeforeDelay_Unsafe(bool bAutoRunScripts) {
 				DRV_StartDriver("TM1638");
 #endif
 			}
+			if(PIN_FindPinIndexForRole(IOR_AHT2X_CLK, -1) != -1 && PIN_FindPinIndexForRole(IOR_AHT2X_DAT, -1) != -1)
+			{
+#ifndef OBK_DISABLE_ALL_DRIVERS
+				DRV_StartDriver("AHT2X");
+#endif
+			}
 		}
 	}
 


### PR DESCRIPTION
AHT20/AHT21/AHT30 chip is almost pin-compatible with CHT8305 (SDA/SCL and VDD/GND are the same, while others on AHT are NC). So this driver is for those, who wish to replace it, those with TuyaMCU, who would like to remove it and wire sensor directly to module, or just add a very cheap board to their device.
Tested it with AHT10 board, AHT20+BMP280 board, and AHT21 chip soldered to door sensor board (which is the same, as generic sensor with SHT30 with exposed pad for CHT8305).
Binary size increased by 1248 bytes in debug build.