### PR TITLE
Set DNS hostname for ln882h

### DIFF
--- a/src/hal/ln882h/hal_wifi_ln882h.c
+++ b/src/hal/ln882h/hal_wifi_ln882h.c
@@ -220,6 +220,7 @@ void wifi_init_sta(const char* oob_ssid, const char* connect_key, obkStaticIP_t 
 
     //2. net device(lwip)
     netdev_set_mac_addr(NETIF_IDX_STA, mac_addr);
+    sysparam_sta_hostname_update(CFG_GetDeviceName());
     netdev_set_active(NETIF_IDX_STA);
 
     //3. wifi start


### PR DESCRIPTION
This should make ln882h appear with proper openLN882h hostaname instead of ln_sta.
Needs SDK fixes here https://github.com/openshwprojects/OpenLN882H/pull/13
Can't test because there is no guide to compile locally.