### PR TITLE
playing with BMP280 driver - adding read chip ID, adding BME680 support

### DIFF
--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,8 +16,8 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0x56
-#define BME280_CHIP_ID        0x60
+#define BMP280_CHIP_ID        0x58
+#define BME280_CHIP_ID        0x61 // trying 61 for BME680
 
 #define BMP280_REG_DIG_T1     0x88
 #define BMP280_REG_DIG_T2     0x8A

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,8 +16,9 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0xFF
-#define BME280_CHIP_ID        0x61 // trying 61 for BME680
+#define BMP280_CHIP_ID        0x58
+#define BME280_CHIP_ID        0x60
+#define BME680_CHIP_ID        0x61
 
 #define BMP280_REG_DIG_T1     0x88
 #define BMP280_REG_DIG_T2     0x8A
@@ -176,13 +177,15 @@ uint8_t BMP280_begin(BMP280_mode mode,
 	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "Read chip ID: %02X", id); // Add this line to output the read chip ID
 
 	if (id == BMP280_CHIP_ID) {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
-	} else if (id == BME280_CHIP_ID) {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
-	} else {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMx280 wrong ID!");
-		return 0;
-	}
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
+  } else if (id == BME280_CHIP_ID) {
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
+  } else if (id == BME680_CHIP_ID) {
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME680 detected!");
+  } else {
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMxx80 wrong ID!");
+    return 0;
+  }
 
   // reset the BMP280 with soft reset
   BMP280_Write8(BMP280_REG_SOFTRESET, 0xB6);

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0x77
+#define BMP280_CHIP_ID        0x56
 #define BME280_CHIP_ID        0x60
 
 #define BMP280_REG_DIG_T1     0x88

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -165,6 +165,7 @@ void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling,
 }
 
 // initializes the BMP280 sensor, returns 1 if OK and 0 if error
+// initializes the BMP280 sensor, returns 1 if OK and 0 if error
 uint8_t BMP280_begin(BMP280_mode mode,
                   BMP280_sampling T_sampling,
                   BMP280_sampling P_sampling,
@@ -172,12 +173,13 @@ uint8_t BMP280_begin(BMP280_mode mode,
                   standby_time  standby)
 {
 	int id = BMP280_Read8(BMP280_REG_CHIPID);
+	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "Read chip ID: %02X", id); // Add this line to output the read chip ID
+
 	if (id == BMP280_CHIP_ID) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
 	} else if (id == BME280_CHIP_ID) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
-	}
-	else {
+	} else {
 		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMx280 wrong ID!");
 		return 0;
 	}

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -41,7 +41,7 @@
 #define BMP280_REG_CONFIG     0xF5
 #define BMP280_REG_PRESS_MSB  0xF7
 
-#define BMP280_I2C_ADDR       0x77  // Define the I2C address as a macro
+#define BMP280_I2C_ADDR       0x77  // I2C Address
 
 int32_t adc_T, adc_P, t_fine;
 
@@ -116,7 +116,7 @@ uint8_t BMP280_Read8(uint8_t reg_addr)
   BMP280_Start();
   BMP280_Write(BMP280_I2C_ADDR);
   BMP280_Write(reg_addr);
-  Soft_I2C_Stop(&g_softI2C);
+  Soft_I2C_Stop();
   BMP280_Start();
   BMP280_Write(BMP280_I2C_ADDR | 1);
   ret = BMP280_Read(0);
@@ -136,14 +136,14 @@ uint16_t BMP280_Read16(uint8_t reg_addr)
   BMP280_Start();
   BMP280_Write(BMP280_I2C_ADDR);
   BMP280_Write(reg_addr);
-  Soft_I2C_Stop(&g_softI2C);
+  Soft_I2C_Stop();
   BMP280_Start();
   BMP280_Write(BMP280_I2C_ADDR | 1);
   ret.b[0] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(0);
   BMP280_Stop();
 
-  return(ret.w);
+  return ret.w;
 }
 
 void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
@@ -153,7 +153,7 @@ void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampl
   _config = ((standby << 5) | (filter << 2)) & 0xFC;
   _ctrl_meas = (T_sampling << 5) | (P_sampling << 2) | mode;
 
-  BMP280_Write8(BMP280_REG_CONFIG,  _config);
+  BMP280_Write8(BMP280_REG_CONFIG, _config);
   BMP280_Write8(BMP280_REG_CONTROL, _ctrl_meas);
 }
 
@@ -194,7 +194,102 @@ uint8_t BMP280_begin(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampli
   return 1;
 }
 
-// Additional functions like BMP280_ForcedMeasurement, BMP280_Update, BMP280_readTemperature, BMP280_readPressure should also be updated in a similar way as shown above.
+uint8_t BMP280_ForcedMeasurement()
+{
+  uint8_t ctrl_meas_reg = BMP280_Read8(BMP280_REG_CONTROL);
 
+  if ((ctrl_meas_reg & 0x03) != 0x00)
+    return 0;  // sensor is not in sleep mode
+
+  BMP280_Write8(BMP280_REG_CONTROL, ctrl_meas_reg | 1);
+  while (BMP280_Read8(BMP280_REG_STATUS) & 0x08)
+    delay_ms(1);
+
+  return 1;
+}
+
+void BMP280_Update()
+{
+  union
+  {
+    uint8_t  b[4];
+    uint32_t dw;
+  } ret;
+  ret.b[3] = 0x00;
+
+  BMP280_Start();
+  BMP280_Write(BMP280_I2C_ADDR);
+  BMP280_Write(BMP280_REG_PRESS_MSB);
+  Soft_I2C_Stop();
+  BMP280_Start();
+  BMP280_Write(BMP280_I2C_ADDR | 1);
+  ret.b[2] = BMP280_Read(1);
+  ret.b[1] = BMP280_Read(1);
+  ret.b[0] = BMP280_Read(1);
+
+  adc_P = (ret.dw >> 4) & 0xFFFFF;
+
+  ret.b[2] = BMP280_Read(1);
+  ret.b[1] = BMP280_Read(1);
+  ret.b[0] = BMP280_Read(0);
+  BMP280_Stop();
+
+  adc_T = (ret.dw >> 4) & 0xFFFFF;
+}
+
+uint8_t BMP280_readTemperature(int32_t *temp)
+{
+  int32_t var1, var2;
+
+  BMP280_Update();
+
+  var1 = ((((adc_T / 8) - ((int32_t)BMP280_calib.dig_T1 * 2))) *
+         ((int32_t)BMP280_calib.dig_T2)) / 2048;
+
+  var2 = (((((adc_T / 16) - ((int32_t)BMP280_calib.dig_T1)) *
+         ((adc_T / 16) - ((int32_t)BMP280_calib.dig_T1))) / 4096) *
+         ((int32_t)BMP280_calib.dig_T3)) / 16384;
+
+  t_fine = var1 + var2;
+
+  *temp = (t_fine * 5 + 128) / 256;
+
+  return 1;
+}
+
+uint8_t BMP280_readPressure(uint32_t *pres)
+{
+  int32_t var1, var2;
+  uint32_t p;
+
+  var1 = (((int32_t)t_fine) / 2) - (int32_t)64000;
+  var2 = (((var1 / 4) * (var1 / 4)) / 2048) * ((int32_t)BMP280_calib.dig_P6);
+  var2 = var2 + ((var1 * ((int32_t)BMP280_calib.dig_P5)) * 2);
+  var2 = (var2 / 4) + (((int32_t)BMP280_calib.dig_P4) * 65536);
+  var1 = ((((int32_t)BMP280_calib.dig_P3 * (((var1 / 4) * (var1 / 4)) / 8192)) / 8) +
+         ((((int32_t)BMP280_calib.dig_P2) * var1) / 2)) / 262144;
+  var1 = ((((32768 + var1)) * ((int32_t)BMP280_calib.dig_P1)) / 32768);
+
+  if (var1 == 0) {
+    return 0; // avoid exception caused by division by zero
+  }
+
+  p = (((uint32_t)(((int32_t)1048576) - adc_P) - (var2 / 4096))) * 3125;
+  if (p < 0x80000000) {
+    p = (p * 2) / ((uint32_t)var1);
+  } else {
+    p = (p / (uint32_t)var1) * 2;
+  }
+
+  var1 = (((int32_t)BMP280_calib.dig_P9) * ((int32_t)(((p / 8) * (p / 8)) / 8192))) / 4096;
+  var2 = (((int32_t)(p / 4)) * ((int32_t)BMP280_calib.dig_P8)) / 8192;
+  p = (uint32_t)((int32_t)p + ((var1 + var2 + (int32_t)BMP280_calib.dig_P7) / 16));
+
+  *pres = p;
+
+  return 1;
+}
+
+}
 
 // end of driver code.

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0x58
+#define BMP280_CHIP_ID        0x77
 #define BME280_CHIP_ID        0x60
 
 #define BMP280_REG_DIG_T1     0x88
@@ -41,46 +41,48 @@
 #define BMP280_REG_CONFIG     0xF5
 #define BMP280_REG_PRESS_MSB  0xF7
 
-#define BMP280_I2C_ADDR       0x77  // I2C Address
-
 int32_t adc_T, adc_P, t_fine;
 
+// BMP280 sensor modes, register ctrl_meas mode[1:0]
 typedef enum
 {
-  MODE_SLEEP  = 0x00,
-  MODE_FORCED = 0x01,
-  MODE_NORMAL = 0x03
+  MODE_SLEEP  = 0x00,  // sleep mode
+  MODE_FORCED = 0x01,  // forced mode
+  MODE_NORMAL = 0x03   // normal mode
 } BMP280_mode;
 
+// oversampling setting. osrs_t[2:0], osrs_p[2:0]
 typedef enum
 {
-  SAMPLING_SKIPPED = 0x00,
-  SAMPLING_X1      = 0x01,
-  SAMPLING_X2      = 0x02,
-  SAMPLING_X4      = 0x03,
-  SAMPLING_X8      = 0x04,
-  SAMPLING_X16     = 0x05
+  SAMPLING_SKIPPED = 0x00,  //skipped, output set to 0x80000
+  SAMPLING_X1      = 0x01,  // oversampling x1
+  SAMPLING_X2      = 0x02,  // oversampling x2
+  SAMPLING_X4      = 0x03,  // oversampling x4
+  SAMPLING_X8      = 0x04,  // oversampling x8
+  SAMPLING_X16     = 0x05   // oversampling x16
 } BMP280_sampling;
 
+// filter setting filter[2:0]
 typedef enum
 {
-  FILTER_OFF = 0x00,
-  FILTER_2   = 0x01,
-  FILTER_4   = 0x02,
-  FILTER_8   = 0x03,
-  FILTER_16  = 0x04
+  FILTER_OFF = 0x00,  // filter off
+  FILTER_2   = 0x01,  // filter coefficient = 2
+  FILTER_4   = 0x02,  // filter coefficient = 4
+  FILTER_8   = 0x03,  // filter coefficient = 8
+  FILTER_16  = 0x04   // filter coefficient = 16
 } BMP280_filter;
 
+// standby (inactive) time in ms (used in normal mode), t_sb[2:0]
 typedef enum
 {
-  STANDBY_0_5   =  0x00,
-  STANDBY_62_5  =  0x01,
-  STANDBY_125   =  0x02,
-  STANDBY_250   =  0x03,
-  STANDBY_500   =  0x04,
-  STANDBY_1000  =  0x05,
-  STANDBY_2000  =  0x06,
-  STANDBY_4000  =  0x07
+  STANDBY_0_5   =  0x00,  // standby time = 0.5 ms
+  STANDBY_62_5  =  0x01,  // standby time = 62.5 ms
+  STANDBY_125   =  0x02,  // standby time = 125 ms
+  STANDBY_250   =  0x03,  // standby time = 250 ms
+  STANDBY_500   =  0x04,  // standby time = 500 ms
+  STANDBY_1000  =  0x05,  // standby time = 1000 ms
+  STANDBY_2000  =  0x06,  // standby time = 2000 ms
+  STANDBY_4000  =  0x07   // standby time = 4000 ms
 } standby_time;
 
 struct
@@ -100,31 +102,34 @@ struct
   int16_t  dig_P9;
 } BMP280_calib;
 
+// writes 1 byte '_data' to register 'reg_addr'
 void BMP280_Write8(uint8_t reg_addr, uint8_t _data)
 {
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR);
+  BMP280_Write(g_softI2C.address8bit);
   BMP280_Write(reg_addr);
   BMP280_Write(_data);
   BMP280_Stop();
 }
 
+// reads 8 bits from register 'reg_addr'
 uint8_t BMP280_Read8(uint8_t reg_addr)
 {
   uint8_t ret;
 
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR);
+  BMP280_Write(g_softI2C.address8bit);
   BMP280_Write(reg_addr);
-  Soft_I2C_Stop();
+  Soft_I2C_Stop(&g_softI2C);
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR | 1);
+  BMP280_Write(g_softI2C.address8bit | 1);
   ret = BMP280_Read(0);
   BMP280_Stop();
 
   return ret;
 }
 
+// reads 16 bits from register 'reg_addr'
 uint16_t BMP280_Read16(uint8_t reg_addr)
 {
   union
@@ -134,45 +139,55 @@ uint16_t BMP280_Read16(uint8_t reg_addr)
   } ret;
 
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR);
+  BMP280_Write(g_softI2C.address8bit);
   BMP280_Write(reg_addr);
-  Soft_I2C_Stop();
+  Soft_I2C_Stop(&g_softI2C);
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR | 1);
+  BMP280_Write(g_softI2C.address8bit | 1);
   ret.b[0] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(0);
   BMP280_Stop();
 
-  return ret.w;
+  return(ret.w);
 }
 
-void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
+// BMP280 sensor configuration function
+void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling,
+                      BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
 {
   uint8_t  _ctrl_meas, _config;
 
   _config = ((standby << 5) | (filter << 2)) & 0xFC;
   _ctrl_meas = (T_sampling << 5) | (P_sampling << 2) | mode;
 
-  BMP280_Write8(BMP280_REG_CONFIG, _config);
+  BMP280_Write8(BMP280_REG_CONFIG,  _config);
   BMP280_Write8(BMP280_REG_CONTROL, _ctrl_meas);
 }
 
-uint8_t BMP280_begin(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
+// initializes the BMP280 sensor, returns 1 if OK and 0 if error
+uint8_t BMP280_begin(BMP280_mode mode,
+                  BMP280_sampling T_sampling,
+                  BMP280_sampling P_sampling,
+                  BMP280_filter filter,
+                  standby_time  standby)
 {
-  int id = BMP280_Read8(BMP280_REG_CHIPID);
-  if (id == BMP280_CHIP_ID) {
-    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
-  } else if (id == BME280_CHIP_ID) {
-    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
-  } else {
-    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMx280 wrong ID!");
-    return 0;
-  }
+	int id = BMP280_Read8(BMP280_REG_CHIPID);
+	if (id == BMP280_CHIP_ID) {
+		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
+	} else if (id == BME280_CHIP_ID) {
+		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
+	}
+	else {
+		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMx280 wrong ID!");
+		return 0;
+	}
 
+  // reset the BMP280 with soft reset
   BMP280_Write8(BMP280_REG_SOFTRESET, 0xB6);
   delay_ms(100);
 
-  while ((BMP280_Read8(BMP280_REG_STATUS) & 0x01) == 0x01)
+  // if NVM data are being copied to image registers, wait 100 ms
+  while ( (BMP280_Read8(BMP280_REG_STATUS) & 0x01) == 0x01 )
     delay_ms(100);
 
   BMP280_calib.dig_T1 = BMP280_Read16(BMP280_REG_DIG_T1);
@@ -194,20 +209,25 @@ uint8_t BMP280_begin(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampli
   return 1;
 }
 
+// Takes a new measurement, for forced mode only!
+// Returns 1 if ok and 0 if error (sensor is not in sleep mode)
 uint8_t BMP280_ForcedMeasurement()
 {
   uint8_t ctrl_meas_reg = BMP280_Read8(BMP280_REG_CONTROL);
 
-  if ((ctrl_meas_reg & 0x03) != 0x00)
-    return 0;  // sensor is not in sleep mode
+  if ( (ctrl_meas_reg & 0x03) != 0x00 )
+    return 0;   // sensor is not in sleep mode
 
+  // set sensor to forced mode
   BMP280_Write8(BMP280_REG_CONTROL, ctrl_meas_reg | 1);
+  // wait for conversion complete
   while (BMP280_Read8(BMP280_REG_STATUS) & 0x08)
     delay_ms(1);
 
   return 1;
 }
 
+// read (updates) adc_P, adc_T and adc_H from BMP280 sensor
 void BMP280_Update()
 {
   union
@@ -218,16 +238,16 @@ void BMP280_Update()
   ret.b[3] = 0x00;
 
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR);
+  BMP280_Write(g_softI2C.address8bit);
   BMP280_Write(BMP280_REG_PRESS_MSB);
-  Soft_I2C_Stop();
+  Soft_I2C_Stop(&g_softI2C);
   BMP280_Start();
-  BMP280_Write(BMP280_I2C_ADDR | 1);
+  BMP280_Write(g_softI2C.address8bit | 1);
   ret.b[2] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(1);
   ret.b[0] = BMP280_Read(1);
 
-  adc_P = (ret.dw >> 4) & 0xFFFFF;
+  adc_P = (ret.dw >> 4) & 0xFFFFF;  
 
   ret.b[2] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(1);
@@ -237,12 +257,16 @@ void BMP280_Update()
   adc_T = (ret.dw >> 4) & 0xFFFFF;
 }
 
+// Reads temperature from BMP280 sensor.
+// Temperature is stored in hundredths C (output value of "5123" equals 51.23 DegC).
+// Temperature value is saved to *temp, returns 1 if OK and 0 if error.
 uint8_t BMP280_readTemperature(int32_t *temp)
 {
   int32_t var1, var2;
 
   BMP280_Update();
 
+  // calculate temperature
   var1 = ((((adc_T / 8) - ((int32_t)BMP280_calib.dig_T1 * 2))) *
          ((int32_t)BMP280_calib.dig_T2)) / 2048;
 
@@ -257,39 +281,45 @@ uint8_t BMP280_readTemperature(int32_t *temp)
   return 1;
 }
 
+// Reads pressure from BMP280 sensor.
+// Pressure is stored in Pa (output value of "96386" equals 96386 Pa = 963.86 hPa).
+// Pressure value is saved to *pres, returns 1 if OK and 0 if error.
 uint8_t BMP280_readPressure(uint32_t *pres)
 {
   int32_t var1, var2;
   uint32_t p;
 
+  // calculate pressure
   var1 = (((int32_t)t_fine) / 2) - (int32_t)64000;
-  var2 = (((var1 / 4) * (var1 / 4)) / 2048) * ((int32_t)BMP280_calib.dig_P6);
-  var2 = var2 + ((var1 * ((int32_t)BMP280_calib.dig_P5)) * 2);
-  var2 = (var2 / 4) + (((int32_t)BMP280_calib.dig_P4) * 65536);
-  var1 = ((((int32_t)BMP280_calib.dig_P3 * (((var1 / 4) * (var1 / 4)) / 8192)) / 8) +
-         ((((int32_t)BMP280_calib.dig_P2) * var1) / 2)) / 262144;
-  var1 = ((((32768 + var1)) * ((int32_t)BMP280_calib.dig_P1)) / 32768);
+  var2 = (((var1/4) * (var1/4)) / 2048 ) * ((int32_t)BMP280_calib.dig_P6);
 
-  if (var1 == 0) {
+  var2 = var2 + ((var1 * ((int32_t)BMP280_calib.dig_P5)) * 2);
+  var2 = (var2/4) + (((int32_t)BMP280_calib.dig_P4) * 65536);
+
+  var1 = ((((int32_t)BMP280_calib.dig_P3 * (((var1/4) * (var1/4)) / 8192 )) / 8) +
+         ((((int32_t)BMP280_calib.dig_P2) * var1)/2)) / 262144;
+
+  var1 =((((32768 + var1)) * ((int32_t)BMP280_calib.dig_P1)) / 32768);
+
+  if (var1 == 0)
     return 0; // avoid exception caused by division by zero
-  }
 
   p = (((uint32_t)(((int32_t)1048576) - adc_P) - (var2 / 4096))) * 3125;
-  if (p < 0x80000000) {
-    p = (p * 2) / ((uint32_t)var1);
-  } else {
-    p = (p / (uint32_t)var1) * 2;
-  }
 
-  var1 = (((int32_t)BMP280_calib.dig_P9) * ((int32_t)(((p / 8) * (p / 8)) / 8192))) / 4096;
-  var2 = (((int32_t)(p / 4)) * ((int32_t)BMP280_calib.dig_P8)) / 8192;
+  if (p < 0x80000000)
+    p = (p * 2) / ((uint32_t)var1);
+
+  else
+    p = (p / (uint32_t)var1) * 2;
+
+  var1 = (((int32_t)BMP280_calib.dig_P9) * ((int32_t)(((p/8) * (p/8)) / 8192))) / 4096;
+  var2 = (((int32_t)(p/4)) * ((int32_t)BMP280_calib.dig_P8)) / 8192;
+
   p = (uint32_t)((int32_t)p + ((var1 + var2 + (int32_t)BMP280_calib.dig_P7) / 16));
 
   *pres = p;
 
   return 1;
-}
-
 }
 
 // end of driver code.

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0x77
+#define BMP280_CHIP_ID        0x58
 #define BME280_CHIP_ID        0x60
 
 #define BMP280_REG_DIG_T1     0x88
@@ -41,48 +41,46 @@
 #define BMP280_REG_CONFIG     0xF5
 #define BMP280_REG_PRESS_MSB  0xF7
 
+#define BMP280_I2C_ADDR       0x77  // I2C Address
+
 int32_t adc_T, adc_P, t_fine;
 
-// BMP280 sensor modes, register ctrl_meas mode[1:0]
 typedef enum
 {
-  MODE_SLEEP  = 0x00,  // sleep mode
-  MODE_FORCED = 0x01,  // forced mode
-  MODE_NORMAL = 0x03   // normal mode
+  MODE_SLEEP  = 0x00,
+  MODE_FORCED = 0x01,
+  MODE_NORMAL = 0x03
 } BMP280_mode;
 
-// oversampling setting. osrs_t[2:0], osrs_p[2:0]
 typedef enum
 {
-  SAMPLING_SKIPPED = 0x00,  //skipped, output set to 0x80000
-  SAMPLING_X1      = 0x01,  // oversampling x1
-  SAMPLING_X2      = 0x02,  // oversampling x2
-  SAMPLING_X4      = 0x03,  // oversampling x4
-  SAMPLING_X8      = 0x04,  // oversampling x8
-  SAMPLING_X16     = 0x05   // oversampling x16
+  SAMPLING_SKIPPED = 0x00,
+  SAMPLING_X1      = 0x01,
+  SAMPLING_X2      = 0x02,
+  SAMPLING_X4      = 0x03,
+  SAMPLING_X8      = 0x04,
+  SAMPLING_X16     = 0x05
 } BMP280_sampling;
 
-// filter setting filter[2:0]
 typedef enum
 {
-  FILTER_OFF = 0x00,  // filter off
-  FILTER_2   = 0x01,  // filter coefficient = 2
-  FILTER_4   = 0x02,  // filter coefficient = 4
-  FILTER_8   = 0x03,  // filter coefficient = 8
-  FILTER_16  = 0x04   // filter coefficient = 16
+  FILTER_OFF = 0x00,
+  FILTER_2   = 0x01,
+  FILTER_4   = 0x02,
+  FILTER_8   = 0x03,
+  FILTER_16  = 0x04
 } BMP280_filter;
 
-// standby (inactive) time in ms (used in normal mode), t_sb[2:0]
 typedef enum
 {
-  STANDBY_0_5   =  0x00,  // standby time = 0.5 ms
-  STANDBY_62_5  =  0x01,  // standby time = 62.5 ms
-  STANDBY_125   =  0x02,  // standby time = 125 ms
-  STANDBY_250   =  0x03,  // standby time = 250 ms
-  STANDBY_500   =  0x04,  // standby time = 500 ms
-  STANDBY_1000  =  0x05,  // standby time = 1000 ms
-  STANDBY_2000  =  0x06,  // standby time = 2000 ms
-  STANDBY_4000  =  0x07   // standby time = 4000 ms
+  STANDBY_0_5   =  0x00,
+  STANDBY_62_5  =  0x01,
+  STANDBY_125   =  0x02,
+  STANDBY_250   =  0x03,
+  STANDBY_500   =  0x04,
+  STANDBY_1000  =  0x05,
+  STANDBY_2000  =  0x06,
+  STANDBY_4000  =  0x07
 } standby_time;
 
 struct
@@ -102,34 +100,31 @@ struct
   int16_t  dig_P9;
 } BMP280_calib;
 
-// writes 1 byte '_data' to register 'reg_addr'
 void BMP280_Write8(uint8_t reg_addr, uint8_t _data)
 {
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit);
+  BMP280_Write(BMP280_I2C_ADDR);
   BMP280_Write(reg_addr);
   BMP280_Write(_data);
   BMP280_Stop();
 }
 
-// reads 8 bits from register 'reg_addr'
 uint8_t BMP280_Read8(uint8_t reg_addr)
 {
   uint8_t ret;
 
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit);
+  BMP280_Write(BMP280_I2C_ADDR);
   BMP280_Write(reg_addr);
-  Soft_I2C_Stop(&g_softI2C);
+  Soft_I2C_Stop();
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit | 1);
+  BMP280_Write(BMP280_I2C_ADDR | 1);
   ret = BMP280_Read(0);
   BMP280_Stop();
 
   return ret;
 }
 
-// reads 16 bits from register 'reg_addr'
 uint16_t BMP280_Read16(uint8_t reg_addr)
 {
   union
@@ -139,55 +134,45 @@ uint16_t BMP280_Read16(uint8_t reg_addr)
   } ret;
 
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit);
+  BMP280_Write(BMP280_I2C_ADDR);
   BMP280_Write(reg_addr);
-  Soft_I2C_Stop(&g_softI2C);
+  Soft_I2C_Stop();
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit | 1);
+  BMP280_Write(BMP280_I2C_ADDR | 1);
   ret.b[0] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(0);
   BMP280_Stop();
 
-  return(ret.w);
+  return ret.w;
 }
 
-// BMP280 sensor configuration function
-void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling,
-                      BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
+void BMP280_Configure(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
 {
   uint8_t  _ctrl_meas, _config;
 
   _config = ((standby << 5) | (filter << 2)) & 0xFC;
   _ctrl_meas = (T_sampling << 5) | (P_sampling << 2) | mode;
 
-  BMP280_Write8(BMP280_REG_CONFIG,  _config);
+  BMP280_Write8(BMP280_REG_CONFIG, _config);
   BMP280_Write8(BMP280_REG_CONTROL, _ctrl_meas);
 }
 
-// initializes the BMP280 sensor, returns 1 if OK and 0 if error
-uint8_t BMP280_begin(BMP280_mode mode,
-                  BMP280_sampling T_sampling,
-                  BMP280_sampling P_sampling,
-                  BMP280_filter filter,
-                  standby_time  standby)
+uint8_t BMP280_begin(BMP280_mode mode, BMP280_sampling T_sampling, BMP280_sampling P_sampling, BMP280_filter filter, standby_time standby)
 {
-	int id = BMP280_Read8(BMP280_REG_CHIPID);
-	if (id == BMP280_CHIP_ID) {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
-	} else if (id == BME280_CHIP_ID) {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
-	}
-	else {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMx280 wrong ID!");
-		return 0;
-	}
+  int id = BMP280_Read8(BMP280_REG_CHIPID);
+  if (id == BMP280_CHIP_ID) {
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 detected!");
+  } else if (id == BME280_CHIP_ID) {
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BME280 detected!");
+  } else {
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMx280 wrong ID!");
+    return 0;
+  }
 
-  // reset the BMP280 with soft reset
   BMP280_Write8(BMP280_REG_SOFTRESET, 0xB6);
   delay_ms(100);
 
-  // if NVM data are being copied to image registers, wait 100 ms
-  while ( (BMP280_Read8(BMP280_REG_STATUS) & 0x01) == 0x01 )
+  while ((BMP280_Read8(BMP280_REG_STATUS) & 0x01) == 0x01)
     delay_ms(100);
 
   BMP280_calib.dig_T1 = BMP280_Read16(BMP280_REG_DIG_T1);
@@ -209,25 +194,20 @@ uint8_t BMP280_begin(BMP280_mode mode,
   return 1;
 }
 
-// Takes a new measurement, for forced mode only!
-// Returns 1 if ok and 0 if error (sensor is not in sleep mode)
 uint8_t BMP280_ForcedMeasurement()
 {
   uint8_t ctrl_meas_reg = BMP280_Read8(BMP280_REG_CONTROL);
 
-  if ( (ctrl_meas_reg & 0x03) != 0x00 )
-    return 0;   // sensor is not in sleep mode
+  if ((ctrl_meas_reg & 0x03) != 0x00)
+    return 0;  // sensor is not in sleep mode
 
-  // set sensor to forced mode
   BMP280_Write8(BMP280_REG_CONTROL, ctrl_meas_reg | 1);
-  // wait for conversion complete
   while (BMP280_Read8(BMP280_REG_STATUS) & 0x08)
     delay_ms(1);
 
   return 1;
 }
 
-// read (updates) adc_P, adc_T and adc_H from BMP280 sensor
 void BMP280_Update()
 {
   union
@@ -238,16 +218,16 @@ void BMP280_Update()
   ret.b[3] = 0x00;
 
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit);
+  BMP280_Write(BMP280_I2C_ADDR);
   BMP280_Write(BMP280_REG_PRESS_MSB);
-  Soft_I2C_Stop(&g_softI2C);
+  Soft_I2C_Stop();
   BMP280_Start();
-  BMP280_Write(g_softI2C.address8bit | 1);
+  BMP280_Write(BMP280_I2C_ADDR | 1);
   ret.b[2] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(1);
   ret.b[0] = BMP280_Read(1);
 
-  adc_P = (ret.dw >> 4) & 0xFFFFF;  
+  adc_P = (ret.dw >> 4) & 0xFFFFF;
 
   ret.b[2] = BMP280_Read(1);
   ret.b[1] = BMP280_Read(1);
@@ -257,16 +237,12 @@ void BMP280_Update()
   adc_T = (ret.dw >> 4) & 0xFFFFF;
 }
 
-// Reads temperature from BMP280 sensor.
-// Temperature is stored in hundredths C (output value of "5123" equals 51.23 DegC).
-// Temperature value is saved to *temp, returns 1 if OK and 0 if error.
 uint8_t BMP280_readTemperature(int32_t *temp)
 {
   int32_t var1, var2;
 
   BMP280_Update();
 
-  // calculate temperature
   var1 = ((((adc_T / 8) - ((int32_t)BMP280_calib.dig_T1 * 2))) *
          ((int32_t)BMP280_calib.dig_T2)) / 2048;
 
@@ -281,45 +257,39 @@ uint8_t BMP280_readTemperature(int32_t *temp)
   return 1;
 }
 
-// Reads pressure from BMP280 sensor.
-// Pressure is stored in Pa (output value of "96386" equals 96386 Pa = 963.86 hPa).
-// Pressure value is saved to *pres, returns 1 if OK and 0 if error.
 uint8_t BMP280_readPressure(uint32_t *pres)
 {
   int32_t var1, var2;
   uint32_t p;
 
-  // calculate pressure
   var1 = (((int32_t)t_fine) / 2) - (int32_t)64000;
-  var2 = (((var1/4) * (var1/4)) / 2048 ) * ((int32_t)BMP280_calib.dig_P6);
-
+  var2 = (((var1 / 4) * (var1 / 4)) / 2048) * ((int32_t)BMP280_calib.dig_P6);
   var2 = var2 + ((var1 * ((int32_t)BMP280_calib.dig_P5)) * 2);
-  var2 = (var2/4) + (((int32_t)BMP280_calib.dig_P4) * 65536);
+  var2 = (var2 / 4) + (((int32_t)BMP280_calib.dig_P4) * 65536);
+  var1 = ((((int32_t)BMP280_calib.dig_P3 * (((var1 / 4) * (var1 / 4)) / 8192)) / 8) +
+         ((((int32_t)BMP280_calib.dig_P2) * var1) / 2)) / 262144;
+  var1 = ((((32768 + var1)) * ((int32_t)BMP280_calib.dig_P1)) / 32768);
 
-  var1 = ((((int32_t)BMP280_calib.dig_P3 * (((var1/4) * (var1/4)) / 8192 )) / 8) +
-         ((((int32_t)BMP280_calib.dig_P2) * var1)/2)) / 262144;
-
-  var1 =((((32768 + var1)) * ((int32_t)BMP280_calib.dig_P1)) / 32768);
-
-  if (var1 == 0)
+  if (var1 == 0) {
     return 0; // avoid exception caused by division by zero
+  }
 
   p = (((uint32_t)(((int32_t)1048576) - adc_P) - (var2 / 4096))) * 3125;
-
-  if (p < 0x80000000)
+  if (p < 0x80000000) {
     p = (p * 2) / ((uint32_t)var1);
-
-  else
+  } else {
     p = (p / (uint32_t)var1) * 2;
+  }
 
-  var1 = (((int32_t)BMP280_calib.dig_P9) * ((int32_t)(((p/8) * (p/8)) / 8192))) / 4096;
-  var2 = (((int32_t)(p/4)) * ((int32_t)BMP280_calib.dig_P8)) / 8192;
-
+  var1 = (((int32_t)BMP280_calib.dig_P9) * ((int32_t)(((p / 8) * (p / 8)) / 8192))) / 4096;
+  var2 = (((int32_t)(p / 4)) * ((int32_t)BMP280_calib.dig_P8)) / 8192;
   p = (uint32_t)((int32_t)p + ((var1 + var2 + (int32_t)BMP280_calib.dig_P7) / 16));
 
   *pres = p;
 
   return 1;
+}
+
 }
 
 // end of driver code.

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0x58
+#define BMP280_CHIP_ID        0xFF
 #define BME280_CHIP_ID        0x61 // trying 61 for BME680
 
 #define BMP280_REG_DIG_T1     0x88

--- a/src/driver/BMP280.h
+++ b/src/driver/BMP280.h
@@ -16,7 +16,7 @@
 
 #include <stdint.h>
 
-#define BMP280_CHIP_ID        0x58
+#define BMP280_CHIP_ID        0x77
 #define BME280_CHIP_ID        0x60
 
 #define BMP280_REG_DIG_T1     0x88

--- a/src/driver/drv_bmp280.c
+++ b/src/driver/drv_bmp280.c
@@ -34,7 +34,7 @@ void BMP280_Stop(void) {		//manufacturer ID
 
 #include "BMP280.h"
 
-// startDriver BMP280 8 14 1 2 236
+// startDriver BMP280 8 14 1 2 238
 // startDriver BMP280 [CLK] [DATA] [ChannelForTemp] [ChannelForPressure] [Adr8bit]
 void BMP280_Init() {
 
@@ -48,9 +48,9 @@ void BMP280_Init() {
 
 	usleep(100);
 	if (BMP280_begin(MODE_NORMAL, SAMPLING_X1, SAMPLING_X1, FILTER_OFF, STANDBY_0_5) == 0) {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 failed!");
+		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMxx80 driver failed to start!");
 	} else {
-		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMP280 ready!");
+		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "BMxx80 driver started!");
 	}
 }
 


### PR DESCRIPTION
[Info:I2C:Address 0x77](https://learn.adafruit.com/i2c-addresses/the-list#0x77-3119935)