### PR TITLE
let echo return expanded arguments

### DIFF
--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -276,22 +276,11 @@ static commandResult_t CMD_Echo(const void* context, const char* cmd, const char
 #else
 	// we want $CH40 etc expanded
 	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START | TOKENIZER_FORCE_SINGLE_ARGUMENT_MODE);
-	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArgFrom(0));
+	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArg(0));
 #endif
 
 	return CMD_RES_OK;
 }
-
-// setChannel 1 123
-// echo $CH1
-// will print 123
-static commandResult_t CMD_Echo_Val(const void* context, const char* cmd, const char* args, int cmdFlags) {
-	// we want $CH40 etc expanded
-	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START | TOKENIZER_FORCE_SINGLE_ARGUMENT_MODE);
-	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArg(0));
-	return CMD_RES_OK;
-}
-
 static commandResult_t CMD_StartupCommand(const void* context, const char* cmd, const char* args, int cmdFlags) {
 	const char *cmdToSet;
 
@@ -649,15 +638,10 @@ void CMD_Init_Early() {
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("alias", CMD_CreateAliasForCommand, NULL);
 	//cmddetail:{"name":"echo","args":"[Message]",
-	//cmddetail:"descr":"Sends given message back to console. This command doesn't expands variables.",
+	//cmddetail:"descr":"Sends given message back to console. This command expands variables, so writing $CH12 will print value of channel 12, etc. Remember that you can also use special channel indices to access persistant flash variables and to access LED variables like dimmer, etc.",
 	//cmddetail:"fn":"CMD_Echo","file":"cmnds/cmd_main.c","requires":"",
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("echo", CMD_Echo, NULL);
-	//cmddetail:{"name":"echoval","args":"[Message]",
-	//cmddetail:"descr":"Sends given message back to console. This command expands variables (but only up to 40 chars), so writing $CH12 will print value of channel 12, etc. Remember that you can also use special channel indices to access persistant flash variables and to access LED variables like dimmer, etc.",
-	//cmddetail:"fn":"CMD_Echo_Val","file":"cmnds/cmd_main.c","requires":"",
-	//cmddetail:"examples":""}
-	CMD_RegisterCommand("echoval", CMD_Echo_Val, NULL);
 	//cmddetail:{"name":"restart","args":"",
 	//cmddetail:"descr":"Reboots the module",
 	//cmddetail:"fn":"CMD_Restart","file":"cmnds/cmd_main.c","requires":"",

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -276,7 +276,7 @@ static commandResult_t CMD_Echo(const void* context, const char* cmd, const char
 #else
 	// we want $CH40 etc expanded
 	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START | TOKENIZER_FORCE_SINGLE_ARGUMENT_MODE);
-	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArgFrom(0));
+	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArg(0));
 #endif
 
 	return CMD_RES_OK;

--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -276,11 +276,22 @@ static commandResult_t CMD_Echo(const void* context, const char* cmd, const char
 #else
 	// we want $CH40 etc expanded
 	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START | TOKENIZER_FORCE_SINGLE_ARGUMENT_MODE);
-	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArg(0));
+	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArgFrom(0));
 #endif
 
 	return CMD_RES_OK;
 }
+
+// setChannel 1 123
+// echo $CH1
+// will print 123
+static commandResult_t CMD_Echo_Val(const void* context, const char* cmd, const char* args, int cmdFlags) {
+	// we want $CH40 etc expanded
+	Tokenizer_TokenizeString(args, TOKENIZER_ALTERNATE_EXPAND_AT_START | TOKENIZER_FORCE_SINGLE_ARGUMENT_MODE);
+	ADDLOG_INFO(LOG_FEATURE_CMD, Tokenizer_GetArg(0));
+	return CMD_RES_OK;
+}
+
 static commandResult_t CMD_StartupCommand(const void* context, const char* cmd, const char* args, int cmdFlags) {
 	const char *cmdToSet;
 
@@ -638,10 +649,15 @@ void CMD_Init_Early() {
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("alias", CMD_CreateAliasForCommand, NULL);
 	//cmddetail:{"name":"echo","args":"[Message]",
-	//cmddetail:"descr":"Sends given message back to console. This command expands variables, so writing $CH12 will print value of channel 12, etc. Remember that you can also use special channel indices to access persistant flash variables and to access LED variables like dimmer, etc.",
+	//cmddetail:"descr":"Sends given message back to console. This command doesn't expands variables.",
 	//cmddetail:"fn":"CMD_Echo","file":"cmnds/cmd_main.c","requires":"",
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("echo", CMD_Echo, NULL);
+	//cmddetail:{"name":"echoval","args":"[Message]",
+	//cmddetail:"descr":"Sends given message back to console. This command expands variables (but only up to 40 chars), so writing $CH12 will print value of channel 12, etc. Remember that you can also use special channel indices to access persistant flash variables and to access LED variables like dimmer, etc.",
+	//cmddetail:"fn":"CMD_Echo_Val","file":"cmnds/cmd_main.c","requires":"",
+	//cmddetail:"examples":""}
+	CMD_RegisterCommand("echoval", CMD_Echo_Val, NULL);
 	//cmddetail:{"name":"restart","args":"",
 	//cmddetail:"descr":"Reboots the module",
 	//cmddetail:"fn":"CMD_Restart","file":"cmnds/cmd_main.c","requires":"",

--- a/src/cmnds/cmd_tokenizer.c
+++ b/src/cmnds/cmd_tokenizer.c
@@ -335,6 +335,9 @@ void Tokenizer_TokenizeString(const char *s, int flags) {
 	if (flags & TOKENIZER_FORCE_SINGLE_ARGUMENT_MODE) {
 		g_args[g_numArgs] = g_buffer;
 		g_argsFrom[g_numArgs] = g_buffer;
+		// some hack, but we fored to have only have one arg, so we can extend the string over array bondaries.
+		// probably better: introducing an union containing g_argsExpanded[][] and one sole string in the same memory area ...
+		CMD_ExpandConstantsWithinString(g_buffer,g_argsExpanded,sizeof(g_argsExpanded)-1);
 		g_numArgs = 1;
 		return;
 	}


### PR DESCRIPTION
I wondered why echo would never expand expressions like "$ch10" but return the string as is (e.g.: "Info:CMD:$ch10").
I think it was just a typo, for "Tokenizer_GetArgFrom(0)" would just return g_argsFrom[0] and not expanding content like "Tokenizer_GetArg(0)".
And since we forced a single argument, this should be correct, I hope.

At least, it now works for me ;-)