### PR TITLE
First attempt to turn device in an access point with WPA password.

### DIFF
--- a/src/hal/bl602/hal_wifi_bl602.c
+++ b/src/hal/bl602/hal_wifi_bl602.c
@@ -73,6 +73,26 @@ int HAL_SetupWiFiOpenAccessPoint(const char *ssid) {
 
 	return 0;
 }
+int HAL_SetupWiFiAccessPoint(const char *ssid, const char *key) {
+
+	uint8_t hidden_ssid = 0;
+	//int channel;
+
+	if ( key && strlen(key) < 8){
+		printf("ERROR! key(%s) needs to be at least 8 characters!\r\n", key);
+		if (g_wifiStatusCallback != 0) {
+			g_wifiStatusCallback(WIFI_AP_FAILED);
+		}
+		return -1;
+	}
+	wifi_interface_t wifi_interface;
+	//struct netif *net;
+	wifi_interface = wifi_mgmr_ap_enable();
+	wifi_mgmr_ap_start(wifi_interface, ssid, hidden_ssid, key, 1);
+	g_bAccessPointMode = 0;
+
+	return 0;
+}
 static void event_cb_wifi_event(input_event_t *event, void *private_data)
 {
 

--- a/src/hal/hal_wifi.h
+++ b/src/hal/hal_wifi.h
@@ -22,6 +22,7 @@ typedef struct obkStaticIP_s {
 } obkStaticIP_t;
 
 int HAL_SetupWiFiOpenAccessPoint(const char* ssid);
+int HAL_SetupWiFiAccessPoint(const char* ssid, const char* key);
 void HAL_ConnectToWiFi(const char* oob_ssid, const char* connect_key, obkStaticIP_t *ip);
 void HAL_DisconnectFromWifi();
 void HAL_WiFi_SetupStatusCallback(void (*cb)(int code));

--- a/src/hal/ln882h/hal_wifi_ln882h.c
+++ b/src/hal/ln882h/hal_wifi_ln882h.c
@@ -273,7 +273,7 @@ static void ap_startup_cb(void * arg)
     }
 }
 
-void wifi_init_ap(const char* ssid)
+void wifi_init_ap(const char* ssid, const char* key)
 {
     tcpip_ip_info_t  ip_info;
     server_config_t  server_config;
@@ -311,11 +311,11 @@ void wifi_init_ap(const char* ssid)
 
     wifi_softap_cfg_t ap_cfg = {
 		.ssid            = ssid,
-		.pwd             = "",
+		.pwd             = (! key || key[0] == 0) ? "" : key,
 		.bssid           = mac_addr,
 		.ext_cfg = {
 			.channel         = 6,
-			.authmode        = WIFI_AUTH_OPEN,
+			.authmode        = (! key || key[0] == 0) ? WIFI_AUTH_OPEN : WIFI_AUTH_WPA2_PSK,
 			.ssid_hidden     = 0,
 			.beacon_interval = 100,
 			.psk_value = NULL,
@@ -329,6 +329,14 @@ void wifi_init_ap(const char* ssid)
     wifi_manager_reg_event_callback(WIFI_MGR_EVENT_SOFTAP_STARTUP, &ap_startup_cb);
 
     ap_cfg.ext_cfg.psk_value = NULL;
+    if (ap_cfg.ext_cfg.authmode == WIFI_AUTH_WPA2_PSK){
+	// generate PSK from SSID and password
+	    static uint8_t psk_value[40]      = {0x0};
+	    if (0 == ln_psk_calc(ap_cfg.ssid, ap_cfg.pwd, psk_value, sizeof (psk_value))) {
+		    ap_cfg.ext_cfg.psk_value = psk_value;
+		    hexdump(LOG_LVL_INFO, "psk value ", psk_value, sizeof(psk_value));
+		}
+    }
 
     //3. wifi
     if(WIFI_ERR_NONE !=  wifi_softap_start(&ap_cfg)){
@@ -341,8 +349,8 @@ void wifi_init_ap(const char* ssid)
 
 int HAL_SetupWiFiOpenAccessPoint(const char* ssid)
 {
-	alert_log("Starting AP: %s", ssid);
-	wifi_init_ap(ssid);
+	alert_log("Starting open AP: %s", ssid);
+	wifi_init_ap(ssid,NULL);
 
 	alert_log("AP started, waiting for: netdev_got_ip()");
     while (!netdev_got_ip()) {
@@ -351,6 +359,37 @@ int HAL_SetupWiFiOpenAccessPoint(const char* ssid)
 
 	alert_log("AP started OK!");
 	g_bOpenAccessPointMode = 1;
+
+	return 0;
+}
+
+int HAL_SetupWiFiAccessPoint(const char* ssid, const char* key)
+{
+	alert_log("Starting WPA2 AP: ssid=%s - PW=%s", ssid,key);
+	if (ssid[0] == 0) {
+		alert_log("Error: empty SSID!!\r\n");
+	        if (g_wifiStatusCallback != NULL) {
+		    g_wifiStatusCallback(WIFI_AP_FAILED);
+		}
+		return WIFI_ERR_INVALID_PARAM;
+	}
+	if (key[0] == 0 || strlen(key) < 8) {
+		alert_log("Error: Password minimum is 8 characters!!\r\n");
+	        if (g_wifiStatusCallback != NULL) {
+		    g_wifiStatusCallback(WIFI_AP_FAILED);
+		}
+		return WIFI_ERR_INVALID_PARAM;
+	}
+	 
+	wifi_init_ap(ssid,key);
+
+	alert_log("AP started, waiting for: netdev_got_ip()");
+    while (!netdev_got_ip()) {
+        OS_MsDelay(1000);
+    }
+
+	alert_log("AP started OK!");
+	g_bOpenAccessPointMode = 0;
 
 	return 0;
 }

--- a/src/hal/w800/hal_wifi_w800.c
+++ b/src/hal/w800/hal_wifi_w800.c
@@ -348,5 +348,24 @@ int HAL_SetupWiFiOpenAccessPoint(const char* ssid)
 
 	return 0;
 }
+int HAL_SetupWiFiAccessPoint(const char* ssid, const char* key)
+{
+
+	if ( key && strlen(key) < 8){
+		printf("ERROR! key(%s) needs to be at least 8 characters!\r\n", key);
+		if (g_wifiStatusCallback != 0) {
+			g_wifiStatusCallback(WIFI_AP_FAILED);
+		}
+		return -1;
+	}
+
+
+	demo_create_softap(ssid, key, 1, IEEE80211_ENCRYT_AUTO_WPA2, 1);
+
+	// dhcp_server_start(0);
+	// dhcp_server_stop(void);
+
+	return 0;
+}
 
 #endif

--- a/src/hal/xr809/hal_wifi_xr809.c
+++ b/src/hal/xr809/hal_wifi_xr809.c
@@ -57,6 +57,23 @@ int HAL_SetupWiFiOpenAccessPoint(const char *ssid) {
 
 	return 0;
 }
+int HAL_SetupWiFiAccessPoint(const char *ssid, const char *key) {
+	
+	if ( key && strlen(key) < 8){
+		printf("ERROR! key(%s) needs to be at least 8 characters!\r\n", key);
+		if (g_wifiStatusCallback != 0) {
+			g_wifiStatusCallback(WIFI_AP_FAILED);
+		}
+		return -1;
+	}
+
+	net_switch_mode(WLAN_MODE_HOSTAP);
+	wlan_ap_disable();
+	wlan_ap_set((uint8_t *)ssid, strlen(ssid), (uint8_t *)key);
+	wlan_ap_enable();
+
+	return 0;
+}
 static void wlan_msg_recv(uint32_t event, uint32_t data, void *arg)
 {
 	uint16_t type = EVENT_SUBTYPE(event);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1241,6 +1241,15 @@ int http_fn_cfg_wifi(http_request_t* request) {
 <input type=\"hidden\" id=\"open\" name=\"open\" value=\"1\">\
 <input type=\"submit\" value=\"Convert to open access wifi\" onclick=\"return confirm('Are you sure to convert module to open access wifi?')\">\
 </form>");
+
+	poststr_h2(request, "Open a (WPA2 based) WiFi Accesspoint");
+	poststr(request, "<form action=\"/cfg_wifi_set\"  onsubmit=\"txt='';ts=this.SSIDAP.value;tp=this.PWAP.value;(ts.length<1)&&(txt='SSID is empty!');(tp.length<8)&&(txt+=' Password is less than 8 chars!'); if (txt != ''){alert(txt); return false}  else   return confirm('Are you sure to convert module to access point with \\nSSID='+ts+' \\nPW='+tp+' \\n?')\" >\
+<input type=\"hidden\" name=\"WPA-AP\" value=\"1\">\
+<input type=\"submit\" value=\"Convert to access point with the following data\" onclick=\"if (thisreturn confirm('Are you sure to convert module to access point?')\">\
+<label>APs SSID:<br><input name=\"SSIDAP\"><label>\
+<label>APs passphrase:<br><input name=\"PWAP\"><label>\
+</form>");
+	
 	poststr_h2(request, "Use this to connect to your WiFi");
 	add_label_text_field(request, "SSID", "ssid", CFG_GetWiFiSSID(), "<form action=\"/cfg_wifi_set\">");
 	add_label_password_field(request, "Password", "pass", CFG_GetWiFiPass(), "<br>");
@@ -1304,6 +1313,7 @@ int http_fn_cfg_name(http_request_t* request) {
 int http_fn_cfg_wifi_set(http_request_t* request) {
 	char tmpA[128];
 	int bChanged;
+	char ssid[32],pw[32];
 
 	addLogAdv(LOG_INFO, LOG_FEATURE_HTTP, "HTTP_ProcessPacket: generating cfg_wifi_set \r\n");
 	bChanged = 0;
@@ -1314,6 +1324,18 @@ int http_fn_cfg_wifi_set(http_request_t* request) {
 		bChanged |= CFG_SetWiFiSSID("");
 		bChanged |= CFG_SetWiFiPass("");
 		poststr(request, "WiFi mode set: open access point.");
+	}
+	else if (http_getArg(request->url, "WPA-AP", tmpA, sizeof(tmpA))) {
+		if (http_getArg(request->url, "SSIDAP", tmpA, sizeof(tmpA))) {
+			strcpy(ssid,tmpA);
+	addLogAdv(LOG_INFO, LOG_FEATURE_HTTP, "APA-AP: ssid=%s \r\n",ssid);
+		}
+		if (http_getArg(request->url, "PWAP", tmpA, sizeof(tmpA))) {
+			strcpy(pw,tmpA);
+	addLogAdv(LOG_INFO, LOG_FEATURE_HTTP, "APA-AP: PW=%s \r\n",pw);
+		}
+		poststr(request, "WiFi mode set to access point.");
+		if (ssid[0] !=0 && pw[0] != 0 && strlen(pw) >7 ) HAL_SetupWiFiAccessPoint(ssid, pw);
 	}
 	else {
 		if (http_getArg(request->url, "ssid", tmpA, sizeof(tmpA))) {


### PR DESCRIPTION
Tested only with LN882H
Since it alters wifi code, I would advice to use it only if UART flashing is possible during test.
It's just a test up to now, for I can only test on LN882H device.
Actually you can only do it on WiFi config page:
![Bildschirmfoto vom 2024-06-02 21-51-45](https://github.com/openshwprojects/OpenBK7231T_App/assets/146550015/2cb91549-4170-4721-813e-414e48b08169)

IP is not altered from AP code - it's using 192.168.4.1 as the open AP of OBK