### PR TITLE
BL0937: Fixed swapped division and multiplication in measured value correction

### DIFF
--- a/src/driver/drv_bl0937.c
+++ b/src/driver/drv_bl0937.c
@@ -293,7 +293,6 @@ void BL0937_RunEverySecond(void) {
 		bNeedRestart = true;
 	}
 
-	ticksElapsed = (xTaskGetTickCount() - pulseStamp);
 
 #if PLATFORM_BEKEN
 	GLOBAL_INT_DECLARATION();
@@ -346,19 +345,20 @@ void BL0937_RunEverySecond(void) {
 
 #endif
 
+	ticksElapsed = (xTaskGetTickCount() - pulseStamp);
 	pulseStamp = xTaskGetTickCount();
 	//addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,"Voltage pulses %i, current %i, power %i\n", res_v, res_c, res_p);
 
     PwrCal_Scale(res_v, res_c, res_p, &final_v, &final_c, &final_p);
 
-	final_v *= (float)ticksElapsed;
-	final_v /= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_v *= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_v /= (float)ticksElapsed;
 
-	final_c *= (float)ticksElapsed;
-	final_c /= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_c *= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_c /= (float)ticksElapsed;
 
-	final_p *= (float)ticksElapsed;
-	final_p /= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_p *= (1000.0f / (float)portTICK_PERIOD_MS);
+	final_p /= (float)ticksElapsed;
 
     /* patch to limit max power reading, filter random reading errors */
     if (final_p > BL0937_PMAX)


### PR DESCRIPTION
value = pulses / time

More pulses for same time - bigger value.
More time for same pulses count - smaller value.
Twice more pulses for twice time - same value.

ticksElapased * tick_period == elapsed time in ms
ticksElapased * tick_period / 1000 == elapsed time in s

final = final * expected_time / elapsed_time; //expected time is 1 second.
final = final * expected_ticks / elapsed_ticks; //expected ticks for 1 second: (1000.0ms / portTICK_PERIOD_MS)

Closes: #1270