### PR TITLE
Add CRC to simple DS18x20 driver

### DIFF
--- a/src/driver/drv_ds1820_simple.c
+++ b/src/driver/drv_ds1820_simple.c
@@ -3,6 +3,8 @@
 static uint8_t   dsread=0;
 static int Pin;
 static int t=-127;
+static int errcount=0;
+static int lastconv;		// secondsElapsed on last successfull reading
 
 
 // usleep adopted from DHT driver
@@ -64,32 +66,9 @@ void usleepds(int r) //delay function do 10*r nops, because rtos_delay_milliseco
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
 	}
 #elif PLATFORM_BEKEN
-	for (volatile int i = 0; i < r; i++) {
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");	// 5
-	}
+	usleep((17*r)/10);		// "1" is to fast and "2" to slow, 1.7 seems better than 1.5 (only from observing readings, no scope involved)
 #elif PLATFORM_LN882H
-	for (volatile int i = 0; i < r; i++) {
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");	// 5
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");	//10
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");	//15
-		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-	}
+	usleep(5*r);			// "5" seems o.k
 #else
 	for (volatile int i = 0; i < r; i++) {
 		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
@@ -98,44 +77,6 @@ void usleepds(int r) //delay function do 10*r nops, because rtos_delay_milliseco
 	}
 #endif
 }
-
-
-/*
-//static int usleepfact=3;
-
-#ifdef WIN32
-	// not possible on Windows port
-#elif PLATFORM_BL602 
-static int usleepfact = 13;
-#elif PLATFORM_W600
-static int usleepfact = 7;
-#elif PLATFORM_W800
-//static int usleepfact = 33;
-static int usleepfact = 25;
-#elif PLATFORM_BEKEN
-//static int usleepfact = 6;
-static int usleepfact = 3;
-#elif PLATFORM_LN882H
-//static int usleepfact = 16;
-static int usleepfact = 10;
-#else
-static int usleepfact = 3;
-#endif
-
-
-void usleepds(int r) //delay function do 10*r nops, because rtos_delay_milliseconds is too much
-{
-	for (volatile int i = 0; i < r*usleepfact; i++) {
-//		__asm__("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop");
-		__asm__("nop\nnop\nnop\nnop\nnop");
-	}
-
-
-}
-
-*/
-
-
 
 
 /*
@@ -308,6 +249,46 @@ int OWTouchByte(int Pin, int data)
 }
 
 
+
+
+uint8_t OWcrc( uint8_t *data, uint8_t len)
+{
+	uint8_t crc = 0;
+	
+	while (len--) {
+		uint8_t inb = *data++;
+		for (uint8_t i = 8; i; i--) {
+			uint8_t mix = (crc ^ inb) & 0x01;
+			crc >>= 1;
+			if (mix) crc ^= 0x8C;
+			inb >>= 1;
+		}
+	}
+	return crc;
+}
+
+// quicker CRC with lookup table
+// based on code found here: https://community.st.com/t5/stm32-mcus-security/use-stm32-crc-to-compare-ds18b20-crc/m-p/333749/highlight/true#M4690
+// Dallas 1-Wire CRC Test App -
+//  x^8 + x^5 + x^4 + 1 0x8C (0x131)
+
+uint8_t Crc8CQuick(uint8_t *Buffer,uint8_t Size)
+{  static const uint8_t CrcTable[] = { // Nibble table for polynomial 0x8C
+    0x00,0x9D,0x23,0xBE,0x46,0xDB,0x65,0xF8,
+    0x8C,0x11,0xAF,0x32,0xCA,0x57,0xE9,0x74 };
+    uint8_t Crc=0x00;
+  while(Size--)
+  {	
+  	Crc ^= *Buffer++; // Apply Data    
+  	Crc = (Crc >> 4) ^ CrcTable[Crc & 0x0F]; // Two rounds of 4-bits
+  	Crc = (Crc >> 4) ^ CrcTable[Crc & 0x0F];  
+  }
+  return(Crc);
+
+}
+
+
+
 int DS1820_getTemp() {
 	return t;
 }
@@ -319,8 +300,9 @@ void DS1820_driver_Init(){};
 void DS1820_AppendInformationToHTTPIndexPage(http_request_t *request)
 {
 
-        hprintf255(request, "<h5>DS1820 Temperature: %.2f C </h5>",(float)t/100);
+        hprintf255(request, "<h5>DS1820 Temperature: %.2f C (read %i secs ago)</h5>",(float)t/100, g_secondsElapsed-lastconv);
 }
+
 
 
 void DS1820_OnEverySecond() {
@@ -328,7 +310,7 @@ void DS1820_OnEverySecond() {
 	// for now just find the pin used
 	//
 	Pin=PIN_FindPinIndexForRole(IOR_DS1820_IO, 99);
-
+	uint8_t scratchpad[9], crc;
 	if (Pin != 99) {	// only if pin is set
 		// request temp if conversion was requested two seconds after request
 		// if (dsread == 1 && g_secondsElapsed % 5 == 2) {
@@ -342,26 +324,44 @@ void DS1820_OnEverySecond() {
 			OWWriteByte(Pin,0xCC);
 			OWWriteByte(Pin,0xBE);
 
-			Low = OWReadByte(Pin);
-			High = OWReadByte(Pin);
-
-
-			Val = (High << 8) + Low; // combine bytes to integer
-			negative = (High >= 8); // negative temperature
-			if (negative)
+			for (int i = 0; i < 9; i++)
+			  {
+			    scratchpad[i] = OWReadByte(Pin);//read Scratchpad Memory of DS
+			  }
+//			crc= OWcrc(scratchpad, 8);
+			crc= Crc8CQuick(scratchpad, 8);
+			if (crc != scratchpad[8])
 			{
-			  Val = (Val ^ 0xffff) + 1;
+				errcount++;
+				addLogAdv(LOG_ERROR, LOG_FEATURE_CFG, "DS1820 - Read CRC=%x != calculated:%x (errcount=%i)\r\n",scratchpad[8],crc,errcount);
+				addLogAdv(LOG_ERROR, LOG_FEATURE_CFG, "DS1820 - Scratchpad Data Read: %x %x %x %x %x %x %x %x %x \r\n",scratchpad[0],scratchpad[1],scratchpad[2],scratchpad[3],scratchpad[4],scratchpad[5],scratchpad[6],scratchpad[7],scratchpad[8]);
+				
+				if (errcount > 5) dsread=0;	// retry afer 5 failures		
+			}	
+			else
+			{		
+				Low = scratchpad[0];
+				High = scratchpad[1];
+			
+
+				Val = (High << 8) + Low; // combine bytes to integer
+				negative = (High >= 8); // negative temperature
+				if (negative)
+				{
+				  Val = (Val ^ 0xffff) + 1;
+				}
+				// Temperature is returned in multiples of 1/16 °C
+				//  we want a simple way to display e.g. xx.yy °C, so just multiply with 100 and we get xxyy 
+				//  --> the last two digits will be the fractional part  (Val%100)
+				// -->  the whole part of temperature is (int)Val/100
+				// so we want 100/16 = 6.25 times the value (the sign to be able to show negative temperatures is in "factor") 
+				Tc = (6 * Val) + Val / 4 ;
+				t = negative ? -1 : 1 * Tc ;
+				dsread=0;
+				lastconv=g_secondsElapsed;
+				addLogAdv(LOG_INFO, LOG_FEATURE_CFG, "DS1820 - Pin=%i temp=%s%i.%02i \r\n",Pin, negative ? "-" : "+", (int)Tc/100 , (int)Tc%100);
+				addLogAdv(LOG_INFO, LOG_FEATURE_CFG, "DS1820 - High=%i Low=%i Val=%i Tc=%i  -- Read CRC=%x - calculated:%x \r\n",High, Low, Val,Tc,scratchpad[8],crc);
 			}
-			// Temperature is returned in multiples of 1/16 °C
-			//  we want a simple way to display e.g. xx.yy °C, so just multiply with 100 and we get xxyy 
-			//  --> the last two digits will be the fractional part  (Val%100)
-			// -->  the whole part of temperature is (int)Val/100
-			// so we want 100/16 = 6.25 times the value (the sign to be able to show negative temperatures is in "factor") 
-			Tc = (6 * Val) + Val / 4 ;
-			t = negative ? -1 : 1 * Tc ;
-			dsread=0;
-			addLogAdv(LOG_INFO, LOG_FEATURE_CFG, "DS1820 - Pin=%i temp=%s%i.%02i \r\n",Pin, negative ? "-" : "+", (int)Tc/100 , (int)Tc%100);
-			addLogAdv(LOG_INFO, LOG_FEATURE_CFG, "DS1820 - High=%i Low=%i Val=%i Tc=%i \r\n",High, Low, Val,Tc);
 		}
 		else if (g_secondsElapsed % 5 == 0) {	// every 5 seconds
 				// ask for "conversion" 
@@ -373,7 +373,7 @@ void DS1820_OnEverySecond() {
 				// lets do usleepds() with numbers 50.000 and 100.00
 				// if all is well, it should take 50ms and 100ms
 				// if not, we need to "calibrate" the loop
-				int tempsleep=50000;
+				int tempsleep=5000;
 				TickType_t actTick=portTICK_RATE_MS*xTaskGetTickCount();
 				usleepds(tempsleep);
 				int duration = (int)(portTICK_RATE_MS*xTaskGetTickCount()-actTick);
@@ -400,6 +400,7 @@ void DS1820_OnEverySecond() {
 				OWWriteByte(Pin,0x44);
 				addLogAdv(LOG_INFO, LOG_FEATURE_CFG, "DS1820 - asked for conversion - Pin %i",Pin);
 				dsread=1;
+				errcount=0;
 			}
 		}
 


### PR DESCRIPTION
As requested in PR #1294:
 
- added CRC calculation to verify OW readings
- changed "usleepds" to multiples of "usleep()" for BEKEN and LN882H
- introduced an information about "age" of reading on Main Page (since bad readings are ignored, temperature might be "older")
![Beken_DS1820_with_age](https://github.com/user-attachments/assets/a5d3fa88-4eb1-46ff-b1e2-a8a8dfde223e)
