### PR TITLE
Change "Build" to "Built" in the build date text

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -59,7 +59,7 @@ const char htmlFooterInfo[] =
 "<a target=\"_blank\" "
 "href=\"https://paypal.me/openshwprojects\">Support project</a><br>";
 
-const char* g_build_str = "Build on " __DATE__ " " __TIME__ " version " USER_SW_VER; // Show GIT version at Build line;
+const char* g_build_str = "Built on " __DATE__ " " __TIME__ " version " USER_SW_VER; // Show GIT version at Build line;
 
 const char httpCorsHeaders[] = "Access-Control-Allow-Origin: *\r\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept";           // TEXT MIME type
 


### PR DESCRIPTION
Reason for the Change:
The current text "Build on xxxxx" is grammatically incorrect in this context. The word "build" is a verb in its base form, which is used to describe the action of constructing or creating something. However, in the context of displaying the date and time when the program was constructed, the past participle "built" should be used. This is because we are referring to an action that has been completed in the past.