### PR TITLE
Fix W800 crashing on "STATUS" request - fixed json_interface.c

### DIFF
--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -552,7 +552,7 @@ static int http_tasmota_json_status_MEM(void* request, jsonCb_t printer) {
 }
 // Test command: http://192.168.0.159/cm?cmnd=STATUS%205
 static int http_tasmota_json_status_NET(void* request, jsonCb_t printer) {
-	char tmpStr[16];
+	char tmpStr[19];	// will be used for MAC string 6*3 chars (18 would be o.k, since last hex has no ":" ...)
 	HAL_GetMACStr(tmpStr);
 
 	printer(request, "\"StatusNET\":{");


### PR DESCRIPTION
Requesting "STATUS" or "STATUS 5" on W800 was crashing the module. Reason was "tmpStr" was too short, now it works.
Might have caused instability on other platforms, too