### PR TITLE
Beautify/fix networking info of W800

### DIFF
--- a/src/hal/w800/hal_wifi_w800.c
+++ b/src/hal/w800/hal_wifi_w800.c
@@ -86,14 +86,11 @@ void HAL_PrintNetworkInfo()
 	unsigned char mac[6] = { 0, 1, 2, 3, 4, 5 };
 
 	struct netif* netif = tls_get_netif();
-	MEMCPY(mac, &netif->hwaddr[0], ETH_ALEN);
+	MEMCPY(mac, &netif->hwaddr, ETH_ALEN);
 	snprintf(macstr, sizeof(macstr), MACSTR, MAC2STR(mac));
 
 	tls_wifi_get_current_bss(&bss);
-
-	wm_printf("sta:rssi=%d,ssid=%s,bssid=" MACSTR ",channel=%d,cipher_type:",
-		bss.rssi, bss.ssid, macstr, bss.channel);
-	print_security_type(bss.encryptype);
+	bss.ssid[bss.ssid_len]=0;
 
 	struct tls_ethif* tmpethif = tls_netif_get_ethif();
 	char buffer[256];
@@ -105,8 +102,16 @@ void HAL_PrintNetworkInfo()
 	strcpy(netmask, inet_ntoa(tmpethif->netmask));
 	char dns[16] = {0};
 	strcpy(dns, inet_ntoa(tmpethif->dns1));
-	snprintf(buffer, 256, "ip=%s,gate=%s,mask=%s,dns=%s\r\n", ip, gw, netmask, dns);
-	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, buffer);
+	snprintf(buffer, 256, 	"Network info:\r\n"
+				"\tsta:rssi=%d, SSID=%s, BSSID=" MACSTR ", channel=%d, encr=%s\r\n"
+				"\tIP=%s, GW=%s, MASK=%s, MAC=%s, DNS=%s\r\n",
+				bss.rssi, bss.ssid, MAC2STR(bss.bssid), bss.channel, 
+				( bss.encryptype >=  IEEE80211_ENCRYT_NONE && bss.encryptype <= IEEE80211_ENCRYT_AUTO_WPA2) ? security_names[bss.encryptype] : "-",
+				 ip, gw, netmask, macstr, dns );
+	bk_printf(buffer);
+	// do we need this in web Log?
+	// disable for now
+//	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, buffer);
 }
 
 int HAL_GetWifiStrength()


### PR DESCRIPTION
The network info of W800 is not too nice:

OpenW800_1.17.655:
```
Info:MAIN:Time 19, idle 0/s, free 29592, MQTT 0(0), bWifi 0, secondsWithNoPing -1, socks 2/8 
sta:rssi=73,ssid=mySSIDe��,bssid=20022778:1f:cd:aa:bb:cc,channel=774909488,cipher_type:WPA2_PSK_CCMP
Info:MAIN:Time 20, idle 0/s, free 29592, MQTT 0(0), bWifi 0, secondsWithNoPing -1, socks 2/8 
Info:GEN:ip=192.168.0.37,gate=192.168.0.1,mask=255.255.255.0,dns=192.168.0.1
Info:MAIN:Time 21, idle 0/s, free 29592, MQTT 0(0), bWifi 0, secondsWithNoPing -1, socks 2/8 
```

I like it better this way (fixed garbage in SSID, added BSSID (MAC was given instead of BSSID), put all information together):
```
Info:MAIN:Time 98, idle 0/s, free 29496, MQTT 0(52), bWifi 1, secondsWithNoPing 1, socks 2/8 
Info:MAIN:Time 99, idle 0/s, free 29496, MQTT 0(52), bWifi 1, secondsWithNoPing 1, socks 2/8 
Network info:
        sta:rssi=73, SSID=mySSID, BSSID=01:02:03:04:05:06, channel=8, encr=WPA2_PSK_CCMP
        IP=192.168.0.37, GW=192.168.0.1, MASK=255.255.255.0, MAC=28:6d:cd:aa:bb:cc, DNS=192.168.0.1
Info:MAIN:Time 100, idle 0/s, free 29496, MQTT 0(52), bWifi 1, secondsWithNoPing 1, socks 2/8 

```

I also removed the information from web console ("addLogAdv(..."). This might be discussed:
It's not present in LN882H but present in BK7231N.