### PR TITLE
Allow faster WIFI connect retries during first seconds after startup

### DIFF
--- a/src/user_main.c
+++ b/src/user_main.c
@@ -312,8 +312,8 @@ void Main_OnWiFiStatusChange(int code)
 		break;
 	case WIFI_STA_AUTH_FAILED:
 		// try to connect again in few seconds
-		// for me first auth will often fail, so retry more aggressive during startup
-		// the maximum of 6 tries during first 30 seconds should be accepttable
+		// for me first auth will often fail, so retry more aggressively during startup
+		// the maximum of 6 tries during first 30 seconds should be acceptable
 		if (g_secondsElapsed < 30) {
 			g_connectToWiFi = 5;
 		}

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -312,7 +312,14 @@ void Main_OnWiFiStatusChange(int code)
 		break;
 	case WIFI_STA_AUTH_FAILED:
 		// try to connect again in few seconds
-		g_connectToWiFi = 60;
+		// for me first auth will often fail, so retry more aggressive during startup
+		// the maximum of 6 tries during first 30 seconds should be accepttable
+		if (g_secondsElapsed < 30) {
+			g_connectToWiFi = 5;
+		}
+		else {
+			g_connectToWiFi = 60;
+		}
 		g_bHasWiFiConnected = 0;
 		ADDLOGF_INFO("Main_OnWiFiStatusChange - WIFI_STA_AUTH_FAILED - %i\r\n", code);
 		break;


### PR DESCRIPTION
For me especially W800 often fails to authenticate to WiFi on the first try.  
Having to wait for 1 minute is very long, especially if you are trying some new versions and have to wait often.

So my proposal is to reduce this to 5 seconds during the first 30 seconds after startup.