### PR TITLE
fix flicker in DDP (fixes #1325)

### DIFF
--- a/src/driver/drv_ddp.c
+++ b/src/driver/drv_ddp.c
@@ -12,6 +12,10 @@
 #include "lwip/inet.h"
 #include "../httpserver/new_http.h"
 
+#if ENABLE_DRIVER_SM16703P
+#include "drv_spiLED.h"
+#endif
+
 static const char* group = "239.255.250.250";
 static int port = 4048;
 static int g_ddp_socket_receive = -1;
@@ -122,13 +126,17 @@ void DDP_Parse(byte *data, int len) {
 		g = data[11];
 		b = data[12];
 
-		LED_SetFinalRGB(r,g,b);
-
 #if ENABLE_DRIVER_SM16703P
-		// Note that this is limited by DDP msgbuf size
-		uint32_t pixel = (len - 10) / 3;
-		// This immediately activates the pixels, maybe we should read the PUSH flag
-		SM16703P_setMultiplePixel(pixel, &data[10], true);
+		if (spiLED.ready) {
+			// Note that this is limited by DDP msgbuf size
+			uint32_t pixel = (len - 10) / 3;
+			// This immediately activates the pixels, maybe we should read the PUSH flag
+			SM16703P_setMultiplePixel(pixel, &data[10], true);
+		} else {
+			LED_SetFinalRGB(r,g,b);
+		}
+#else
+		LED_SetFinalRGB(r,g,b);
 #endif
 	}
 }


### PR DESCRIPTION
The DDP_Parse() function should write the incoming DDP data to the LEDs. But it did it twice per incoming packet. First with LED_SetFinalRGB() which set all LEDs to a single color(?) and then again with SM16703P_setMultiplePixel() to the correct values. Resulting in flickering LEDs.

This fixes that and writes the pixels with either the SM16703P function OR the other one.

fixes https://github.com/openshwprojects/OpenBK7231T_App/issues/1325