### PR TITLE
Add channel label to dimmer

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -544,7 +544,7 @@ int http_fn_index(http_request_t* request) {
 			}
 			pwmValue = CHANNEL_Get(i);
 			poststr(request, "<tr><td>");
-			hprintf255(request, "<form action=\"index\" id=\"form%i\">", i);
+			hprintf255(request, "Channel %s:<br><form action=\"index\" id=\"form%i\">", CHANNEL_GetLabel(i), i);
 			hprintf255(request, "<input type=\"range\" min=\"0\" max=\"%i\" name=\"%s\" id=\"slider%i\" value=\"%i\" onchange=\"this.form.submit()\">", maxValue, inputName, i, pwmValue);
 			hprintf255(request, "<input type=\"hidden\" name=\"%sIndex\" value=\"%i\">", inputName, i);
 			hprintf255(request, "<input type=\"submit\" class='disp-none' value=\"Toggle %s\"/></form>", CHANNEL_GetLabel(i));


### PR DESCRIPTION
ATM a Dimmer channel is visible on the main page without showing, to which channel it belongs:

![grafik](https://github.com/user-attachments/assets/54b8b00a-d69b-40dd-be45-71374933b310)



This PR adds the label - I did not use the way like PWN for this (with "\<h5>") leads to a bigger gap between label and slider than just inserting the text and a linebreak:

![grafik](https://github.com/user-attachments/assets/f8211745-77f1-48a6-90f9-a87128cd7472)


