### PR TITLE
allow to publish channel labels instead of channel ids.

### DIFF
--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -449,7 +449,11 @@ HassDeviceInfo* hass_init_binary_sensor_device_info(int index, bool bInverse) {
 	}
 	HassDeviceInfo* info = hass_init_device_info(BINARY_SENSOR, index, payload_on, payload_off);
 
-	sprintf(g_hassBuffer, "~/%i/get", index);
+	if (CHANNEL_PublishLabel(index)){
+		sprintf(g_hassBuffer, "~/%s/get", CHANNEL_GetLabel(index));
+	} else {
+		sprintf(g_hassBuffer, "~/%i/get", index);
+	}
 	cJSON_AddStringToObject(info->root, "stat_t", g_hassBuffer);   //state_topic
 
 	return info;

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -1359,7 +1359,7 @@ OBK_Publish_Result MQTT_ChannelPublish(int channel, int flags)
 		}
 	}
 
-	return MQTT_PublishMain(mqtt_client, channelNameStr, valueStr, flags, true);
+	return MQTT_PublishMain(mqtt_client, CHANNEL_PublishLabel(channel) ? CHANNEL_GetLabel(channel) : channelNameStr, valueStr, flags, true);
 }
 // This console command will trigger a publish of all used variables (channels and extra stuff)
 commandResult_t MQTT_PublishAll(const void* context, const char* cmd, const char* args, int cmdFlags) {

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1374,6 +1374,7 @@ bool CHANNEL_HasLabel(int ch);
 const char* CHANNEL_GetLabel(int ch);
 bool CHANNEL_ShouldAddTogglePrefixToUI(int ch);
 bool CHANNEL_HasNeverPublishFlag(int ch);
+bool CHANNEL_PublishLabel(int ch);	// use channels label instead of channel id when publishing
 //ledRemap_t *CFG_GetLEDRemap();
 
 void PIN_get_Relay_PWM_Count(int* relayCount, int* pwmCount, int* dInputCount);


### PR DESCRIPTION
   - introduce a new "bit-vector" `g_PublishChannelLabel `(like e.g. `g_doNotPublishChannels`) which needs to be 1 to publish the label instead of the channel
   - as a quick hack I "extended" the `SetChannelLabel` command: it uses 0/1 to show/hide the prefix "Toggle". Now you can use 2/3 to do the same, but use labels as topic.
     (so instead of calling "`SetChannelLabel 30 MeinDimmer 0"` you may call "`SetChannelLabel 30 MeinDimmer 2`" (and "3" instead of "1" to hide the prefix)
   - I also tried to do the proposed change in hass.c, but I'm not sure, if that's the only part of code which needs adjustments...
   - If label shall be published, the label will be "validated", unwanted characters are set to '_'.