### PR TITLE
LN882H - static ip

### DIFF
--- a/src/cmnds/cmd_tokenizer.c
+++ b/src/cmnds/cmd_tokenizer.c
@@ -21,8 +21,9 @@ static int tok_flags = 0;
 #define g_bAllowExpand (!(tok_flags&TOKENIZER_DONT_EXPAND))
 
 int str_to_ip(const char *s, byte *ip) {
-#if PLATFORM_W600
+#if PLATFORM_W600 || PLATFORM_LN882H
 	//seems like sscanf in W600 does not support %hhu and uses it as %u, thus overwriting more memory, use temp array for it
+	// same for LN882h: %hhu isn't recognised, so we have to use %u for IP_STRING_FORMAT, which will lead to problems in sscanf, too
 	int tmp_ip[4];
 	int res; 
 	res = sscanf(s, IP_STRING_FORMAT, &tmp_ip[0], &tmp_ip[1], &tmp_ip[2], &tmp_ip[3]);

--- a/src/hal/ln882h/hal_wifi_ln882h.c
+++ b/src/hal/ln882h/hal_wifi_ln882h.c
@@ -231,11 +231,9 @@ void wifi_init_sta(const char* oob_ssid, const char* connect_key, obkStaticIP_t 
             ip_info.netmask.addr = ipaddr_addr((const char *)g_IP);
             convert_IP_to_string(g_IP, ip->gatewayIPAddr);
             ip_info.gw.addr      = ipaddr_addr((const char *)g_IP);
-//            convert_IP_to_string(g_IP, ip->dnsServerIpAddr);
-//            ip_info.dns.addr      = ipaddr_addr((const char *)g_IP);
-// ToDo: set DNS server
-
+	
             netdev_set_ip_info(NETIF_IDX_STA, &ip_info);
+            dns_setserver(0,&ip->dnsServerIpAddr);
        } else  LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, no static IP - use DHCP (ip->localIPAddr[0] == 0)");
 
 

--- a/src/hal/ln882h/hal_wifi_ln882h.c
+++ b/src/hal/ln882h/hal_wifi_ln882h.c
@@ -13,11 +13,15 @@
 #include "ln_psk_calc.h"
 #include "utils/sysparam_factory_setting.h"
 #include <lwip/sockets.h>
+#include <stdbool.h>	// for bool "g_STA_static_IP"
 
 
 #define PM_WIFI_DEFAULT_PS_MODE           (WIFI_NO_POWERSAVE)
 
 static void (*g_wifiStatusCallback)(int code)  = NULL;
+
+// if we are using a static IP, prevent using DHCP in lwips interface implementation in ethernetif.c
+bool g_STA_static_IP=0;
 
 void alert_log(const char *format, ...) {
      va_list args;
@@ -222,10 +226,11 @@ void wifi_init_sta(const char* oob_ssid, const char* connect_key, obkStaticIP_t 
     netdev_set_mac_addr(NETIF_IDX_STA, mac_addr);
     sysparam_sta_hostname_update(CFG_GetDeviceName());
     // static ip address
-       if (ip->localIPAddr[0] != 0){
+    g_STA_static_IP = (ip->localIPAddr[0] != 0) ;
+       if (g_STA_static_IP){
             tcpip_ip_info_t  ip_info;
             convert_IP_to_string(g_IP, ip->localIPAddr);
-            LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, ip->localIPAddr[0] != 0 - setting static IP (%s)",g_IP);
+            LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta - setting static IP (%s)\r\n",g_IP);
             ip_info.ip.addr      = ipaddr_addr((const char *)g_IP);
             convert_IP_to_string(g_IP, ip->netMask);
             ip_info.netmask.addr = ipaddr_addr((const char *)g_IP);
@@ -234,10 +239,7 @@ void wifi_init_sta(const char* oob_ssid, const char* connect_key, obkStaticIP_t 
 	
             netdev_set_ip_info(NETIF_IDX_STA, &ip_info);
             dns_setserver(0,&ip->dnsServerIpAddr);
-       } else  LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, no static IP - use DHCP (ip->localIPAddr[0] == 0)");
-
-
-
+       } else  LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, no static IP - using DHCP\r\n");
 
     netdev_set_active(NETIF_IDX_STA);
 

--- a/src/hal/ln882h/hal_wifi_ln882h.c
+++ b/src/hal/ln882h/hal_wifi_ln882h.c
@@ -221,7 +221,28 @@ void wifi_init_sta(const char* oob_ssid, const char* connect_key, obkStaticIP_t 
     //2. net device(lwip)
     netdev_set_mac_addr(NETIF_IDX_STA, mac_addr);
     sysparam_sta_hostname_update(CFG_GetDeviceName());
+    // static ip address
+       if (ip->localIPAddr[0] != 0){
+            tcpip_ip_info_t  ip_info;
+            convert_IP_to_string(g_IP, ip->localIPAddr);
+            LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, ip->localIPAddr[0] != 0 - setting static IP (%s)",g_IP);
+            ip_info.ip.addr      = ipaddr_addr((const char *)g_IP);
+            convert_IP_to_string(g_IP, ip->netMask);
+            ip_info.netmask.addr = ipaddr_addr((const char *)g_IP);
+            convert_IP_to_string(g_IP, ip->gatewayIPAddr);
+            ip_info.gw.addr      = ipaddr_addr((const char *)g_IP);
+//            convert_IP_to_string(g_IP, ip->dnsServerIpAddr);
+//            ip_info.dns.addr      = ipaddr_addr((const char *)g_IP);
+// ToDo: set DNS server
+
+            netdev_set_ip_info(NETIF_IDX_STA, &ip_info);
+       } else  LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, no static IP - use DHCP (ip->localIPAddr[0] == 0)");
+
+
+
+
     netdev_set_active(NETIF_IDX_STA);
+
 
     //3. wifi start
     wifi_manager_reg_event_callback(WIFI_MGR_EVENT_STA_SCAN_COMPLETE, &wifi_scan_complete_cb);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -987,18 +987,22 @@ int http_fn_cfg_ip(http_request_t* request) {
 
 	if (http_getArg(request->url, "IP", tmp, sizeof(tmp))) {
 		str_to_ip(tmp, g_cfg.staticIP.localIPAddr);
+//hprintf255(request, "<br>IP=%s (%02x %02x %02x %02x)<br>",tmp,g_cfg.staticIP.localIPAddr[0],g_cfg.staticIP.localIPAddr[1],g_cfg.staticIP.localIPAddr[2],g_cfg.staticIP.localIPAddr[3]);
 		g_changes++;
 	}
 	if (http_getArg(request->url, "mask", tmp, sizeof(tmp))) {
 		str_to_ip(tmp, g_cfg.staticIP.netMask);
+//hprintf255(request, "<br>Mask=%s (%02x %02x %02x %02x)<br>",tmp, g_cfg.staticIP.netMask[0], g_cfg.staticIP.netMask[1], g_cfg.staticIP.netMask[2], g_cfg.staticIP.netMask[3]);
 		g_changes++;
 	}
 	if (http_getArg(request->url, "dns", tmp, sizeof(tmp))) {
 		str_to_ip(tmp, g_cfg.staticIP.dnsServerIpAddr);
+//hprintf255(request, "<br>DNS=%s (%02x %02x %02x %02x)<br>",tmp, g_cfg.staticIP.dnsServerIpAddr[0], g_cfg.staticIP.dnsServerIpAddr[1], g_cfg.staticIP.dnsServerIpAddr[2], g_cfg.staticIP.dnsServerIpAddr[3]);
 		g_changes++;
 	}
 	if (http_getArg(request->url, "gate", tmp, sizeof(tmp))) {
 		str_to_ip(tmp, g_cfg.staticIP.gatewayIPAddr);
+//hprintf255(request, "<br>GW=%s (%02x %02x %02x %02x)<br>",tmp, g_cfg.staticIP.gatewayIPAddr[0], g_cfg.staticIP.gatewayIPAddr[1], g_cfg.staticIP.gatewayIPAddr[2], g_cfg.staticIP.gatewayIPAddr[3]);
 		g_changes++;
 	}
 	if (g_changes) {

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -468,8 +468,11 @@ typedef enum
     EXCELLENT,
 } WIFI_RSSI_LEVEL;
 
+#if PLATFORM_LN882H
+#define IP_STRING_FORMAT	"%u.%u.%u.%u"
+#else
 #define IP_STRING_FORMAT	"%hhu.%hhu.%hhu.%hhu"
-
+#endif
 WIFI_RSSI_LEVEL wifi_rssi_scale(int8_t rssi_value);
 extern const char *str_rssi[];
 extern int bSafeMode;


### PR DESCRIPTION
Enable static IP for LN882H

Needs a change in SDK - in 

[sdk/OpenLN882H/components/net/lwip-2.1.3/src/port/ln_osal/netif/ethernetif.c b/components/net/lwip-2.1.3/src/port/ln_osal/netif/ethernetif.c](url)

to make sure, DHCP isn't called after we set the IP. Simple approach: If we set an IP in STA mod, don't start DHCP:

```
diff --git a/components/net/lwip-2.1.3/src/port/ln_osal/netif/ethernetif.c b/components/net/lwip-2.1.3/src/port/ln_osal/netif/ethernetif.c
index e2b485e..2884ef3 100644
--- a/components/net/lwip-2.1.3/src/port/ln_osal/netif/ethernetif.c
+++ b/components/net/lwip-2.1.3/src/port/ln_osal/netif/ethernetif.c
@@ -16,6 +16,7 @@

 #define IF_NAME_STA "ST" // Only support two ascii characters
 #define IF_NAME_AP  "AP" // Only support two ascii characters
+static int STA_USE_DHCP = 1;

 typedef struct {
     struct netif              nif;
@@ -267,9 +268,10 @@ int netdev_set_state(netif_idx_t nif_idx, netdev_state_t state)

             netif_set_status_callback(nif, sta_netif_status_changed_cb);
             netif_set_link_callback(nif, sta_netif_link_changed_cb);
-
             netifapi_dhcp_stop(nif);
+       if (STA_USE_DHCP) {
             netifapi_dhcp_start(nif);
+            }
         }
         else
         {
@@ -362,6 +364,8 @@ int netdev_set_ip_info(netif_idx_t nif_idx, tcpip_ip_info_t *ip_info)

     if (ndev && ip_info) {
         netifapi_netif_set_addr(netdev2netif(ndev), &ip_info->ip, &ip_info->netmask, &ip_info->gw);
+        // we set an IP in STA mode? --> disable DHCP, or it will be overwritten
+        if (nif_idx == NETIF_IDX_STA) STA_USE_DHCP = 0;
         return 0;
     }
     return -1;
```