### PR TITLE
Add UID of user when building to avoid permission issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM --platform=linux/amd64 ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USERNAME=devuser
+ARG UID=1000
 
 RUN dpkg --add-architecture i386 \
  && apt-get update \
@@ -13,7 +14,7 @@ RUN dpkg --add-architecture i386 \
 
 RUN pip3 install pycryptodomex configobj toml fdt
 
-RUN useradd -m -s /bin/bash ${USERNAME}
+RUN useradd -m -s /bin/bash -u "${UID}" ${USERNAME}
 
 COPY build_target_platforms.sh /build_target_platforms.sh
 RUN chmod 775 /build_target_platforms.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM --platform=linux/amd64 ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USERNAME=devuser
 ARG UID=1000
+ARG TZ="Etc/UTC"
+
+RUN echo "$TZ" > /etc/timezone
 
 RUN dpkg --add-architecture i386 \
  && apt-get update \

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,21 @@ This docker will build all or some of the platforms that OpenBeken supports. To 
 docker build -t openbk_build --build-arg UID=$UID --build-arg USERNAME=$USER .
 ```
 
-Note that the current user name is passed through to the docker image build. This is to preserve local file permissions when OpenBeken is built.
+Note that the current user name and user ID is passed through to the docker image build.
+This is to preserve local file permissions when OpenBeken is built.
+
+If you want to change the timezone you can use the argument TZ for that like
+
+```sh
+docker build -t openbk_build --build-arg UID=$UID --build-arg USERNAME=$USER --build-arg TZ="Etc/UTC" .
+```
+
+or
+
+```sh
+docker build -t openbk_build --build-arg UID=$UID --build-arg USERNAME=$USER --build-arg TZ="Asia/Tokyo" .
+```
+
 
 Once the docker image is build, you can use it to build the SDKs as follows (assumed you are in the current `docker` directory):
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 This docker will build all or some of the platforms that OpenBeken supports. To use, first build the docker image:
 
 ```sh
-docker build -t openbk_build --build-arg USERNAME=$USER .
+docker build -t openbk_build --build-arg UID=$UID --build-arg USERNAME=$USER .
 ```
 
 Note that the current user name is passed through to the docker image build. This is to preserve local file permissions when OpenBeken is built.


### PR DESCRIPTION
Hi,

When I tried to compile OpenBeken with docker locally, I had the same issue as #767 .

This was due to the UID of user used by the docker container. The UID was 1000 in docker and not the one of my Host user.

To correct this, I added the current UID as an argument to build the container image.
