### PR TITLE
Fix release sometimes missing windows binaries

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -155,7 +155,7 @@ jobs:
   release:
     name: Semantic Release Images and Artifacts
     runs-on: ubuntu-20.04
-    needs: [ refs, build ]
+    needs: [ refs, build, build2 ]
     if: always() && needs.refs.outputs.new_release == 'true' && (github.ref == 'refs/heads/main' || github.ref_name == 'alpha')
     steps:
       - name: Source checkout


### PR DESCRIPTION
Update workflow.yaml try fix (sometimes) missing windows binaries by adding "build2" as "needs" for release