### PR TITLE
Fix bug preventing divider of 2 to work properly for home assistant auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Fork intention
-Fork from "official" OpenBK7231T/OpenBeken to experiment with improvement of home assissten auto detection feature by implementing more precise value templates (val_tmp)
+Fork from "official" OpenBK7231T/OpenBeken to experiment with improvement of home assistant auto detection feature by implementing more precise value templates (val_tmp)
 Use case: TuYaMCU based Thermostat, with temperature devider /2 instead of /10
+Edit: it seems, that this functionality has been already implemented, but buggy.
 
 # Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Introduction
 
+Fork from "official" OpenBK7231T/OpenBeken to experiment with improvement of home assissten auto detection feature by implementing more precise value templates (val_tmp)
+Use case: TuYaMCU based Thermostat, with temperature devider /2 instead of /10
+
 OpenBK7231T/OpenBeken is a Tasmota/Esphome replacement for new Tuya modules featuring MQTT and Home Assistant compatibility.
 This repository is named "OpenBK7231T_App", but now it's a multiplatform app, supporting build for multiple separate chips:
 - [BK7231T](https://www.elektroda.com/rtvforum/topic3951016.html) ([WB3S](https://developer.tuya.com/en/docs/iot/wb3s-module-datasheet?id=K9dx20n6hz5n4), [WB2S](https://developer.tuya.com/en/docs/iot/wb2s-module-datasheet?id=K9ghecl7kc479), WB2L, etc)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# Fork intention
-Fork from "official" OpenBK7231T/OpenBeken to experiment with improvement of home assistant auto detection feature by implementing more precise value templates (val_tmp)
-Use case: TuYaMCU based Thermostat, with temperature devider /2 instead of /10
-Edit: it seems, that this functionality has been already implemented, but buggy.
-
 # Introduction
 
 OpenBK7231T/OpenBeken is a Tasmota/Esphome replacement for new Tuya modules featuring MQTT and Home Assistant compatibility.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Introduction
-
+# Fork intention
 Fork from "official" OpenBK7231T/OpenBeken to experiment with improvement of home assissten auto detection feature by implementing more precise value templates (val_tmp)
 Use case: TuYaMCU based Thermostat, with temperature devider /2 instead of /10
+
+# Introduction
 
 OpenBK7231T/OpenBeken is a Tasmota/Esphome replacement for new Tuya modules featuring MQTT and Home Assistant compatibility.
 This repository is named "OpenBK7231T_App", but now it's a multiplatform app, supporting build for multiple separate chips:

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -507,9 +507,7 @@ HassDeviceInfo* hass_init_energy_sensor_device_info(int index) {
 // {{ float(value)*0.1 }} for value=12 give 1.2000000000000002, using round() to limit the decimal places
 // 2023 10 19 - it is not a perfect solution, it's better to use:
 // {{ '%0.2f'|format(states('sensor.varasto2_osram_temp')|float + 0.7) }}
-//
 char *hass_generate_multiplyAndRound_template(int decimalPlacesForRounding, int decimalPointOffset, int divider) {
-#if 1
 	char tmp[8];
 	int i;
 
@@ -522,28 +520,11 @@ char *hass_generate_multiplyAndRound_template(int decimalPlacesForRounding, int 
 		for (i = 1; i < decimalPointOffset; i++) {
 			strcat(g_hassBuffer, "0");
 		}
-		strcat(g_hassBuffer, "1");
+		sprintf(tmp, "%i", divider);
+		strcat(g_hassBuffer, tmp);
 	}
 	strcat(g_hassBuffer, ") }}");
-#else
-	char tmp[8];
-	int i;
 
-	strcpy(g_hassBuffer, "{{ float(value)*");
-	if (decimalPointOffset != 0) {
-		strcat(g_hassBuffer, "0.");
-		for (i = 1; i < decimalPointOffset; i++) {
-			strcat(g_hassBuffer, "0");
-		}
-	}
-	// usually it's 1
-	sprintf(tmp, "%i", divider);
-	strcat(g_hassBuffer, tmp);
-	strcat(g_hassBuffer, "|round(");
-	sprintf(tmp, "%i", decimalPlacesForRounding);
-	strcat(g_hassBuffer, tmp);
-	strcat(g_hassBuffer, ") }}");
-#endif
 	return g_hassBuffer;
 }
 


### PR DESCRIPTION
Home assistant auto discovery did only work correctly for value dividers of 1, 10, 100, ...
Functionality for divider of 2 has been implemented but disabled later-on (by mistake?)

In my case (BHT-002 climate control with TuyaMCU), using this small fix, it is now working correctly