### PR TITLE
UART RingBuffer overflow and reported size fix

### DIFF
--- a/src/driver/drv_uart.h
+++ b/src/driver/drv_uart.h
@@ -6,7 +6,7 @@ byte UART_GetByte(int idx);
 void UART_ConsumeBytes(int idx);
 void UART_AppendByteToReceiveRingBuffer(int rc);
 void UART_SendByte(byte b);
-void UART_InitUART(int baud, int parity);
+int UART_InitUART(int baud, int parity);
 void UART_AddCommands();
 void UART_RunEverySecond();
 


### PR DESCRIPTION
- fix for incorrectly reported size of UART_GetDataSize when Ring Buffer overflows
- fix for reading UART buffer - when Ring Buffer overflows we now always have the last (g_recvBufSize - 1) bytes to read