### PR TITLE
Ssid2 retain mod - last used SSID will be preserved /Beken Only/

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1318,7 +1318,7 @@ int http_fn_cfg_wifi(http_request_t* request) {
 	poststr_h2(request, "Alternate WiFi (used when first one is not responding)");
 	poststr(request, "Note: It is possible to retain connected SSID in channel using command setStartupSSIDChannel in early.bat");
 #ifndef PLATFORM_BEKEN
-	poststr_h2(request, "SSID2 only on Beken Platform (BK7231T, BK7231N).");
+	poststr_h2(request, "SSID2 only on Beken Platform (BK7231T, BK7231N)");
 #endif
 	add_label_text_field(request, "SSID2", "ssid2", CFG_GetWiFiSSID2(), "");
 	add_label_password_field(request, "", "pass2", CFG_GetWiFiPass2(), "<br>Password2<span  style=\"float:right;\"><input type=\"checkbox\" onclick=\"e=getElement('pass2');if(this.checked){e.value='';e.type='text'}else e.type='password'\" > enable clear text password (clears existing)</span>");

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1316,7 +1316,7 @@ int http_fn_cfg_wifi(http_request_t* request) {
 	add_label_text_field(request, "SSID", "ssid", CFG_GetWiFiSSID(), "<form action=\"/cfg_wifi_set\">");
 	add_label_password_field(request, "", "pass", CFG_GetWiFiPass(), "<br>Password<span  style=\"float:right;\"><input type=\"checkbox\" onclick=\"e=getElement('pass');if(this.checked){e.value='';e.type='text'}else e.type='password'\" > enable clear text password (clears existing)</span>");
 	poststr_h2(request, "Alternate WiFi (used when first one is not responding)");
-	poststr(request, "Note: It is possible to retain connected SSID in channel using command setStartupSSIDChannel in early.bat");
+	poststr(request, "Note: It is possible to retain used SSID using command setStartupSSIDChannel in early.bat");
 #ifndef PLATFORM_BEKEN
 	poststr_h2(request, "SSID2 only on Beken Platform (BK7231T, BK7231N)");
 #endif

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1316,9 +1316,9 @@ int http_fn_cfg_wifi(http_request_t* request) {
 	add_label_text_field(request, "SSID", "ssid", CFG_GetWiFiSSID(), "<form action=\"/cfg_wifi_set\">");
 	add_label_password_field(request, "", "pass", CFG_GetWiFiPass(), "<br>Password<span  style=\"float:right;\"><input type=\"checkbox\" onclick=\"e=getElement('pass');if(this.checked){e.value='';e.type='text'}else e.type='password'\" > enable clear text password (clears existing)</span>");
 	poststr_h2(request, "Alternate WiFi (used when first one is not responding)");
+	poststr(request, "Note: It is possible to retain connected SSID in channel using command setStartupSSIDChannel in early.bat");
 #ifndef PLATFORM_BEKEN
 	poststr_h2(request, "SSID2 only on Beken Platform (BK7231T, BK7231N).");
-	poststr(request, "Note: It is possible to retain last connected SSID in channel using command setLastSSIDChannel in early.bat");
 #endif
 	add_label_text_field(request, "SSID2", "ssid2", CFG_GetWiFiSSID2(), "");
 	add_label_password_field(request, "", "pass2", CFG_GetWiFiPass2(), "<br>Password2<span  style=\"float:right;\"><input type=\"checkbox\" onclick=\"e=getElement('pass2');if(this.checked){e.value='';e.type='text'}else e.type='password'\" > enable clear text password (clears existing)</span>");

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1317,7 +1317,8 @@ int http_fn_cfg_wifi(http_request_t* request) {
 	add_label_password_field(request, "", "pass", CFG_GetWiFiPass(), "<br>Password<span  style=\"float:right;\"><input type=\"checkbox\" onclick=\"e=getElement('pass');if(this.checked){e.value='';e.type='text'}else e.type='password'\" > enable clear text password (clears existing)</span>");
 	poststr_h2(request, "Alternate WiFi (used when first one is not responding)");
 #ifndef PLATFORM_BEKEN
-	poststr_h2(request, "SSID2 only on Beken Platform (BK7231T, BK7231N)");
+	poststr_h2(request, "SSID2 only on Beken Platform (BK7231T, BK7231N).");
+	poststr(request, "Note: It is possible to retain last connected SSID in channel using command setLastSSIDChannel in early.bat");
 #endif
 	add_label_text_field(request, "SSID2", "ssid2", CFG_GetWiFiSSID2(), "");
 	add_label_password_field(request, "", "pass2", CFG_GetWiFiPass2(), "<br>Password2<span  style=\"float:right;\"><input type=\"checkbox\" onclick=\"e=getElement('pass2');if(this.checked){e.value='';e.type='text'}else e.type='password'\" > enable clear text password (clears existing)</span>");

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -50,7 +50,10 @@ void FV_UpdateLastSSIDIfChanged_StoredValue(int assidindex) {
 	if ((g_LastSSIDRetainChannel < 0) || (g_LastSSIDRetainChannel >= MAX_RETAIN_CHANNELS)) return;
 	if ((assidindex < 0) && (assidindex > 1)) return;	//only SSID1 (0) and SSID2 (1) allowed
 	int fval = HAL_FlashVars_GetChannelValue(g_LastSSIDRetainChannel);
-	if (fval == g_LastSSIDRetainChannel) return;	//same value, no update
+	if (fval == assidindex) {
+		addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "WiFi unchanged (SSID%i), HAL_FlashVars_SaveChannel skipped", assidindex+1);
+		return;	//same value, no update
+	}
 	HAL_FlashVars_SaveChannel(g_LastSSIDRetainChannel,assidindex);
 }
 #endif

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -2228,8 +2228,12 @@ static commandResult_t CMD_setStartupSSID(const void* context, const char* cmd, 
 			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "Cannot set setStartupSSID, StartupSSIDChannel not set. Use setStartupSSIDChannel first");
 			return CMD_RES_BAD_ARGUMENT;
 		}
-		if (!(fval==fold)) FV_UpdateStartupSSIDIfChanged_StoredValue(fval);	//update ony on change
-		addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "StartupSSID changed to %i", fval);
+		if (!(fval==fold)) {
+			FV_UpdateStartupSSIDIfChanged_StoredValue(fval);	//update ony on change
+			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "StartupSSID changed to %i", fval);
+		} else {
+			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "StartupSSID unchanged %i", fval);
+		}
 	} else {
 		addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "StartupSSID is %i", fold);
 	}

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -2212,7 +2212,8 @@ static commandResult_t CMD_setStartupSSIDChannel(const void* context, const char
 	return CMD_RES_OK;
 }
 // setStartupSSID [0/1]  
-// Sets startup SSID - 0=SSID1 1=SSID2 - which SSID will be used after reboot, setStartupSSIDChannel and SSID2 must be set
+// Sets startup SSID - 0=SSID1 1=SSID2 - which SSID will be used after reboot. 
+// for this to work, setStartupSSIDChannel and SSID2 must be set
 static commandResult_t CMD_setStartupSSID(const void* context, const char* cmd, const char* args, int cmdFlags) {
 
 	Tokenizer_TokenizeString(args, 0);
@@ -2225,11 +2226,11 @@ static commandResult_t CMD_setStartupSSID(const void* context, const char* cmd, 
 			return CMD_RES_BAD_ARGUMENT;
 		}
 		if (g_StartupSSIDRetainChannel<0) {
-			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "Cannot set setStartupSSID, StartupSSIDChannel not set. Use setStartupSSIDChannel first");
+			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "Cannot set StartupSSID, StartupSSIDChannel is not set.");
 			return CMD_RES_BAD_ARGUMENT;
 		}
 		if (!(fval==fold)) {
-			FV_UpdateStartupSSIDIfChanged_StoredValue(fval);	//update ony on change
+			FV_UpdateStartupSSIDIfChanged_StoredValue(fval);//update flash only when changed
 			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "StartupSSID changed to %i", fval);
 		} else {
 			addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "StartupSSID unchanged %i", fval);

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -2196,6 +2196,7 @@ static commandResult_t CMD_SetChannelType(const void* context, const char* cmd, 
 	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "Channel %i type changed to %s", channel, type);
 	return CMD_RES_OK;
 }
+#if ALLOW_SSID2
 // setStartupSSIDChannel [-1 or RetainChannelIndex]
 static commandResult_t CMD_setStartupSSIDChannel(const void* context, const char* cmd, const char* args, int cmdFlags) {
 
@@ -2244,6 +2245,7 @@ static commandResult_t CMD_setStartupSSID(const void* context, const char* cmd, 
 	}
 	return CMD_RES_OK;
 }
+#endif
 /// @brief Computes the Relay and PWM count.
 /// @param relayCount Number of relay and LED channels.
 /// @param pwmCount Number of PWM channels.
@@ -2405,6 +2407,7 @@ void PIN_AddCommands(void)
 	//cmddetail:"fn":"CMD_setButtonHoldRepeat","file":"new_pins.c","requires":"",
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("setButtonHoldRepeat", CMD_setButtonHoldRepeat, NULL);
+#if ALLOW_SSID2
 	//cmddetail:{"name":"setStartupSSIDChannel","args":"[Value]",
 	//cmddetail:"descr":"Sets retain channel number to store last used SSID, 0..MAX_RETAIN_CHANNELS-1, -1 to disable. Suggested channel number is 7 (MAXMAX_RETAIN_CHANNELS-5)",
 	//cmddetail:"fn":"CMD_setStartupSSIDChannel","file":"new_pins.c","requires":"",
@@ -2415,4 +2418,5 @@ void PIN_AddCommands(void)
 	//cmddetail:"fn":"CMD_setStartupSSID","file":"new_pins.c","requires":"",
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("setStartupSSID", CMD_setStartupSSID, NULL);
+#endif
 }

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -39,6 +39,10 @@ byte *g_defaultWakeEdge = 0;
 int g_initialPinStates = 0;
 
 #if ALLOW_SSID2
+//20241125 XJIKKA SSID retain - last used SSID will be preserved
+// To enable this feature, the channel that will be used to store the last SSID 
+// must be set using the setStartupSSIDChannel command in early.bat. 
+// It has to be in early.bat.Autoexec.bat is processed after the wifi data is loaded.
 int g_StartupSSIDRetainChannel = -1; // -1 disabled, 0..MAX_RETAIN_CHANNELS-1 channel to store last SSID
 
 int FV_GetStartupSSID_StoredValue(int adefault) {

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1435,8 +1435,8 @@ int PIN_IOR_NofChan(int test);
 extern const char* g_channelTypeNames[];
 
 #if ALLOW_SSID2
-int FV_GetLastSSID_StoredValue(int adefault);
-void FV_UpdateLastSSIDIfChanged_StoredValue(int assidindex);
+int FV_GetStartupSSID_StoredValue(int adefault);
+void FV_UpdateStartupSSIDIfChanged_StoredValue(int assidindex);
 #endif
 
 #endif

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1434,4 +1434,9 @@ int PIN_IOR_NofChan(int test);
 
 extern const char* g_channelTypeNames[];
 
+#if ALLOW_SSID2
+int FV_GetLastSSID_StoredValue(int adefault);
+void FV_UpdateLastSSIDIfChanged_StoredValue(int assidindex);
+#endif
+
 #endif

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -311,10 +311,10 @@ void CheckForSSID12_Switch() {
 }
 
 //20241125 XJIKKA Init last stored SSID from RetailChannel if set
-//Note that it must be set in early.bat using CMD_setLastSSIDChannel
+//Note that it must be set in early.bat using CMD_setStartupSSIDChannel
 void Init_WiFiSSIDactual_FromChannelIfSet(void) {
 #if ALLOW_SSID2
-	g_SSIDactual = FV_GetLastSSID_StoredValue(SSID_USE_SSID1);
+	g_SSIDactual = FV_GetStartupSSID_StoredValue(SSID_USE_SSID1);
 #endif
 }
 const char* CFG_GetWiFiSSIDX() {
@@ -380,7 +380,7 @@ void Main_OnWiFiStatusChange(int code)
 		break;
 	case WIFI_STA_CONNECTED:
 #if ALLOW_SSID2
-		if (!g_bHasWiFiConnected) FV_UpdateLastSSIDIfChanged_StoredValue(g_SSIDactual);	//update ony on first connect
+		if (!g_bHasWiFiConnected) FV_UpdateStartupSSIDIfChanged_StoredValue(g_SSIDactual);	//update ony on first connect
 #endif
 		g_bHasWiFiConnected = 1;
 #if ALLOW_SSID2
@@ -1356,7 +1356,7 @@ void Main_Init_After_Delay()
 		ADDLOGF_INFO("###### safe mode activated - boot failures %d", g_bootFailures);
 	}
 #if ALLOW_SSID2
-	Init_WiFiSSIDactual_FromChannelIfSet();//Channel must be set in early.bat using CMD_setLastSSIDChannel
+	Init_WiFiSSIDactual_FromChannelIfSet();//Channel must be set in early.bat using CMD_setStartupSSIDChannel
 #endif
 	wifi_ssid = CFG_GetWiFiSSIDX();
 	wifi_pass = CFG_GetWiFiPassX();

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -289,7 +289,9 @@ void LN882H_ApplyPowerSave(int bOn);
 
 // SSID switcher by xjikka 20240525
 #if ALLOW_SSID2
-static int g_SSIDactual = 0;        // 0=SSID1 1=SSID2
+#define SSID_USE_SSID1  0
+#define SSID_USE_SSID2  1
+static int g_SSIDactual = SSID_USE_SSID1;       // -1 not initialized,  0=SSID1 1=SSID2
 static int g_SSIDSwitchAfterTry = 3;// switch to opposite SSID after
 static int g_SSIDSwitchCnt = 0;     // switch counter
 #endif
@@ -308,6 +310,13 @@ void CheckForSSID12_Switch() {
 #endif
 }
 
+//20241125 XJIKKA Init last stored SSID from RetailChannel if set
+//Note that it must be set in early.bat using CMD_setLastSSIDChannel
+void Init_WiFiSSIDactual_FromChannelIfSet(void) {
+#if ALLOW_SSID2
+	g_SSIDactual = FV_TryGetLastSSID_StoredValue(SSID_USE_SSID1);
+#endif
+}
 const char* CFG_GetWiFiSSIDX() {
 #if ALLOW_SSID2
 	if (g_SSIDactual) {
@@ -370,6 +379,9 @@ void Main_OnWiFiStatusChange(int code)
 		ADDLOGF_INFO("Main_OnWiFiStatusChange - WIFI_STA_AUTH_FAILED - %i\r\n", code);
 		break;
 	case WIFI_STA_CONNECTED:
+#if ALLOW_SSID2
+		if (!g_bHasWiFiConnected) FV_UpdateLastSSIDIfChanged_StoredValue(g_SSIDactual);	//update ony on first connect
+#endif
 		g_bHasWiFiConnected = 1;
 #if ALLOW_SSID2
 		g_SSIDSwitchCnt = 0;
@@ -1343,9 +1355,11 @@ void Main_Init_After_Delay()
 	if (bSafeMode) {
 		ADDLOGF_INFO("###### safe mode activated - boot failures %d", g_bootFailures);
 	}
-
-	wifi_ssid = CFG_GetWiFiSSID();
-	wifi_pass = CFG_GetWiFiPass();
+#if ALLOW_SSID2
+	Init_WiFiSSIDactual_FromChannelIfSet();//Channel must be set in early.bat using CMD_setLastSSIDChannel
+#endif
+	wifi_ssid = CFG_GetWiFiSSIDX();
+	wifi_pass = CFG_GetWiFiPassX();
 
 #if 0
 	// you can use this if you bricked your module by setting wrong access point data

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -314,7 +314,7 @@ void CheckForSSID12_Switch() {
 //Note that it must be set in early.bat using CMD_setLastSSIDChannel
 void Init_WiFiSSIDactual_FromChannelIfSet(void) {
 #if ALLOW_SSID2
-	g_SSIDactual = FV_TryGetLastSSID_StoredValue(SSID_USE_SSID1);
+	g_SSIDactual = FV_GetLastSSID_StoredValue(SSID_USE_SSID1);
 #endif
 }
 const char* CFG_GetWiFiSSIDX() {


### PR DESCRIPTION
I have added new commands to allow preserve the last used SSID. The last used SSID is stored in the retained channel. By default, the feature is disabled.

To enable this feature, the channel that will be used to store the last SSID must be set using the setStartupSSIDChannel command in early.bat. The recommended value is 7, values 8-12 are already used for LED brightness and so on.
It has to be in early.bat. Autoexec.bat is processed after the wifi data is loaded.

To disable this feature, set setStartupSSIDChannel -1

There is also a setStartupSSID command that will force the SSID to be used on the next reboot. 0=SSID1, 1=SSID2.

[early.bat]
setStartupSSIDChannel 7

