### PR TITLE
Added 48-NEC1 support to the Arduino-IRremote-mod

### DIFF
--- a/src/libraries/Arduino-IRremote-mod/src/IRSend.hpp
+++ b/src/libraries/Arduino-IRremote-mod/src/IRSend.hpp
@@ -194,7 +194,11 @@ size_t IRsend::write(IRData *aIRSendData, int_fast8_t aNumberOfRepeats) {
      * Order of protocols is in guessed relevance :-)
      */
     if (tProtocol == NEC) {
-        sendNEC(tAddress, tCommand, aNumberOfRepeats);
+        if (aIRSendData->numberOfBits == 48) {
+            sendNEC48(tAddress, tCommand, aNumberOfRepeats);
+        } else {
+            sendNEC(tAddress, tCommand, aNumberOfRepeats);
+        }
 
     } else if (tProtocol == SAMSUNG) {
         sendSamsung(tAddress, tCommand, aNumberOfRepeats);

--- a/src/libraries/Arduino-IRremote-mod/src/IRremoteInt.h
+++ b/src/libraries/Arduino-IRremote-mod/src/IRremoteInt.h
@@ -522,6 +522,7 @@ public:
     void sendNEC2(uint16_t aAddress, uint8_t aCommand, int_fast8_t aNumberOfRepeats);
     void sendNECRaw(uint32_t aRawData, int_fast8_t aNumberOfRepeats = NO_REPEATS);
     // NEC variants
+    void sendNEC48(uint16_t aAddress, uint16_t aCommand, int_fast8_t aNumberOfRepeats);
     void sendOnkyo(uint16_t aAddress, uint16_t aCommand, int_fast8_t aNumberOfRepeats);
     void sendApple(uint8_t aAddress, uint8_t aCommand, int_fast8_t aNumberOfRepeats);
 

--- a/src/libraries/Arduino-IRremote-mod/src/ir_NEC.hpp
+++ b/src/libraries/Arduino-IRremote-mod/src/ir_NEC.hpp
@@ -153,6 +153,19 @@ void IRsend::sendNEC2(uint16_t aAddress, uint8_t aCommand, int_fast8_t aNumberOf
 }
 
 /*
+ * Experimental nec48 protocol based by:
+ * aCommand contains command and E variable
+ */
+void IRsend::sendNEC48(uint16_t aAddress, uint16_t aCommand, int_fast8_t aNumberOfRepeats) {
+
+    uint32_t necRawArray[2];
+    necRawArray[0] = computeNECRawDataAndChecksum(aAddress, aCommand >> 8);
+    uint8_t eValue = aCommand & 0x00FF;
+    necRawArray[1] = (uint32_t) ((~eValue) << 8) | eValue;
+    sendPulseDistanceWidthFromArray(&NECProtocolConstants, (uint32_t *) &necRawArray, NEC_BITS + 16, aNumberOfRepeats);
+}
+
+/*
  * Repeat commands should be sent in a 110 ms raster.
  * There is NO delay after the last sent repeat!
  * @param aSendOnlySpecialNECRepeat if true, send only one repeat frame without leading and trailing space


### PR DESCRIPTION
Hi, just wanted to share my workaround code for sending IR codes in 48-NEC1 protocol:
http://www.hifi-remote.com/johnsfine/DecodeIR.html#48-NEC1

The  Arduino-IRremote-mod doesn't support it natively, so I patched it in. The library supports sending RAW or pronto codes, but I think OpenBeken has a limited payload, so it will not fit.
The result is this example command:
**IRSend NEC-1-0303-0-30**
you need to specify **bit length!** (in hex: 0x30=48 bits)
and the 16bit aCommand is has 2 fields:
- command/function in the highByte (mask: 0xFF00)
- E value in lowByte (mask: 0x00FF)

I tested it with my FAN controllable with IR remote, it works nicely