### PR TITLE
feat(httpserver): improved mimetype handling for js, css

### DIFF
--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -20,6 +20,8 @@ const char httpHeader[] = "HTTP/1.1 %d OK\nContent-type: %s";  // HTTP header
 const char httpMimeTypeHTML[] = "text/html";              // HTML MIME type
 const char httpMimeTypeText[] = "text/plain";           // TEXT MIME type
 const char httpMimeTypeXML[] = "text/xml";           // TEXT MIME type
+const char httpMimeTypeCSS[] = "text/css";           // CSS MIME type
+const char httpMimeTypeJavascript[] = "application/javascript";   // NOTE: According to RFC 4329 text/javascript became obsolete see: https://www.rfc-editor.org/rfc/rfc4329.html#section-7.2
 const char httpMimeTypeJson[] = "application/json";           // TEXT MIME type
 const char httpMimeTypeBinary[] = "application/octet-stream";   // binary/file MIME type
 

--- a/src/httpserver/new_http.h
+++ b/src/httpserver/new_http.h
@@ -8,6 +8,8 @@ extern const char httpMimeTypeText[];           // TEXT MIME type
 extern const char httpMimeTypeJson[];
 extern const char httpMimeTypeBinary[];
 extern const char httpMimeTypeXML[];
+extern const char httpMimeTypeCSS[];           // CSS MIME type
+extern const char httpMimeTypeJavascript[];   // JS MIME type
 
 extern const char htmlShortcutIcon[];
 extern const char htmlDoctype[];

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -444,8 +444,8 @@ static int http_rest_get_lfs_file(http_request_t* request) {
 					mimetype = "image/x-icon";
 					break;
 				}
-				if (EndsWith(fpath, ".js")) {
-					mimetype = "text/javascript";
+				if (EndsWith(fpath, ".js") || EndsWith(fpath, ".vue")) {
+					mimetype = httpMimeTypeJavascript;
 					break;
 				}
 				if (EndsWith(fpath, ".json")) {
@@ -453,11 +453,11 @@ static int http_rest_get_lfs_file(http_request_t* request) {
 					break;
 				}
 				if (EndsWith(fpath, ".html")) {
-					mimetype = "text/html";
+					mimetype = httpMimeTypeHTML;
 					break;
 				}
-				if (EndsWith(fpath, ".vue")) {
-					mimetype = "application/javascript";
+				if (EndsWith(fpath, ".css")) {
+					mimetype = httpMimeTypeCSS;
 					break;
 				}
 				break;


### PR DESCRIPTION
I've slightly edited some lfs http handlers so that it will correctly respond with text/css mimetype for .css files.