### PR TITLE
Measure imported and exported energy if "allow negativ"-flag is set (BL0942)

### DIFF
--- a/src/driver/drv_bl0937.c
+++ b/src/driver/drv_bl0937.c
@@ -381,5 +381,5 @@ void BL0937_RunEverySecond(void) {
 		addLogAdv(LOG_INFO, LOG_FEATURE_ENERGYMETER,dbg);
 	}
 #endif
-	BL_ProcessUpdate(final_v, final_c, final_p, NAN, NAN);
+	BL_ProcessUpdate(final_v, final_c, final_p);
 }

--- a/src/driver/drv_bl_shared.h
+++ b/src/driver/drv_bl_shared.h
@@ -3,7 +3,7 @@
 #include "../httpserver/new_http.h"
 
 void BL_Shared_Init(void);
-void BL_ProcessUpdate(float voltage, float current, float power,
-                      float frequency, float energyWh);
+void BL_ProcessUpdate(float voltage, float current, float power);
+void BL_ProcessUpdateExt(float voltage, float current, float power,
+                         float frequency, float importWh, float exportWh);
 void BL09XX_AppendInformationToHTTPIndexPage(http_request_t *request);
-

--- a/src/driver/drv_cse7766.c
+++ b/src/driver/drv_cse7766.c
@@ -185,7 +185,7 @@ int CSE7766_TryToGetNextCSE7766Packet() {
         float voltage, current, power;
         PwrCal_Scale(raw_unscaled_voltage, raw_unscaled_current,
                      raw_unscaled_power, &voltage, &current, &power);
-        BL_ProcessUpdate(voltage, current, power, NAN, NAN);
+        BL_ProcessUpdate(voltage, current, power);
     }
 
 #if 0

--- a/src/driver/drv_public.h
+++ b/src/driver/drv_public.h
@@ -24,7 +24,9 @@ typedef enum energySensor_e {
 	OBK_CONSUMPTION_TODAY = OBK_CONSUMPTION__DAILY_FIRST, 
 	OBK_CONSUMPTION_YESTERDAY,
 	OBK_CONSUMPTION_2_DAYS_AGO,
+	OBK_EXPORT_TOAL = OBK_CONSUMPTION_2_DAYS_AGO,
 	OBK_CONSUMPTION_3_DAYS_AGO,
+	OBK_EXPORT_TODAY = OBK_CONSUMPTION_3_DAYS_AGO,
 	OBK_CONSUMPTION__DAILY_LAST = OBK_CONSUMPTION_3_DAYS_AGO,
 
 	OBK_CONSUMPTION_CLEAR_DATE,
@@ -35,8 +37,8 @@ typedef enum energySensor_e {
 typedef struct energySensorNames_s {	
 	const char* const hass_dev_class;
 	const char* const units;
-	const char* const name_friendly;
-	const char* const name_mqtt;
+	const char* name_friendly;
+	const char* name_mqtt;
 	const char* const hass_uniq_id_suffix; //keep identifiers persistent in case OBK_ENERG_SENSOR changes
 } energySensorNames_t;
 

--- a/src/driver/drv_rn8209.c
+++ b/src/driver/drv_rn8209.c
@@ -138,7 +138,7 @@ void RN8029_RunEverySecond(void) {
 		"V %u, C %u %u, P %u %u\n", g_voltage, g_currentA, g_currentB, g_powerA, g_powerB);
 
 	PwrCal_Scale(g_voltage, g_currentA, g_powerA, &final_v, &final_c, &final_p);
-	BL_ProcessUpdate(final_v, final_c, final_p, NAN, NAN);
+	BL_ProcessUpdate(final_v, final_c, final_p);
 }
 /*
 Send: 36 (command code)

--- a/src/driver/drv_test_drivers.c
+++ b/src/driver/drv_test_drivers.c
@@ -48,7 +48,7 @@ void Test_Power_RunEverySecond(void) {
 		final_v += (rand() % 100) * 0.1f;
 		final_p += (rand() % 100) * 0.1f;
 	}
-	BL_ProcessUpdate(final_v, final_c, final_p, NAN, NAN);
+	BL_ProcessUpdate(final_v, final_c, final_p);
 }
 
 //Test LED driver


### PR DESCRIPTION
When generating energy, i.e. with a solar system, one want to measure imported and exported energy separately. The BL0942 is capable of measure positive and negative power. Thus this can be realized:

Implementation details:
- The BL0942 can only count energy sum or absolute sum. Absolute sum is used. The ratio of positive and negative power energy is calculated for each energy count change. The energy count change amount is then split in import and export energy.
- The energy flash values are limited to 32 bytes. Currently there are Energy Total, Today, Yesterday, 2 Days Ago, 3 Days Ago. When activating this new function (setting "allow negative power"), Energy 2 Days Ago and 3 Days Ago are used for Energy Export Total and Energy Export Today. 

Usage:
- Works only for BL0942
- Set configuration flag "allow negative power"
- Reset energy counters
- See and use export energy in web interface and MQTT