### PR TITLE
Various fixes for callback list management.

### DIFF
--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -21,6 +21,7 @@ int cmd_uartInitIndex = 0;
 #elif PLATFORM_LN882H
 #include <wifi.h>
 #include <power_mgmt/ln_pm.h>
+#include <system_parameter.h>
 #elif PLATFORM_ESPIDF
 #include "esp_wifi.h"
 #include "esp_pm.h"

--- a/src/cmnds/cmd_tokenizer.c
+++ b/src/cmnds/cmd_tokenizer.c
@@ -343,7 +343,7 @@ void Tokenizer_TokenizeString(const char *s, int flags) {
 		g_argsFrom[g_numArgs] = g_buffer;
 		// some hack, but we fored to have only have one arg, so we can extend the string over array bondaries.
 		// probably better: introducing an union containing g_argsExpanded[][] and one sole string in the same memory area ...
-		CMD_ExpandConstantsWithinString(g_buffer,g_argsExpanded,sizeof(g_argsExpanded)-1);
+		CMD_ExpandConstantsWithinString(g_buffer, (char *)g_argsExpanded,sizeof(g_argsExpanded)-1);
 		g_numArgs = 1;
 		return;
 	}

--- a/src/driver/drv_charts.c
+++ b/src/driver/drv_charts.c
@@ -428,9 +428,9 @@ void Chart_Display(http_request_t *request, chart_t *s) {
 	}
 	poststr(request, "<script>");
 	poststr(request, "function cha() {");
-	poststr(request, "var labels =document.getElementById('chartlabels').value.split(/\s*,\s*/).map(Number).map((x)=>new Date(x * 1000).toLocaleTimeString());"); // we transmitted only timestamps, let Javascript do the work to convert them ;-)
+	poststr(request, "var labels =document.getElementById('chartlabels').value.split(/\\s*,\\s*/).map(Number).map((x)=>new Date(x * 1000).toLocaleTimeString());"); // we transmitted only timestamps, let Javascript do the work to convert them ;-)
 	for (int i = 0; i < s->numVars; i++) {
-		hprintf255(request, "var data%i = document.getElementById('chartdata%i').value.split(/\s*,\s*/).map(Number);",i,i);	
+		hprintf255(request, "var data%i = document.getElementById('chartdata%i').value.split(/\\s*,\\s*/).map(Number);",i,i);
 	}
 	poststr(request, "if (! window.obkChartInstance) {");
 	poststr(request, "console.log('Initializing chart');");

--- a/src/hal/ln882h/hal_flashVars_ln882h.c
+++ b/src/hal/ln882h/hal_flashVars_ln882h.c
@@ -168,6 +168,7 @@ int HAL_FlashVars_GetBootCount() {
 		return flash_vars.boot_count;
 	}
 #endif
+	return 0;
 }
 
 int HAL_FlashVars_GetChannelValue(int ch) {

--- a/src/hal/ln882h/hal_wifi_ln882h.c
+++ b/src/hal/ln882h/hal_wifi_ln882h.c
@@ -1,5 +1,6 @@
 #ifdef PLATFORM_LN882H
 
+#include "../../new_cfg.h"
 #include "../hal_wifi.h"
 #include "wifi.h"
 #include "wifi_port.h"
@@ -13,6 +14,7 @@
 #include "ln_psk_calc.h"
 #include "utils/sysparam_factory_setting.h"
 #include <lwip/sockets.h>
+#include <lwip/dns.h>
 #include <stdbool.h>	// for bool "g_STA_static_IP"
 
 
@@ -238,7 +240,7 @@ void wifi_init_sta(const char* oob_ssid, const char* connect_key, obkStaticIP_t 
             ip_info.gw.addr      = ipaddr_addr((const char *)g_IP);
 	
             netdev_set_ip_info(NETIF_IDX_STA, &ip_info);
-            dns_setserver(0,&ip->dnsServerIpAddr);
+            dns_setserver(0, (ip_addr_t *)&ip->dnsServerIpAddr);
        } else  LOG(LOG_LVL_INFO, "INSIDE wifi_init_sta, no static IP - using DHCP\r\n");
 
     netdev_set_active(NETIF_IDX_STA);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -39,6 +39,7 @@ static char SUBMIT_AND_END_FORM[] = "<br><input type=\"submit\" value=\"Submit\"
 #include "BkDriverFlash.h"
 #include "temp_detect_pub.h"
 #elif defined(PLATFORM_LN882H)
+#include "reboot_trace.h"
 #elif defined(PLATFORM_TR6260)
 #elif defined(PLATFORM_RTL87X0C)
 #include "hal_sys_ctrl.h"

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -1214,7 +1214,7 @@ static int _check_ota_header(ota_header_t *ota_header, uint32_t *ota_len, int *u
 #include "hal/hal_flash.h"
 #include "netif/ethernetif.h"
 #include "flash_partition_table.h"
-
+#include "ln_nvds.h"
 
 #define KV_OTA_UPG_STATE           ("kv_ota_upg_state")
 #define HTTP_OTA_DEMO_STACK_SIZE   (1024 * 16)

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -382,7 +382,8 @@ OSStatus rtos_suspend_thread(beken_thread_t* thread);
 #define bk_printf printf
 
 #define kNoErr                      0       //! No error occurred.
-#define rtos_delay_milliseconds OS_MsDelay
+#define rtos_delay_milliseconds(x) OS_MsDelay(x)
+#define delay_ms(x) OS_MsDelay(x)
 typedef void *beken_thread_arg_t;
 typedef void *beken_thread_t;
 typedef void (*beken_thread_function_t)( beken_thread_arg_t arg );


### PR DESCRIPTION
I noticed some messy and broken logic in new_mttq.c by chance and offer some fixes and minor improvements.  As is removeCallback can't function since ID is never set in addCallback, and a malloc failure for the subscriptionTopic will cause a use-after-free since topic is only freed and not NULLified.  To simplify the array traversal this change also ensures that all numCallback entries are valid by compacting the array in removeCallback.

As per the commit log:

 - use-after-free in the case of a failed malloc
 - registercallback never sets ID, so removecallback can't work
 - clearcallbacks doesn't reset numCallbacks
 - redundant NULL checks for os_free
 - change to avoid empty slots in list by copying the last entry to the newly empty slot in removecallback

