### PR TITLE
http_client: fix sending HTTP POST without content

### DIFF
--- a/src/httpclient/http_client.c
+++ b/src/httpclient/http_client.c
@@ -1300,13 +1300,17 @@ int HTTPClient_Async_SendPost(const char *url_in, int http_port, const char *con
 		// NOTE: remember to free it!
 		request->flags |= HTTPREQUEST_FLAG_FREE_HEADER;
 	}
-	client_data->post_buf = CMD_ExpandingStrdup(post_content);  //Sets the user data to be posted.
-	client_data->post_buf_len = strlen(client_data->post_buf);  //Sets the post data length.
-	// NOTE: remember to free it!
-	request->flags |= HTTPREQUEST_FLAG_FREE_POST_BUF;
-	client_data->post_content_type = strdup(content_type);  //Sets the content type.
-	// NOTE: remember to free it!
-	request->flags |= HTTPREQUEST_FLAG_FREE_POST_CONTENT_TYPE;
+
+	if (post_content) {
+		client_data->post_buf = CMD_ExpandingStrdup(post_content);  //Sets the user data to be posted.
+		client_data->post_buf_len = strlen(client_data->post_buf);  //Sets the post data length.
+		// NOTE: remember to free it!
+		request->flags |= HTTPREQUEST_FLAG_FREE_POST_BUF;
+		client_data->post_content_type = strdup(content_type);  //Sets the content type.
+		// NOTE: remember to free it!
+		request->flags |= HTTPREQUEST_FLAG_FREE_POST_CONTENT_TYPE;
+	}
+
 	request->data_callback = 0;
 	request->port = http_port;
 	request->url = url;


### PR DESCRIPTION
Invoking HTTP POST without a request-body results in a request which incorrectly has content-type and content-length set.

This results from a missing check if a body is provided as an argument.

Add this missing check in order to allow POST requests without a message body to work.