### PR TITLE
Fix multi-line startup command for BL602

### DIFF
--- a/src/cmnds/cmd_script.c
+++ b/src/cmnds/cmd_script.c
@@ -246,7 +246,7 @@ typedef struct scriptInstance_s {
 } scriptInstance_t;
 
 int g_scrBufferSize = 0;
-char *g_scrBuffer = 0;
+char *g_scrBuffer = NULL;
 int svm_deltaMS;
 scriptFile_t *g_scriptFiles = 0;
 scriptInstance_t *g_scriptThreads = 0;
@@ -365,6 +365,11 @@ void SVM_RunThread(scriptInstance_t *t, int maxLoops) {
 	int loop = 0;
 	const char *start, *end;
 	int len, p;
+	
+	if(g_scrBuffer == NULL) {
+		g_scrBufferSize = 256;
+		g_scrBuffer = malloc(g_scrBufferSize + 1);
+	}
 
 	while(1) {
 		loop++;
@@ -432,10 +437,6 @@ void SVM_RunThreads(int deltaMS) {
 	c_run = 0;
 	svm_deltaMS = deltaMS;
 
-	if(g_scrBuffer == 0) {
-		g_scrBufferSize = 256;
-		g_scrBuffer = malloc(g_scrBufferSize + 1);
-	}
 
 	g_activeThread = g_scriptThreads;
 	while(g_activeThread) {

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -1120,11 +1120,7 @@ void Main_Init_AfterDelay_Unsafe(bool bStartAutoRunScripts) {
 
 		// NOTE: this will try to read autoexec.bat,
 		// so ALL commands expected in autoexec.bat should have been registered by now...
-
-#if PLATFORM_BL602
-		// temporary fix
-		CMD_ExecuteCommand(CFG_GetShortStartupCommand(), COMMAND_FLAG_SOURCE_SCRIPT);
-#elif ENABLE_OBK_SCRIPTING
+#if ENABLE_OBK_SCRIPTING
 		SVM_RunStartupCommandAsScript();
 #else
 		CMD_ExecuteCommand(CFG_GetShortStartupCommand(), COMMAND_FLAG_SOURCE_SCRIPT);


### PR DESCRIPTION
This fixes multi-line command for BL602 issue #1523 . Problem is that realloc is not working on BL602. So by moving malloc for g_scrbuffer to the function where it's used realloc is not required and so everything works. (except it would fail if single script line is more than 256 chars long, but that problem exists already and should not be stopping this fix)

I think realloc is broken on BL602 because malloc and free is redefined in aos_freertos.c file, while realloc is not, so the one libc is used and obviously you can't mix those two. I need to check maybe new sdk fixed realloc.