### PR TITLE
Create .clang-format mirroring .vscode/settings.json

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: LLVM
+UseTab: Always
+IndentWidth: 4
+TabWidth: 4
+BreakBeforeBraces: Attach
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 0
+AccessModifierOffset: -4
+NamespaceIndentation: All
+FixNamespaceComments: false

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,6 +3,7 @@
 ## Editor
 
 Any editor can be used for editing. However, the repository does have settings to ensure consistent formatting when using [Visual Code](https://code.visualstudio.com/). For other editors, please use `tab` instead of `spaces` with `tabSize` of `4` for indentation.
+`.clang-format` provides consistent formatting for other editors.
 
 ## Nodejs
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,7 @@
 ## Editor
 
 Any editor can be used for editing. However, the repository does have settings to ensure consistent formatting when using [Visual Code](https://code.visualstudio.com/). For other editors, please use `tab` instead of `spaces` with `tabSize` of `4` for indentation.
-`.clang-format` provides consistent formatting for other editors.
+`.clang-format` provides consistent formatting for other editors and can be used by the command line `clang-format` tool to format a file with `clang-format -i <filename>`.
 
 ## Nodejs
 


### PR DESCRIPTION
I don't use vscode, but the editor I use (vim) and other editors have good integration with `clang-format` and `clang-format` looks for `.clang-format` when formatting code, so this would make it really convenient for me.

In the future this could be used in CI with the `clang-format` command line tool to check for consistent formatting.