### PR TITLE
HASS - Sensor name 'Battery' also for BATTERY_CHANNEL_SENSOR

### DIFF
--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -287,7 +287,7 @@ HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, const char* p
 		case BATTERY_CHANNEL_SENSOR:
 			isSensor = true;
 			sprintf(g_hassBuffer, "Battery");
-			break;		
+			break;
 		case BATTERY_VOLTAGE_SENSOR:
 		case VOLTAGE_SENSOR:
 			isSensor = (type == BATTERY_VOLTAGE_SENSOR);

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -293,7 +293,7 @@ HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, const char* p
 		case BATTERY_CHANNEL_SENSOR:
 			isSensor = true;
 			sprintf(g_hassBuffer, "Battery");
-			break;		
+			break;
 		case BATTERY_VOLTAGE_SENSOR:
 		case VOLTAGE_SENSOR:
 			isSensor = (type == BATTERY_VOLTAGE_SENSOR);

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -90,8 +90,8 @@ void hass_populate_unique_id(ENTITY_TYPE type, int index, char* uniq_id, int ase
 		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "battery", index);
 		break;
 	case BATTERY_CHANNEL_SENSOR:
-		//battery_ch, because there may be a collision on channel 0 with BATTERY_SENSOR - hardcoded channel 0
-		//previously there was default "sensor" - the probability of a collision is much higher
+		//20250326 XJIKKA previously there was default "sensor" - the probability of a collision was high
+		//I used battery_ch (because battery could also collide on channel 0 with BATTERY_SENSOR, where channel 0 is hardcoded)
 		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "battery_ch", index);
 		break;
 	case VOLTAGE_SENSOR:

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -89,6 +89,11 @@ void hass_populate_unique_id(ENTITY_TYPE type, int index, char* uniq_id, int ase
 	case BATTERY_SENSOR:
 		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "battery", index);
 		break;
+	case BATTERY_CHANNEL_SENSOR:
+		//battery_ch, because there may be a collision on channel 0 with BATTERY_SENSOR - hardcoded channel 0
+		//previously there was default "sensor" - the probability of a collision is much higher
+		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "battery_ch", index);
+		break;
 	case VOLTAGE_SENSOR:
 	case BATTERY_VOLTAGE_SENSOR:
 		sprintf(uniq_id, "%s_%s_%d", longDeviceName, "voltage", index);
@@ -168,6 +173,7 @@ void hass_populate_device_config_channel(ENTITY_TYPE type, char* uniq_id, HassDe
 	case ENERGY_SENSOR:
 	case TIMESTAMP_SENSOR:
 	case BATTERY_SENSOR:
+	case BATTERY_CHANNEL_SENSOR:
 	case BATTERY_VOLTAGE_SENSOR:
 	case TEMPERATURE_SENSOR:
 	case HUMIDITY_SENSOR:
@@ -287,7 +293,7 @@ HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, const char* p
 		case BATTERY_CHANNEL_SENSOR:
 			isSensor = true;
 			sprintf(g_hassBuffer, "Battery");
-			break;
+			break;		
 		case BATTERY_VOLTAGE_SENSOR:
 		case VOLTAGE_SENSOR:
 			isSensor = (type == BATTERY_VOLTAGE_SENSOR);

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -284,9 +284,10 @@ HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, const char* p
 			sprintf(g_hassBuffer, "Tvoc");
 			break;
 		case BATTERY_SENSOR:
+		case BATTERY_CHANNEL_SENSOR:
 			isSensor = true;
 			sprintf(g_hassBuffer, "Battery");
-			break;
+			break;		
 		case BATTERY_VOLTAGE_SENSOR:
 		case VOLTAGE_SENSOR:
 			isSensor = (type == BATTERY_VOLTAGE_SENSOR);


### PR DESCRIPTION
HASS - Sensor name 'Battery' also for BATTERY_CHANNEL_SENSOR

Designed for battery-powered temperature sensors with TuyaMCU, where this is used:

```
setChannelType 3 BatteryLevelPercent
linkTuyaMCUOutputToChannel 3 val 3 0 50

```
Changes HASS discovery name from:

![image](https://github.com/user-attachments/assets/2f2a979f-2169-4788-85e7-7b388db938ec)

to 

![image](https://github.com/user-attachments/assets/3cacea32-74d9-41dd-be37-8a28090a8971)

