### PR TITLE
tuyaMcu_sendCmd without second param bugfix

### DIFF
--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -2008,15 +2008,19 @@ commandResult_t TuyaMCU_SendUserCmd(const void* context, const char* cmd, const 
 	Tokenizer_TokenizeString(args, 0);
 
 	int command = Tokenizer_GetArgInteger(0);
-	const char *s = Tokenizer_GetArg(1);
+	//XJIKKA 20250327 tuyaMcu_sendCmd without second param bug
+	if (Tokenizer_GetArgsCount() >= 2) {
+		const char* s = Tokenizer_GetArg(1);
+		if (s) {
+			while (*s) {
+				byte b;
+				b = CMD_ParseOrExpandHexByte(&s);
 
-	while (*s) {
-		byte b;
-		b = CMD_ParseOrExpandHexByte(&s);
-
-		if (sizeof(packet) > c + 1) {
-			packet[c] = b;
-			c++;
+				if (sizeof(packet) > c + 1) {
+					packet[c] = b;
+					c++;
+				}
+			}
 		}
 	}
 	TuyaMCU_SendCommandWithData(command,packet, c);


### PR DESCRIPTION
When using the tuyaMcu_sendCmd command without data - for example for heartbeat, a random byte was sent in the data.

`const char *s=Tokenizer_GetArg(1);`

Tokenizer_GetArg() returns 0 if the parameter is missing, and (s) was not tested, but only (*s)

tuyaMcu_sendCmd 0x00 

data sent before bugfix: 55 EA 00 00 00 01 DB DB  - BAD 

data sent aftrer bugfix:  55 EA 00 00 00 00 FF  - OK