### PR TITLE
Movable average mod for BL_shared (BL0942+BL0937) for power and current

### DIFF
--- a/src/driver/drv_bl_shared.c
+++ b/src/driver/drv_bl_shared.c
@@ -654,6 +654,11 @@ void BL_ProcessUpdate(float voltage, float current, float power,
     }
   }
 
+#ifdef ENABLE_BL_MOVINGAVG
+  power = XJ_MovingAverage_float((float)sensdataset->sensors[OBK_POWER].lastReading, power);
+  current = XJ_MovingAverage_float((float)sensdataset->sensors[OBK_CURRENT].lastReading, current);
+#endif
+
   sensdataset->sensors[OBK_VOLTAGE].lastReading = voltage;
   sensdataset->sensors[OBK_CURRENT].lastReading = current;
   sensdataset->sensors[OBK_POWER].lastReading = power;

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1496,4 +1496,9 @@ int FV_GetStartupSSID_StoredValue(int adefault);
 void FV_UpdateStartupSSIDIfChanged_StoredValue(int assidindex);
 #endif
 
+#ifdef ENABLE_BL_MOVINGAVG
+float XJ_MovingAverage_float(float aprevvalue, float aactvalue);
+int XJ_MovingAverage_int(int aprevvalue, int aactvalue);
+#endif
+
 #endif

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -413,8 +413,10 @@
 // if power metering chip is enabled, also enable backend for that
 #if ENABLE_DRIVER_BL0937 || ENABLE_DRIVER_BL0942 || ENABLE_DRIVER_BL0942SPI || ENABLE_DRIVER_CSE7766
 #define ENABLE_BL_SHARED	1
-//allow use two BL0942 on two ports  +600 bytes
+//allow use two BL0942 on two ports  +940 bytes
 //#define ENABLE_BL_TWIN	1
+//allow moving average energy calculation +180 bytes
+//#define ENABLE_BL_MOVINGAVG	1
 #endif
 
 // closing OBK_CONFIG_H


### PR DESCRIPTION
I added the possibility of calculating the movable average for BL_shared (BL0942+BL0937) for Power and Current.

Reason: I have multiple devices (heating) at home that change the power input in seconds PWM (this way it controls the temperature proportionally). Thus, the value in HASS and OBK too "jumps". This mod allows you to activate values ​​averaging. The output is then smoother - see graph:

![image](https://github.com/user-attachments/assets/62a1bbdf-680e-47d1-8092-debe1b8c02e0)

The total value is always the same in the total due to the averaging.

To make it working, it must be turned on for compilation in obk_config using ENABLE_BL_MOVINGAVG  1
And in autoexec.bat the appropriate setMovingAvg value:
 - 2..20 to activate the average - higher value, slower changes
 - 0 or 1 is disabled (default)

If ENABLE_BL_MOVINGAVG disabled - real OBK source code remains unchanged (as before)

If ENABLE_BL_MOVINGAVG enabled - averaging is still off by default (0) and the values ​​behave as before. Averaging must be activated in autoexec.bat using the setMovingAvg command.

--------------------------------------------------------------------------------------------------------------------------------------
IMPORTANT!!!
It only makes sense if the input interval has the same period. It must basically the "seconds" equivalent to PWM.
--------------------------------------------------------------------------------------------------------------------------------------

Value flow in time:

  | 1 | 3 | 8
-- | -- | -- | --
Raw Power | MovingAvg=1 | MovingAvg=3 | MovingAvg=8
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
0 | 0,0 | 0,0 | 0,0
200 | 200,0 | 66,7 | 8,3
0 | 0,0 | 44,4 | 12,8
200 | 200,0 | 96,3 | 23,3
0 | 0,0 | 64,2 | 28,4
200 | 200,0 | 109,5 | 38,5
0 | 0,0 | 73,0 | 42,8
200 | 200,0 | 115,3 | 51,9
0 | 0,0 | 76,9 | 55,0
200 | 200,0 | 117,9 | 62,9
0 | 0,0 | 78,6 | 64,8
200 | 200,0 | 119,1 | 71,6
0 | 0,0 | 79,4 | 72,6
200 | 200,0 | 119,6 | 78,5
0 | 0,0 | 79,7 | 78,6
200 | 200,0 | 119,8 | 83,8
0 | 0,0 | 79,9 | 83,3
200 | 200,0 | 119,9 | 87,9
0 | 0,0 | 79,9 | 86,9
200 | 200,0 | 120,0 | 91,0
0 | 0,0 | 80,0 | 89,6
200 | 200,0 | 120,0 | 93,4
0 | 0,0 | 80,0 | 91,7
200 | 200,0 | 120,0 | 95,3
0 | 0,0 | 80,0 | 93,4
200 | 200,0 | 120,0 | 96,7
0 | 0,0 | 80,0 | 94,6
200 | 200,0 | 120,0 | 97,8
0 | 0,0 | 80,0 | 95,6
200 | 200,0 | 120,0 | 98,6
0 | 0,0 | 80,0 | 96,3
200 | 200,0 | 120,0 | 99,3
200 | 200,0 | 146,7 | 105,2
200 | 200,0 | 164,4 | 112,6
200 | 200,0 | 176,3 | 120,6
200 | 200,0 | 184,2 | 128,5
200 | 200,0 | 189,5 | 136,1
200 | 200,0 | 193,0 | 143,2
200 | 200,0 | 195,3 | 149,7
200 | 200,0 | 196,9 | 155,6
200 | 200,0 | 197,9 | 160,9
200 | 200,0 | 198,6 | 165,6
200 | 200,0 | 199,1 | 169,8
200 | 200,0 | 199,4 | 173,5
200 | 200,0 | 199,6 | 176,8
200 | 200,0 | 199,7 | 179,6
200 | 200,0 | 199,8 | 182,2
200 | 200,0 | 199,9 | 184,4
200 | 200,0 | 199,9 | 186,3
200 | 200,0 | 199,9 | 188,0
200 | 200,0 | 200,0 | 189,5
200 | 200,0 | 200,0 | 190,8
200 | 200,0 | 200,0 | 192,0
200 | 200,0 | 200,0 | 193,0
200 | 200,0 | 200,0 | 193,8
200 | 200,0 | 200,0 | 194,6
200 | 200,0 | 200,0 | 195,3
200 | 200,0 | 200,0 | 195,9
200 | 200,0 | 200,0 | 196,4
200 | 200,0 | 200,0 | 196,8
200 | 200,0 | 200,0 | 197,2
200 | 200,0 | 200,0 | 197,6


