### PR TITLE
ENABLE_BL_TWIN mode - reset energy_today also for channel B

### DIFF
--- a/src/driver/drv_bl_shared.c
+++ b/src/driver/drv_bl_shared.c
@@ -34,11 +34,13 @@ int stat_updatesSkipped[BL_SENSDATASETS_COUNT] = { 0 ,0 };
 int stat_updatesSent[BL_SENSDATASETS_COUNT] = { 0,0 };
 bool sensors_reciveddata[BL_SENSDATASETS_COUNT] = { 0,0 };  //1 if data received
 float lastSavedEnergyCounterValue[BL_SENSDATASETS_COUNT] = { 0.0f, 0.0f };
+int actual_mday[BL_SENSDATASETS_COUNT] = { -1 ,-1 };
 #else
 float lastSavedEnergyCounterValue[BL_SENSDATASETS_COUNT] = { 0.0f };
 int stat_updatesSkipped[BL_SENSDATASETS_COUNT] = { 0 };
 int stat_updatesSent[BL_SENSDATASETS_COUNT] = { 0 };
 bool sensors_reciveddata[BL_SENSDATASETS_COUNT] = { 0 };  //1 if data received
+int actual_mday[BL_SENSDATASETS_COUNT] = { -1 };
 #endif
 
 // Order corrsponds to enums OBK_VOLTAGE - OBK__LAST
@@ -116,7 +118,6 @@ portTickType energyCounterMinutesStamp;
 long energyCounterMinutesIndex;
 bool energyCounterStatsJSONEnable = false;
 
-int actual_mday = -1;
 float changeSavedThresholdEnergy = 10.0f;
 long ConsumptionSaveCounter = 0;
 portTickType lastConsumptionSaveStamp;
@@ -276,7 +277,7 @@ void BL09XX_SaveEmeteringStatistics()
     data.TotalConsumption = (float)sensdataset->sensors[OBK_CONSUMPTION_TOTAL].lastReading;
     data.TodayConsumpion = (float)sensdataset->sensors[OBK_CONSUMPTION_TODAY].lastReading;
     data.YesterdayConsumption = (float)sensdataset->sensors[OBK_CONSUMPTION_YESTERDAY].lastReading;
-    data.actual_mday = actual_mday;
+    data.actual_mday = actual_mday[BL_SENSORS_IX_0];//one in flashvars is enough, I assume that both channels are synchronized
 #if ENABLE_BL_TWIN
     data.TotalConsumption_b = (float)sensdataset1->sensors[OBK_CONSUMPTION_TOTAL].lastReading;
     data.TodayConsumpion_b = (float)sensdataset1->sensors[OBK_CONSUMPTION_TODAY].lastReading;
@@ -705,17 +706,17 @@ void BL_ProcessUpdate(float voltage, float current, float power,
       if (ConsumptionResetTime == 0)
         ConsumptionResetTime = (time_t)ntpTime;
 
-      if (actual_mday == -1)
+      if (actual_mday[asensdatasetix] == -1)
       {
-        actual_mday = ltm->tm_mday;
+        actual_mday[asensdatasetix] = ltm->tm_mday;
       }
-      if (actual_mday != ltm->tm_mday)
+      if (actual_mday[asensdatasetix] != ltm->tm_mday)
       {
         for (i = OBK_CONSUMPTION__DAILY_LAST; i >= OBK_CONSUMPTION__DAILY_FIRST; i--) {
           sensdataset->sensors[i].lastReading = sensdataset->sensors[i - 1].lastReading;
         }
         sensdataset->sensors[OBK_CONSUMPTION_TODAY].lastReading = 0.0;
-        actual_mday = ltm->tm_mday;
+        actual_mday[asensdatasetix] = ltm->tm_mday;
 
         //MQTT_PublishMain_StringFloat(sensdataset->sensors[OBK_CONSUMPTION_YESTERDAY].names.name_mqtt, BL_ChangeEnergyUnitIfNeeded(sensors[OBK_CONSUMPTION_YESTERDAY].lastReading ),
         //							sensdataset->sensors[OBK_CONSUMPTION_YESTERDAY].rounding_decimals, 0);
@@ -982,7 +983,7 @@ void BL_Shared_Init(void) {
       sensdataset->sensors[OBK_CONSUMPTION_TOTAL].lastReading = data.TotalConsumption;
       sensdataset->sensors[OBK_CONSUMPTION_TODAY].lastReading = data.TodayConsumpion;
       sensdataset->sensors[OBK_CONSUMPTION_YESTERDAY].lastReading = data.YesterdayConsumption;
-      actual_mday = data.actual_mday;
+      actual_mday[BL_SENSORS_IX_0] = data.actual_mday;//one in flashvars is enough, I assume that both channels are synchronized
 #if ENABLE_BL_TWIN
       sensdataset1->sensors[OBK_CONSUMPTION_TOTAL].lastReading = data.TotalConsumption_b;
       sensdataset1->sensors[OBK_CONSUMPTION_TODAY].lastReading = data.TodayConsumpion_b;
@@ -990,6 +991,7 @@ void BL_Shared_Init(void) {
       lastSavedEnergyCounterValue[BL_SENSORS_IX_1] = data.TotalConsumption_b;
       energyCounterStamp[BL_SENSORS_IX_0] = xTaskGetTickCount();
       energyCounterStamp[BL_SENSORS_IX_1] = xTaskGetTickCount();
+      actual_mday[BL_SENSORS_IX_1] = data.actual_mday;//one in flashvars is enough, I assume that both channels are synchronized
 #else
       lastSavedEnergyCounterValue[BL_SENSORS_IX_0] = data.TotalConsumption;
       sensdataset->sensors[OBK_CONSUMPTION_2_DAYS_AGO].lastReading = data.ConsumptionHistory[0];


### PR DESCRIPTION
Bugfix: in ENABLE_BL_TWIN mode, energy_today for channel B was not reset if both channels were used in parallel.