### PR TITLE
tuyaMCU: replace network state magic values

### DIFF
--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -2216,8 +2216,7 @@ void TuyaMCU_RunStateMachine_BatteryPowered() {
 	case TM0_STATE_AWAITING_WIFI:
 		if (g_tuyaNextRequestDelay <= 0) {
 			if (Main_IsConnectedToWiFi()) {
-				// send wifi state 0x03 
-				Tuya_SetWifiState_V0(0x03);
+				Tuya_SetWifiState_V0(TUYA_NETWORK_STATUS_CONNECTED_TO_ROUTER);
 				// retry
 				g_tuyaNextRequestDelay = 3;
 			}
@@ -2237,8 +2236,7 @@ void TuyaMCU_RunStateMachine_BatteryPowered() {
 				)
 #endif
 			{
-				// send wifi state 0x04 
-				Tuya_SetWifiState_V0(0x04);
+				Tuya_SetWifiState_V0(TUYA_NETWORK_STATUS_CONNECTED_TO_CLOUD);
 				// retry
 				g_tuyaNextRequestDelay = 3;
 			}


### PR DESCRIPTION
Replace magic values present in the code with the more descriptive macros.

As these macros are redundant with the comments, drop the repsective comments.