### PR TITLE
Fix tests on linux

### DIFF
--- a/src/berry/be_run.c
+++ b/src/berry/be_run.c
@@ -12,9 +12,9 @@ const char berryPrelude[] =
 	"  return _suspended_closures_idx\n"
 	"end\n"
 	"\n"
-	"def run_closure(idx,x,y)\n"
+	"def run_closure(idx, *args)\n"
 	"  closure = _suspended_closures[idx]\n"
-	"  closure(x,y)\n"
+	"  call(closure, args)\n"
 	"end\n"
 	"\n"
 	"def remove_closure(idx)\n"
@@ -126,6 +126,21 @@ void berryRunClosureIntInt(bvm *vm, int closureId, int x, int y) {
 	be_call(vm, 3);
 	//int s2 = Berry_GetStackSizeCurrent();
 	be_pop(vm, 4);
+	//int s3 = Berry_GetStackSizeCurrent();
+	//printf("%i %i %i\n", s1, s2, s3);
+}
+
+void berryRunClosurePtr(bvm *vm, int closureId, void* x) {
+	//int s1 = Berry_GetStackSizeCurrent();
+	if (!be_getglobal(vm, "run_closure")) {
+		return;
+	}
+	be_pushint(vm, closureId);
+	be_pushcomptr(vm, x);
+	// call run_closure(closureId)
+	be_call(vm, 2);
+	//int s2 = Berry_GetStackSizeCurrent();
+	be_pop(vm, 3);
 	//int s3 = Berry_GetStackSizeCurrent();
 	//printf("%i %i %i\n", s1, s2, s3);
 }

--- a/src/cmnds/cmd_berry.c
+++ b/src/cmnds/cmd_berry.c
@@ -91,7 +91,8 @@ void CMD_Berry_RunEventHandlers_IntInt(byte eventCode, int argument, int argumen
 		t = t->next;
 	}
 }
-int CMD_Berry_RunEventHandlers_StrInt(byte eventCode, const char *argument, int argument2) {
+
+int CMD_Berry_RunEventHandlers_StrPtr(byte eventCode, const char *argument, void* argument2) {
 	berryInstance_t *t;
 
 	t = g_berryThreads;
@@ -105,13 +106,14 @@ int CMD_Berry_RunEventHandlers_StrInt(byte eventCode, const char *argument, int 
 		} else if (t->wait.waitingForEvent == eventCode
 			&& t->wait.waitingForRelation == 'm'
 			&& !stricmp(t->wait.waitingForArgumentStr,argument)) {
-			berryRunClosureIntInt(g_vm, t->closureId, argument2, 0);
+			berryRunClosurePtr(g_vm, t->closureId, argument2);
 			calls++;
 		}
 		t = t->next;
 	}
 	return calls;
 }
+
 void CMD_Berry_RunEventHandlers_IntBytes(byte eventCode, int argument, const byte *data, int size) {
 	berryInstance_t *t;
 
@@ -205,11 +207,11 @@ int be_addClosure(bvm *vm, const char *eventName, int relation, int reqArg, cons
 int be_poststr(bvm *vm) {
 	int top = be_top(vm);
 
-	if (top == 2 && be_isstring(vm, 2) && be_isint(vm, 1)) {
+	if (top == 2 && be_isstring(vm, 2) && be_iscomptr(vm, 1)) {
 		const char *s = be_tostring(vm, 2);
-		int request = be_toint(vm, 1);
+		http_request_t* request = be_tocomptr(vm, 1);
 
-		poststr((http_request_t*)request, s);
+		poststr(request, s);
 	}
 	be_return_nil(vm);
 }

--- a/src/cmnds/cmd_public.h
+++ b/src/cmnds/cmd_public.h
@@ -313,7 +313,7 @@ int CMD_GetCountActiveScriptThreads();
 void CMD_InitBerry();
 void CMD_Berry_RunEventHandlers_IntInt(byte eventCode, int argument, int argument2);
 void CMD_Berry_RunEventHandlers_IntBytes(byte eventCode, int argument, const byte *data, int size);
-int CMD_Berry_RunEventHandlers_StrInt(byte eventCode, const char *argument, int argument2);
+int CMD_Berry_RunEventHandlers_StrPtr(byte eventCode, const char *argument, void* argument2);
 int CMD_Berry_RunEventHandlers_Str(byte eventCode, const char *argument, const char *argument2);
 
 const char* CMD_GetResultString(commandResult_t r);

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -343,7 +343,7 @@ int http_fn_index(http_request_t* request) {
 #if ENABLE_OBK_BERRY
 		void Berry_SaveRequest(http_request_t *r);
 		Berry_SaveRequest(request);
-		CMD_Berry_RunEventHandlers_StrInt(CMD_EVENT_ON_HTTP, "prestate", (int)request);
+		CMD_Berry_RunEventHandlers_StrPtr(CMD_EVENT_ON_HTTP, "prestate", request);
 #endif
 #ifndef OBK_DISABLE_ALL_DRIVERS
 		DRV_AppendInformationToHTTPIndexPage(request, true);
@@ -355,7 +355,7 @@ int http_fn_index(http_request_t* request) {
 #if ENABLE_OBK_BERRY
 	void Berry_SaveRequest(http_request_t *r);
 	Berry_SaveRequest(request);
-	CMD_Berry_RunEventHandlers_StrInt(CMD_EVENT_ON_HTTP, "state", (int)request);
+	CMD_Berry_RunEventHandlers_StrPtr(CMD_EVENT_ON_HTTP, "state", request);
 #endif
 
 	if (!CFG_HasFlag(OBK_FLAG_HTTP_NO_ONOFF_WORDS)){
@@ -3209,7 +3209,7 @@ int http_fn_ota(http_request_t* request) {
 int http_fn_other(http_request_t* request) {
 	http_setup(request, httpMimeTypeHTML);
 #if ENABLE_OBK_BERRY
-	if (CMD_Berry_RunEventHandlers_StrInt(CMD_EVENT_ON_HTTP, request->url, (int)request)) {
+	if (CMD_Berry_RunEventHandlers_StrPtr(CMD_EVENT_ON_HTTP, request->url, request)) {
 		return 0;
 	}
 #endif


### PR DESCRIPTION
The tests were segfaulting on linux, I don't know how they work on Windows, perhaps casting `void*` to `int` happens to work there. Generally it's not portable.

Berry has a dedicated `comptr` type, so let's use that and be portable.

Also makes `run_closure` handle arbitrary number of arguments, see https://berry.readthedocs.io/en/latest/source/en/Chapter-5.html#function-with-variable-number-of-arguments-vararg for docs.

Test Plan:
* CI
* make -f custom.mk, ./build/win_main -runUnitTests 2