### PR TITLE
ln882h CMakeLists.txt - activate sm16703 driver

### DIFF
--- a/platforms/LN882H/CMakeLists.txt
+++ b/platforms/LN882H/CMakeLists.txt
@@ -68,7 +68,7 @@ set(PROJ_ALL_SRC
     app/src/driver/drv_sgp.c
     app/src/driver/drv_shiftRegister.c
     app/src/driver/drv_sht3x.c
-#    app/src/driver/drv_sm16703P.c
+    app/src/driver/drv_sm16703P.c
     app/src/driver/drv_sm2135.c
     app/src/driver/drv_sm2235.c
     app/src/driver/drv_soft_i2c.c


### PR DESCRIPTION
Generate a custom build for ln882h that includes the sm16703 led driver. 