### PR TITLE
berry workaround for broken realloc on OpenBK7231N

### DIFF
--- a/include/berry_conf.h
+++ b/include/berry_conf.h
@@ -232,7 +232,7 @@
 #define BE_EXPLICIT_MALLOC malloc
 #define BE_EXPLICIT_FREE free
 // normal realloc appears broken on OpenBK7231T: #1563, #298
-#ifdef PLATFORM_BK7231T
+#ifdef PLATFORM_BK7231T || PLATFORM_BK7231N
 #define BE_EXPLICIT_REALLOC os_realloc
 #else
 #define BE_EXPLICIT_REALLOC realloc


### PR DESCRIPTION
I ran `addRepeatingEvent 1 -1 testRealloc 100` on a OpenBK7231N device and it failed. This is the same problem as #1563.

This might be related to mysterious crashes I was getting while importing big modules like this:
`addRepeatingEvent 1 1 berry import modulename`.