### PR TITLE
Fix out-of-bounds access on g_cfg.pins.channelTypes

### DIFF
--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -1118,7 +1118,7 @@ void TuyaMCU_ApplyMapping(tuyaMCUMapping_t* mapping, int dpID, int value) {
 		addLogAdv(LOG_DEBUG, LOG_FEATURE_TUYAMCU, "ApplyMapping: id %i (val %i) not mapped\n", dpID, value);
 		return;
 	}
-	if (mapping->channel == -1) {
+	if (mapping->channel < 0) {
 		return;
 	}
 


### PR DESCRIPTION
This place expected -1 for "unmapped", but -999 can come from this line: https://github.com/openshwprojects/OpenBK7231T_App/blob/fe51ee8f47237e13062cb0df9ab95ad6867ef987/src/driver/drv_tuyaMCU.c#L883

This was detected with ASAN (#1651), the error message:
```
=================================================================
==2532658==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5642389c5e37 at pc 0x564237e67492 bp 0x7fff17726e50 sp 0x7fff17726e40
READ of size 1 at 0x5642389c5e37 thread T0
    #0 0x564237e67491 in CHANNEL_GetType src/new_cfg.c:427
    #1 0x564237dfc933 in TuyaMCU_ApplyMapping src/driver/drv_tuyaMCU.c:1126
    #2 0x564237dff92f in TuyaMCU_ParseStateMessage src/driver/drv_tuyaMCU.c:1632
    #3 0x564237e019fa in TuyaMCU_ProcessIncoming src/driver/drv_tuyaMCU.c:1977
    #4 0x564237e027ee in TuyaMCU_RunReceive src/driver/drv_tuyaMCU.c:2178
    #5 0x564237e02dc2 in TuyaMCU_RunFrame src/driver/drv_tuyaMCU.c:2335
    #6 0x564237dd2ce6 in DRV_RunQuickTick src/driver/drv_main.c:536
    #7 0x564237ec4037 in QuickTick src/user_main.c:946
    #8 0x564237eca8a5 in Sim_RunFrame src/win_main.c:106
    #9 0x564237eca993 in Sim_RunFrames src/win_main.c:134
    #10 0x564237ebce4a in Test_TuyaMCU_Basic src/selftest/selftest_tuyaMCU.c:369
    #11 0x564237ecab1f in Win_DoUnitTests src/win_main.c:194
    #12 0x564237ecba57 in main src/win_main.c:535
    #13 0x7fb55312ed8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x7fb55312ee3f in __libc_start_main_impl ../csu/libc-start.c:392
    #15 0x564237cb16b4 in _start (/home/niteria/tmp/broken-realloc/OpenBK7231T_App/build/win_main+0xcf6b4)

0x5642389c5e37 is located 51 bytes to the right of global variable 'stat_deduper_culled_tooFast' defined in 'src/mqtt/new_mqtt_deduper.c:40:12' (0x5642389c5e00) of size 4
0x5642389c5e37 is located 9 bytes to the left of global variable 'g_mutex' defined in 'src/mqtt/new_mqtt_deduper.c:42:26' (0x5642389c5e40) of size 4
SUMMARY: AddressSanitizer: global-buffer-overflow src/new_cfg.c:427 in CHANNEL_GetType
Shadow bytes around the buggy address:
  0x0ac8c7130b70: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x0ac8c7130b80: 00 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x0ac8c7130b90: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x0ac8c7130ba0: 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9
  0x0ac8c7130bb0: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
=>0x0ac8c7130bc0: 04 f9 f9 f9 f9 f9[f9]f9 04 f9 f9 f9 f9 f9 f9 f9
  0x0ac8c7130bd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac8c7130be0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac8c7130bf0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac8c7130c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac8c7130c10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2532658==ABORTING
```