### PR TITLE
Run linux tests with UBSAN

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -123,6 +123,26 @@ jobs:
         export LSAN_OPTIONS=suppressions=platforms/linux/asan.suppressions
         ./build/win_main -runUnitTests 2
 
+  build_ubsan:
+    name: Build Linux Simulator and Run Tests With Undefined Behavior Sanitizer
+    needs: refs
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Checkout berry submodule
+      run: |
+        git submodule update --init --recursive libraries/berry
+
+    - name: Build project
+      run: UBSAN=1 make -f custom.mk
+    - name: Run unit tests
+      run: |
+        export UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:suppressions=platforms/linux/ubsan.suppressions
+        ./build/win_main -runUnitTests 2
+
   build:
     name: Build
     needs: refs

--- a/custom.mk
+++ b/custom.mk
@@ -50,6 +50,13 @@ ifeq ($(ASAN),1)
     LDFLAGS += -g -static-libasan -fsanitize=address
 endif
 
+# Append UBSAN flags if UBSAN=1
+ifeq ($(UBSAN),1)
+    CPPFLAGS += -g -fsanitize=undefined -fno-omit-frame-pointer
+    CFLAGS += -g -fsanitize=undefined -fno-omit-frame-pointer
+    LDFLAGS += -g -static-libasan -fsanitize=undefined
+endif
+
 $(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)
 	@echo "Linking: $@"
 	$(CC) $(OBJS) -o $@ $(LDFLAGS) $(LDLIBS)

--- a/platforms/linux/ubsan.suppressions
+++ b/platforms/linux/ubsan.suppressions
@@ -1,0 +1,7 @@
+shift-base:PIN_get_Relay_PWM_Count
+shift-base:CFG_HasFlag
+shift-base:http_fn_index
+shift-base:CHANNEL_HasNeverPublishFlag
+shift-base:doHomeAssistantDiscovery
+shift-base:BL0942_Init
+shift-base:CFG_SetFlag


### PR DESCRIPTION
Undefined Behavior Sanitizer (UBSAN) [1] is a similar tool to ASAN, useful for catching bugs related to undefined behavior.

All the problems it detects seem related to the bitshifts related to flags. Here's a sample:

```
src/new_pins.c:2437:8: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
	#0 0x55a1b51011c1 in PIN_get_Relay_PWM_Count src/new_pins.c:2437
	#1 0x55a1b500389b in NewLED_InitCommands src/cmnds/cmd_newLEDDriver.c:1627
	#2 0x55a1b5150208 in Main_Init_BeforeDelay_Unsafe src/user_main.c:1151
	#3 0x55a1b51506e7 in Main_Init_Before_Delay src/user_main.c:1290
	#4 0x55a1b5150a05 in Main_Init src/user_main.c:1428
	#5 0x55a1b515902c in SIM_ClearOBK src/win_main.c:166
	#6 0x55a1b515a0fd in main src/win_main.c:534
	#7 0x7f1acfdabd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
	#8 0x7f1acfdabe3f in __libc_start_main_impl ../csu/libc-start.c:392
	#9 0x55a1b4fd8eb4 in _start (/home/niteria/tmp/broken-realloc/OpenBK7231T_App/build/win_main+0x10ceb4)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/new_pins.c:2437:8 in
```

```
src/new_cfg.c:591:9: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
	#0 0x5629450eb803 in CFG_HasFlag src/new_cfg.c:591
	#1 0x562944ffdb53 in CMD_Init_Early src/cmnds/cmd_main.c:1007
	#2 0x562945153230 in Main_Init_BeforeDelay_Unsafe src/user_main.c:1162
	#3 0x5629451536e7 in Main_Init_Before_Delay src/user_main.c:1290
	#4 0x562945153a05 in Main_Init src/user_main.c:1428
	#5 0x56294515c02c in SIM_ClearOBK src/win_main.c:166
	#6 0x56294515d0fd in main src/win_main.c:534
	#7 0x7f9f5e12bd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
	#8 0x7f9f5e12be3f in __libc_start_main_impl ../csu/libc-start.c:392
	#9 0x562944fdbeb4 in _start (/home/niteria/tmp/broken-realloc/OpenBK7231T_App/build/win_main+0x10ceb4)
```

```
src/httpserver/http_fns.c:369:8: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
	#0 0x560135601d44 in http_fn_index src/httpserver/http_fns.c:369
	#1 0x5601356185cb in HTTP_ProcessPacket src/httpserver/new_http.c:826
	#2 0x5601356a1e93 in Test_FakeHTTPClientPacket_Generic src/selftest/selftest_http.c:86
	#3 0x5601356a2002 in Test_FakeHTTPClientPacket_GET src/selftest/selftest_http.c:102
	#4 0x5601356b773f in Test_PIR src/selftest/selftest_pir.c:27
	#5 0x5601356d204b in Win_DoUnitTests src/win_main.c:171
	#6 0x5601356d3116 in main src/win_main.c:538
	#7 0x7f6911b2ad8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
	#8 0x7f6911b2ae3f in __libc_start_main_impl ../csu/libc-start.c:392
	#9 0x560135551eb4 in _start (/home/niteria/tmp/broken-realloc/OpenBK7231T_App/build/win_main+0x10ceb4)
```

Preexisting problems are suppressed in `platforms/linux/ubsan.suppressions`

[1] https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html