### PR TITLE
simple correction in config page

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2676,7 +2676,7 @@ int http_fn_cfg_pins(http_request_t* request) {
 	poststr(request, "<p>The first field assigns a role to the given pin. The next field is used to enter channel index (relay index), used to support multiple relays and buttons. ");
 	poststr(request, "So, first button and first relay should have channel 1, second button and second relay have channel 2, etc.</p>");
 	poststr(request, "<p>Only for button roles another field will be provided to enter channel to toggle when doing double click. ");
-	poststr(request, "It shows up when you change role to button and save.</p>");
+	poststr(request, "It shows up when you change role to button.</p>");
 #if PLATFORM_BK7231N || PLATFORM_BK7231T
 	poststr(request, "<p>BK7231N/BK7231T supports PWM only on pins 6, 7, 8, 9, 24 and 26!</p>");
 #endif


### PR DESCRIPTION
Since I saw this in an illustration for an "issue". If I'm not mistaken, I changed the GUI some time ago so the additional input appears/vanishes as soon as role is changed to button. So no need to wait for saving...