### PR TITLE
CHANNEL_IsInUse() report only used channels

### DIFF
--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -1727,10 +1727,11 @@ bool CHANNEL_IsInUse(int ch) {
 
 	for (i = 0; i < PLATFORM_GPIO_MAX; i++) {
 		if (g_cfg.pins.roles[i] != IOR_None) {
-			if (g_cfg.pins.channels[i] == ch) {
+			int NofC=PIN_IOR_NofChan(g_cfg.pins.roles[i]);
+			if (NofC>=1 && g_cfg.pins.channels[i] == ch) {
 				return true;
 			}
-			if (g_cfg.pins.channels2[i] == ch) {
+			if (NofC>=2 && g_cfg.pins.channels2[i] == ch) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Actually, CHANNEL_IsInUse() will report all channel values. Change to only report used channels up to PIN_IOR_NofChan() for this role