### PR TITLE
Changing HAL_Delay_us for Beken

### DIFF
--- a/src/driver/drv_ds1820_common.c
+++ b/src/driver/drv_ds1820_common.c
@@ -26,7 +26,9 @@
 #define SP2STR(T)	DEV2STR(T),T[8]
 
 
-
+#if ENABLE_DS1820_TEST_US	
+	static bool testus_initialized = false;
+#endif
 
 int OWReset(int Pin)
 {
@@ -216,16 +218,16 @@ commandResult_t CMD_OW_testus(const void *context, const char *cmd, const char *
    int pause = Tokenizer_GetArgInteger(1);
    if (tests > MAXUSTESTS){
       tests = MAXUSTESTS;
-      DS1820_LOG(INFO, "testus -  Warning, will only do the first %i tests!\r\n",tests);
+      ADDLOG_ERROR(LOG_FEATURE_CMD, "testus -  Warning, will only do the first %i tests!\r\n",tests);
    } 
    for (int i=0; i<tests; i++){
       testvals[i]=Tokenizer_GetArgInteger(2+i);
    }
-   DS1820_LOG(DEBUG, "testus - pin=%i pause=%i tests=%i ...",pin,pause,tests);
+   ADDLOG_DEBUG(LOG_FEATURE_CMD, "testus - pin=%i pause=%i tests=%i ...",pin,pause,tests);
    for (int i=0; i<tests; i++){
-      DS1820_LOG(DEBUG, "test %i value=%i ...",i,testvals[i]);
+      ADDLOG_DEBUG(LOG_FEATURE_CMD, "test %i value=%i ...",i,testvals[i]);
    }
-   DS1820_LOG(DEBUG, "\r\n starting tests ...");
+   ADDLOG_DEBUG(LOG_FEATURE_CMD, "\r\n starting tests ...");
 
    HAL_PIN_SetOutputValue(pin, 1);
    HAL_PIN_Setup_Output(pin);
@@ -241,7 +243,7 @@ commandResult_t CMD_OW_testus(const void *context, const char *cmd, const char *
       interrupts();
       HAL_Delay_us(pause);
    }
-   DS1820_LOG(DEBUG, "... tests done\r\n");
+   ADDLOG_DEBUG(LOG_FEATURE_CMD, "... tests done\r\n");
    return CMD_RES_OK;
 }
 #endif
@@ -252,7 +254,8 @@ void init_TEST_US(){
 	//cmddetail:"descr":"tests usleep on given pin ",
 	//cmddetail:"fn":"NULL);","file":"driver/drv_ds1820_simple.c","requires":"",
 	//cmddetail:"examples":"testus 11 5 2 4 6 10 20 50 100 200 500"}
-	CMD_RegisterCommand("testus", CMD_OW_testus, NULL);
+	if (! testus_initialized) CMD_RegisterCommand("testus", CMD_OW_testus, NULL);
+	testus_initialized = true;
 #endif
 }
 

--- a/src/driver/drv_ds1820_common.c
+++ b/src/driver/drv_ds1820_common.c
@@ -204,7 +204,7 @@ uint8_t Crc8CQuick(uint8_t* Buffer, uint8_t Size)
 }
 
 
-#if ENABLE_DS1820_TEST_US
+#if ENABLE_DS1820_TEST_US && ! WINDOWS
 // will allow testus <pin> <us between tests> <us val 1> <us val 2> .... 
 commandResult_t CMD_OW_testus(const void *context, const char *cmd, const char *args, int cmdFlags) {
    Tokenizer_TokenizeString(args, TOKENIZER_ALLOW_QUOTES);
@@ -249,7 +249,7 @@ commandResult_t CMD_OW_testus(const void *context, const char *cmd, const char *
 #endif
 
 void init_TEST_US(){
-#if ENABLE_DS1820_TEST_US	
+#if ENABLE_DS1820_TEST_US && ! WINDOWS	
 	//cmddetail:{"name":"testus","args":"pin <pause in us> <testval 1 in us> [<testval n in us>...]",
 	//cmddetail:"descr":"tests usleep on given pin ",
 	//cmddetail:"fn":"NULL);","file":"driver/drv_ds1820_simple.c","requires":"",

--- a/src/driver/drv_ds1820_full.c
+++ b/src/driver/drv_ds1820_full.c
@@ -728,6 +728,12 @@ void DS1820_full_driver_Init()
 	CMD_RegisterCommand("DS1820_FULL_scansensors", CMD_DS18B20_scansensors, NULL);
 
 	// no need to discover the "family" we know the address, the first byte is the family
+
+#if ENABLE_DS1820_TEST_US	
+	init_TEST_US();
+#endif
+
+
 };
 
 void DS1820_full_AppendInformationToHTTPIndexPage(http_request_t* request, int bPreState)

--- a/src/driver/drv_ds1820_simple.c
+++ b/src/driver/drv_ds1820_simple.c
@@ -81,6 +81,11 @@ void DS1820_driver_Init()
 	Pin = PIN_FindPinIndexForRole(IOR_DS1820_IO, -1);
 	if (Pin >= 0)
 		DS1820_DiscoverFamily();
+		
+#if ENABLE_DS1820_TEST_US	
+	init_TEST_US();
+#endif
+
 };
 
 void DS1820_AppendInformationToHTTPIndexPage(http_request_t* request, int bPreState)

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -16,6 +16,7 @@ void HAL_RebootModule()
 	bk_reboot();
 }
 
+#if ! (PLATFORM_BK7252 || PLATFORM_BK7238)
 #if !defined TIMER0_2_READ_VALUE && defined TIMERR0_2_READ_VALUE
 //typo in sdk
 #define TIMER0_2_READ_VALUE TIMERR0_2_READ_VALUE
@@ -47,10 +48,12 @@ static uint32_t getTicksCount() {
 // 26 ticks per us * 15 000 000 us per overflow
 #define TICKS_PER_OVERFLOW (TICKS_PER_US * US_PER_OVERFLOW)
 
+#endif // #if ! (PLATFORM_BK7252 || PLATFORM_BK7238)
+
 // https://github.com/libretiny-eu/libretiny
 // not working on BK7238
 void HAL_Delay_us(int delay) {
-#if PLATFORM_BK7238
+#if (PLATFORM_BK7252) || (PLATFORM_BK7238)
 		// starting over again for BK7238
 		// read factors between 5 and 6,7 - using 6 seems a good start
 		// trying with 6.4 - higher values are off else

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -50,25 +50,9 @@ static uint32_t getTicksCount() {
 // https://github.com/libretiny-eu/libretiny
 // not working on BK7238
 void HAL_Delay_us(int delay) {
-#if 0	// try other delay for BK7238, too
-PLATFORM_BK7238
-	if (delay < 100){
-		usleep((17*delay)/10);
-	}else{
-		uint64_t m = (uint64_t)rtos_get_time_us();
-		uint64_t e = (m + delay);
-		if(m > e)
-		{ //overflow
-			while((uint64_t)rtos_get_time_us() > e)
-			{
-				__asm ("NOP");
-			}
-		}
-		while((uint64_t)rtos_get_time_us() < e)
-		{
-			__asm ("NOP");
-		}
-	}
+#if PLATFORM_BK7238
+		// starting over again for BK7238
+		usleep(delay);
 #else
 	uint32_t startTick = getTicksCount();
 	if (delay > 1 && startTick != BK_TIMER_FAILURE ){		// be sure, timer works

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -50,8 +50,9 @@ static uint32_t getTicksCount() {
 // https://github.com/libretiny-eu/libretiny
 // not working on BK7238
 void HAL_Delay_us(int delay) {
-#if PLATFORM_BK7238
-	if (delay < 0){		// effectivly remove for testing
+#if 0	// try other delay for BK7238, too
+PLATFORM_BK7238
+	if (delay < 100){
 		usleep((17*delay)/10);
 	}else{
 		uint64_t m = (uint64_t)rtos_get_time_us();

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -51,7 +51,7 @@ static uint32_t getTicksCount() {
 // not working on BK7238
 void HAL_Delay_us(int delay) {
 #if PLATFORM_BK7238
-	if (delay < 100){
+	if (delay < 0){		// effectivly remove for testing
 		usleep((17*delay)/10);
 	}else{
 		uint64_t m = (uint64_t)rtos_get_time_us();

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -2,6 +2,11 @@
 #include "../hal_generic.h"
 #include <BkDriverWdg.h>
 
+#include "../../beken378/driver/include/arm_arch.h"
+#include "../../beken378/driver/pwm/bk_timer.h"
+#include "../../beken378/driver/include/bk_timer_pub.h"
+#include "../../beken378/func/include/fake_clock_pub.h"
+
 // from wlan_ui.c
 void bk_reboot(void);
 extern bool g_powersave;
@@ -11,17 +16,115 @@ void HAL_RebootModule()
 	bk_reboot();
 }
 
-void HAL_Delay_us(int delay)
-{
-	float adj = 1;
-	if(g_powersave) adj = 1.5;
+#if !defined TIMER0_2_READ_VALUE && defined TIMERR0_2_READ_VALUE
+//typo in sdk
+#define TIMER0_2_READ_VALUE TIMERR0_2_READ_VALUE
+#endif
+
+static uint32_t getTicksCount() {
+	uint32_t timeout = 0;
+	if (CAL_TIMER_ID >2) bk_printf("ERROR - in getTicksCount() CAL_TIMER_ID = %i\r\n",CAL_TIMER_ID);
+	REG_WRITE(TIMER0_2_READ_CTL, (CAL_TIMER_ID << 2) | 1);
+	while (REG_READ(TIMER0_2_READ_CTL) & 1) {
+		timeout++;
+		if (timeout > (120 * 1000)){
+			bk_printf("ERROR - timeout in getTicksCount()\r\n");
+			return BK_TIMER_FAILURE;
+		}
+	}
+	return REG_READ(TIMER0_2_READ_VALUE);
+}
+
+#if !defined CFG_XTAL_FREQUENCE
+//26MHz, as per bk7231t_os/beken378/driver/sys_ctrl/sys_ctrl.c
+#define CFG_XTAL_FREQUENCE 26000000
+#endif
+
+//ONE_CAL_TIME - from fake_clock.c
+#define ONE_CAL_TIME       15000
+#define TICKS_PER_US       (CFG_XTAL_FREQUENCE / 1000 / 1000)
+#define US_PER_OVERFLOW    (ONE_CAL_TIME * 1000)
+// 26 ticks per us * 15 000 000 us per overflow
+#define TICKS_PER_OVERFLOW (TICKS_PER_US * US_PER_OVERFLOW)
+
+// https://github.com/libretiny-eu/libretiny
+// not working on BK7238
+void HAL_Delay_us(int delay) {
 #if PLATFORM_BK7238
-	//  current n/t are for 120mhz, BK7238 freq is 160mhz
-	usleep((23 * delay * adj) / 10); // "1" is to fast and "2" to slow, 1.7 seems better than 1.5 (only from observing readings, no scope involved)
+	if (delay < 100){
+		usleep((17*delay)/10);
+	}else{
+		uint64_t m = (uint64_t)rtos_get_time_us();
+		uint64_t e = (m + delay);
+		if(m > e)
+		{ //overflow
+			while((uint64_t)rtos_get_time_us() > e)
+			{
+				__asm ("NOP");
+			}
+		}
+		while((uint64_t)rtos_get_time_us() < e)
+		{
+			__asm ("NOP");
+		}
+	}
 #else
-	usleep((17 * delay * adj) / 10); // "1" is to fast and "2" to slow, 1.7 seems better than 1.5 (only from observing readings, no scope involved)
+	uint32_t startTick = getTicksCount();
+	if (delay > 1 && startTick != BK_TIMER_FAILURE ){		// be sure, timer works
+		uint32_t endTicks = startTick + TICKS_PER_US * delay;	// end tick value after delay
+		// 
+		// there are three possible cases: 
+		//	1. a delay with overflow 
+		//	2. a delay surely without overflow
+		//	3. a delay with a possible overflow
+		// 
+		// Case 1. with overflow:
+		//	quite "easy":
+		//		wait for overflow, then wait until counter > calculated end value (after overflow)
+		if (endTicks >= TICKS_PER_OVERFLOW){
+			while (getTicksCount() > startTick) {};	// until overflow happens, the actual count is > than start
+			endTicks -= TICKS_PER_OVERFLOW;		// calculate endTicks (subtracting maximum value
+			while (getTicksCount() < endTicks) {};	// wait, until end counter is reached
+			
+		} 
+		else {
+		// 
+		//	For the other two cases we need to define a "safe distance" away from overflow
+		//		if the end value is lower, we define it as "safe" - there can be no overflow when testing 
+		//	 
+		
+			uint32_t safeTick = TICKS_PER_OVERFLOW - (TICKS_PER_US * 10);	// an end value "10 us away" from overflow should be safe 
+
+		// Case 2. surely no overflow:
+		//	very easy:
+		//		since end value is a "safe distance" away from overflow we can simply wait, until end value is reached 
+		
+			if (endTicks < safeTick){			// so end value is "safe" distance away from overflow
+				while (getTicksCount() < endTicks) {};	// just wait, until end counter is reached
+			}
+			else {
+			
+		// Case 3. the tricky one: end value is "near" to overflow - so we can't simply wait, until end value is reached, 
+		//	because we might miss the check, were counter is > endTicks and the next test is after an overflow and (since the value returend is way below our end point) we missed the end condition.
+		//	So we need two checks: is the value still below endTicks AND was there no overflow (we test, if the value is still > startTick)
+		// 
+		// 	to make the "expensive" tests as low as possible, devide the test:
+		//		first test "simple" inside the safe boundaries
+		//		then do the test for end value and check, if overflow happened   
+
+				while (getTicksCount() < safeTick) {};	// "simple" wait, until safeTick is reached
+				uint32_t t = getTicksCount();
+				while ( t < endTicks && t > startTick){	// when "near" overflow, check if endTicks is reached or overflow happened (then t < startTick)
+					t = getTicksCount();
+				};
+
+			}
+		}
+
+	}
 #endif
 }
+
 
 void HAL_Configure_WDT()
 {

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -53,7 +53,8 @@ void HAL_Delay_us(int delay) {
 #if PLATFORM_BK7238
 		// starting over again for BK7238
 		// read factors between 5 and 6,7 - using 6 seems a good start
-		usleep(6*delay);
+		// trying with 6.4 - higher values are off else
+		usleep((64*delay)/10);
 #else
 	uint32_t startTick = getTicksCount();
 	if (delay > 1 && startTick != BK_TIMER_FAILURE ){		// be sure, timer works

--- a/src/hal/bk7231/hal_generic_bk7231.c
+++ b/src/hal/bk7231/hal_generic_bk7231.c
@@ -52,7 +52,8 @@ static uint32_t getTicksCount() {
 void HAL_Delay_us(int delay) {
 #if PLATFORM_BK7238
 		// starting over again for BK7238
-		usleep(delay);
+		// read factors between 5 and 6,7 - using 6 seems a good start
+		usleep(6*delay);
 #else
 	uint32_t startTick = getTicksCount();
 	if (delay > 1 && startTick != BK_TIMER_FAILURE ){		// be sure, timer works

--- a/src/hal/bk7231/hal_pins_bk7231.c
+++ b/src/hal/bk7231/hal_pins_bk7231.c
@@ -65,24 +65,24 @@ int HAL_PIN_CanThisPinBePWM(int index) {
 	return 1;
 }
 void HAL_PIN_SetOutputValue(int index, int iVal) {
-	bk_gpio_output(index, iVal);
+	gpio_output(index, iVal);
 }
 
 int HAL_PIN_ReadDigitalInput(int index) {
-	return bk_gpio_input(index);
+	return gpio_input(index);
 }
 void HAL_PIN_Setup_Input_Pullup(int index) {
-	bk_gpio_config_input_pup(index);
+	gpio_config(index, GMODE_INPUT_PULLUP);
 }
 void HAL_PIN_Setup_Input_Pulldown(int index) {
-	bk_gpio_config_input_pdwn(index);
+	gpio_config(index, GMODE_INPUT_PULLDOWN);
 }
 void HAL_PIN_Setup_Input(int index) {
-	bk_gpio_config_input(index);
+	gpio_config(index, GMODE_INPUT);
 }
 void HAL_PIN_Setup_Output(int index) {
-	bk_gpio_config_output(index);
-	bk_gpio_output(index, 0);
+	gpio_config(index, GMODE_OUTPUT);
+	gpio_output(index, 0);
 }
 void HAL_PIN_PWM_Stop(int index) {
 	int pwmIndex;

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -516,6 +516,14 @@
 //#define ENABLE_BL_MOVINGAVG	1
 #endif
 
+// enable testing HAL_Delay_us with a special command
+// testus
+#if (ENABLE_DRIVER_DS1820 || ENABLE_DRIVER_DS1820_FULL)
+#define ENABLE_DS1820_TEST_US					1
+#endif
+
+
+
 // closing OBK_CONFIG_H
 #endif
 


### PR DESCRIPTION
Change for Beken HAL_Delay_us() as proposed in #1579 by @rpv-tomsk

Added a simple command to test usleep on a given pin with (need to start a DS1820 driver before to get this command registered)

`testus <pin> <delay in us between tests> <testvalue 1> <testvalue 2> <testvalue 3> ... <testvalue 10> `

tested on BK7231N to work with both drivers (I am aware of) using HAL_Delay_us
DS1820 and DHT (tested with DHT11 only, but timing should be the same for other sensors)

Tested "regular" and alternative build for this platform
Tested with and without powersave

Timing on BK7231N looks really good with this driver, at least for usleep > 6 its allways 2 us more:

value	analyzer
500	502
200	202
100	102
 50	 52
 20	 22
 10	 12
  6	  8
  4	  7

Now it's time to test on other Beken platforms, too:

I didn't get BK7238 working first, neither with  calendar approach from @NonPIayerCharacter 
(it's only kind of working for "big" values, only sleeping multiples of 31us) non with my old approach:
While i had it working before with a factor to usleep, it didn't work anymore - timing was way to short.

So actually for BK7238 I'm using usleep(6.4*x) which works well here:

value	analyzer
500	502
200	202
100	101
 50	 51
 20	 21
 10	 11
  6	 7
  4	 5
  
DHT11 and DS1820 are working, I also tried "powersave" on BK7238, but this seems to "halt" the device?!?

```
Info:CMD:CMD_PowerSave: will set to 1
first enable sleep 
power_save_me_ps_first_set_state 678
me_send_ps_req 2 0 0
mcu_ps_init 0
Info:CMD:[WebApp Cmd 'powersaset_ps_mode_cfm:1110 1 4 0
set listen dtim:1
enter 0 ps,p:1 m:1 int:100 l:30!
power_save_dtim_ps_init
ve' Result] OK
Info:MQTT:mqtt_host empty, not starting mqtt
Info:MAIN:Time 41, idle 200557/s, free 116080, MQTT 0(3), bWifi 1, secondsWithNoPing -1, socks 2/24 POWERSAVE
 sleep_f�
```


On the other hand: I also didn't get powersave to work with release, so I'm probably missing something for this:

```
Info:MAIN:Time 28, idle 224111/s, free 116168, MQTT 0(1), bWifi 1, secondsWithN 
Info:CMD:CMD_PowerSave: will set to 1                                           
first enable sleep                                                              
power_save_me_ps_first_set_state 678                                            
me_send_ps_req 2 0 0                                                            
mcu_ps_init 0                                                                   
Info:CMD:[WebApp Cset_ps_mode_cfm:1110 1 4 0                                    
set listen dtim:1                                                               
enter 0 ps,p:1 m:1 int:100 l:30!                                                
power_save_dtim_ps_init                                                         
md 'powersave' Result] OK                                                       
 sleep

```