### PR TITLE
SM16703P: learn to handle RGBCW, e.g. more than 3 channels per pixel.

### DIFF
--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -660,7 +660,7 @@ void apply_smart_light() {
 #endif
 #if	ENABLE_DRIVER_SM16703P
 	if (pixel_count > 0 && (g_lightMode != Light_Anim || g_lightEnableAll == 0)) {
-		SM16703P_setAllPixels(finalColors[0], finalColors[1], finalColors[2]);
+		SM16703P_setAllPixels(finalColors[0], finalColors[1], finalColors[2], finalColors[3], finalColors[4]);
 		SM16703P_Show();
 	}
 #endif

--- a/src/driver/drv_drawers.c
+++ b/src/driver/drv_drawers.c
@@ -34,7 +34,7 @@ static int DR_LedIndex(http_request_t* request) {
 	int index = atoi(tmp);
 	g_timeOuts[index] = g_on_timeout_ms;
 #if ENABLE_DRIVER_SM16703P
-	SM16703P_setPixel(index, SPLIT_COLOR(g_on_color));
+	SM16703P_setPixel(index, SPLIT_COLOR(g_on_color), 0, 0);
 #endif
 	g_changes++;
 	return 0;
@@ -47,7 +47,7 @@ static void applyAmbient() {
 	g_changes++;
 	for (int i = 0; i < g_numLEDs; i++) {
 #if ENABLE_DRIVER_SM16703P
-		SM16703P_setPixel(i, SPLIT_COLOR(c));
+		SM16703P_setPixel(i, SPLIT_COLOR(c), 0, 0);
 #endif
 	}
 }
@@ -155,7 +155,7 @@ void Drawers_QuickTick() {
 			g_timeOuts[i] -= g_deltaTimeMS;
 			if (g_timeOuts[i] <= 0) {
 #if ENABLE_DRIVER_SM16703P
-				SM16703P_setPixel(i,SPLIT_COLOR(g_off_color));
+				SM16703P_setPixel(i,SPLIT_COLOR(g_off_color), 0, 0);
 #endif
 				g_timeOuts[i] = 0;
 				g_changes++;

--- a/src/driver/drv_local.h
+++ b/src/driver/drv_local.h
@@ -56,9 +56,13 @@ void DRV_GosundSW2_Init();
 void DRV_GosundSW2_RunFrame();
 
 void SM16703P_Init();
-void SM16703P_setPixel(int pixel, int r, int g, int b);
-void SM16703P_setPixelWithBrig(int pixel, int r, int g, int b);
-void SM16703P_setAllPixels(int r, int g, int b);
+void SM16703P_Shutdown();
+// set RGBCW values - Cold and Warm White are optional and might be ignored if hardware does not support them, or if
+// channel order does not include them.
+// default is RGB, so C and W are ignored by default - needs to be enabled with something like 'SM16703P_Init 20 RGBCW'
+void SM16703P_setPixel(int pixel, int r, int g, int b, int c, int w);
+void SM16703P_setPixelWithBrig(int pixel, int r, int g, int b, int c, int w);
+void SM16703P_setAllPixels(int r, int g, int b, int c, int w);
 void SM16703P_scaleAllPixels(int scale);
 void SM16703P_Show();
 extern uint32_t pixel_count;

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -258,7 +258,7 @@ static driver_t g_drivers[] = {
 	//drvdetail:"title":"TODO",
 	//drvdetail:"descr":"SM16703P is an individually addressable LEDs controller like WS2812B. Currently SM16703P LEDs are supported through hardware SPI, LEDs data should be connected to P16 (MOSI), [here you can read](https://www.elektroda.com/rtvforum/topic4005865.html) how to break it out on CB2S.",
 	//drvdetail:"requires":""}
-	{ "SM16703P",	SM16703P_Init,		NULL,						NULL, NULL, NULL, NULL, NULL, false },
+	{ "SM16703P",	SM16703P_Init,		NULL,						NULL, NULL, SM16703P_Shutdown, NULL, NULL, false },
 #endif
 #if ENABLE_DRIVER_SM15155E
 	//drvdetail:{"name":"SM15155E",

--- a/src/driver/drv_pixelAnim.c
+++ b/src/driver/drv_pixelAnim.c
@@ -58,14 +58,14 @@ void ShootingStar_Run() {
 	if (direction == -1) {        // Reverse direction option for LEDs
 		if (count < pixel_count) {
 			SM16703P_setPixelWithBrig(pixel_count - (count % (pixel_count + 1)),
-				led_baseColors[0], led_baseColors[1], led_baseColors[2]);    // Set LEDs with the color value
+				led_baseColors[0], led_baseColors[1], led_baseColors[2], led_baseColors[3], led_baseColors[4]);    // Set LEDs with the color value
 		}
 		count++;
 	}
 	else {
 		if (count < pixel_count) {     // Forward direction option for LEDs
 			SM16703P_setPixelWithBrig(count % pixel_count,
-				led_baseColors[0], led_baseColors[1], led_baseColors[2]);    // Set LEDs with the color value
+				led_baseColors[0], led_baseColors[1], led_baseColors[2], led_baseColors[3], led_baseColors[4]);    // Set LEDs with the color value
 		}
 		count++;
 	}
@@ -81,7 +81,7 @@ void RainbowCycle_Run() {
 
 	for (i = 0; i < pixel_count; i++) {
 		c = RainbowWheel_Wheel(((i * 256 / pixel_count) + j) & 255);
-		SM16703P_setPixelWithBrig(pixel_count - 1 - i, *c, *(c + 1), *(c + 2));
+		SM16703P_setPixelWithBrig(pixel_count - 1 - i, *c, *(c + 1), *(c + 2), 0, 0);
 	}
 	SM16703P_Show();
 	j++;
@@ -98,13 +98,13 @@ void Fire_setPixelHeatColor(int Pixel, byte temperature) {
 
 	// Figure out which third of the spectrum we're in:
 	if (t192 > 0x80) {                    // hottest
-		SM16703P_setPixelWithBrig(Pixel, 255, 255, heatramp);
+		SM16703P_setPixelWithBrig(Pixel, 255, 255, heatramp, 0, 0); // red to yellow
 	}
 	else if (t192 > 0x40) {               // middle
-		SM16703P_setPixelWithBrig(Pixel, 255, heatramp, 0);
+		SM16703P_setPixelWithBrig(Pixel, 255, heatramp, 0, 0, 0); // red to yellow
 	}
 	else {                               // coolest
-		SM16703P_setPixelWithBrig(Pixel, heatramp, 0, 0);
+		SM16703P_setPixelWithBrig(Pixel, heatramp, 0, 0, 0, 0);
 	}
 }
 // FlameHeight - Use larger value for shorter flames, default=50.


### PR DESCRIPTION
As the title says, this adds support for SM16703P compatible ICs with more than 3 channel.
For example
 - 4 channel: RGBW
 - 5 channel: RGBCW
 - Also more or less channels are possible, if such hardware exists, e.g. RGB with 2 warm-white channel (of same temperature)
 - Also crazy combination would be possible, like a white and a red channel, but no other channels (if such hardware exists)

I did it as generic as possible.
Modification should be fully backward compatible.

`SM16703P_Init` command has been modified to support also cold-white and warm-white channel.
Default is still "RGB", e.g. `SM16703P_Init 20` is same as `SM16703P_Init 20 RGB` and enables 20 RGB-ICs with "RGB" channel order - as before.
To use OpenBeken with 5 channel RGB-ICs call something like: `SM16703P_Init 20 RGBCW`

I did these modification to solve [https://www.elektroda.com/rtvforum/topic4062886.html](https://www.elektroda.com/rtvforum/topic4062886.html). I got myself the same string lights which are working fine now.

Flag 4 is still needed to enable RGBCW controller for RGBICs. (No changes on that)

This is my first contribution on OpenBeken. Please kindly let me know if something should be done in a different way.