### PR TITLE
Add DS1820 to JSON sensor output

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -58,7 +58,7 @@ jobs:
   build2:
     name: Build Simulator
     needs: refs
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - name: Checkout repository

--- a/src/driver/drv_ds1820_full.c
+++ b/src/driver/drv_ds1820_full.c
@@ -736,6 +736,40 @@ void DS1820_full_driver_Init()
 
 };
 
+
+*/
+		printer(request, "\"DS1820\":");
+		// following check will clear NaN values
+		printer(request, "{");
+		printer(request, "\"Temperature\": %.1f,", chan_val1);
+		// close ENERGY block
+		printer(request, "},");
+
+*/
+
+static char *jsonSensor_reststr = NULL;
+char *DS1820_full_jsonSensors(){
+	if (ds18_count <= 0 ) return NULL;
+	if (jsonSensor_reststr!=NULL) free jsonSensor_reststr; 
+	// {"DS1820_<name>":{"Temperature": <temp>},
+	// {"DS1820_<name - DS18B20namel>":{"Temperature": <temp -127,00>},
+	// 123456789                     123456789012345678      1234567890   
+	// length of str: 10 + DS18B20namel + 18 + 10 --> 40 + DS18B20namel
+	
+	int size = (40 + DS18B20namel) * ds18_count;
+	char *str = (char *)malloc(size * sizeof(char));
+	if (str == NULL) {
+        	return NULL; // string allocation failed
+        }
+	for (int i=0; i < ds18_count; i++) {
+		char tmp[50 + DS18B20namel];
+		sprintf(tmp, "{\"DS1820_%s\":{"\"Temperature\": %.1f},",ds18b20devices.name[i],ds18b20devices.lasttemp[i]);
+		strncat(str, tmp, size - strlen(str) - 1); // Concatenate to the main string
+	}
+        jsonSensor_reststr = str;
+	return jsonSensor_reststr;
+}
+
 void DS1820_full_AppendInformationToHTTPIndexPage(http_request_t* request, int bPreState)
 {
 	if (bPreState){

--- a/src/driver/drv_ds1820_full.c
+++ b/src/driver/drv_ds1820_full.c
@@ -737,7 +737,7 @@ void DS1820_full_driver_Init()
 };
 
 
-*/
+/*
 		printer(request, "\"DS1820\":");
 		// following check will clear NaN values
 		printer(request, "{");

--- a/src/driver/drv_ds1820_full.c
+++ b/src/driver/drv_ds1820_full.c
@@ -761,9 +761,10 @@ char *DS1820_full_jsonSensors(){
 	if (str == NULL) {
         	return NULL; // string allocation failed
         }
+	str[0] = 0;
 	for (int i=0; i < ds18_count; i++) {
 		char tmp[50 + DS18B20namel];
-		sprintf(tmp, "{\"DS1820_%s\":{\"Temperature\": %.1f},",ds18b20devices.name[i],ds18b20devices.lasttemp[i]);
+		sprintf(tmp, "\"DS1820_%s\":{\"Temperature\": %.1f},",ds18b20devices.name[i],ds18b20devices.lasttemp[i]);
 		strncat(str, tmp, size - strlen(str) - 1); // Concatenate to the main string
 	}
         jsonSensor_reststr = str;

--- a/src/driver/drv_ds1820_full.c
+++ b/src/driver/drv_ds1820_full.c
@@ -750,7 +750,7 @@ void DS1820_full_driver_Init()
 static char *jsonSensor_reststr = NULL;
 char *DS1820_full_jsonSensors(){
 	if (ds18_count <= 0 ) return NULL;
-	if (jsonSensor_reststr!=NULL) free jsonSensor_reststr; 
+	if (jsonSensor_reststr!=NULL) free(jsonSensor_reststr); 
 	// {"DS1820_<name>":{"Temperature": <temp>},
 	// {"DS1820_<name - DS18B20namel>":{"Temperature": <temp -127,00>},
 	// 123456789                     123456789012345678      1234567890   
@@ -763,7 +763,7 @@ char *DS1820_full_jsonSensors(){
         }
 	for (int i=0; i < ds18_count; i++) {
 		char tmp[50 + DS18B20namel];
-		sprintf(tmp, "{\"DS1820_%s\":{"\"Temperature\": %.1f},",ds18b20devices.name[i],ds18b20devices.lasttemp[i]);
+		sprintf(tmp, "{\"DS1820_%s\":{\"Temperature\": %.1f},",ds18b20devices.name[i],ds18b20devices.lasttemp[i]);
 		strncat(str, tmp, size - strlen(str) - 1); // Concatenate to the main string
 	}
         jsonSensor_reststr = str;

--- a/src/driver/drv_ds1820_full.h
+++ b/src/driver/drv_ds1820_full.h
@@ -24,4 +24,4 @@ float ds18b20_getTempC(const uint8_t *deviceAddress);
 bool isConversionComplete();
 void reset_search();
 bool search(uint8_t *newAddr, bool search_mode, int Pin);
-
+char *DS1820_full_jsonSensors();

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -852,7 +852,7 @@ bool DRV_IsMeasuringBattery() {
 
 bool DRV_IsSensor() {
 #ifndef OBK_DISABLE_ALL_DRIVERS
-	return DRV_IsRunning("SHT3X") || DRV_IsRunning("CHT83XX") || DRV_IsRunning("SGP") || DRV_IsRunning("AHT2X");
+	return DRV_IsRunning("SHT3X") || DRV_IsRunning("CHT83XX") || DRV_IsRunning("SGP") || DRV_IsRunning("AHT2X") || DRV_IsRunning("DS1820") || DRV_IsRunning("DS1820_full");
 #else
 	return false;
 #endif

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -298,7 +298,17 @@ static int http_tasmota_json_SENSOR(void* request, jsonCb_t printer) {
 #endif
 #if (ENABLE_DRIVER_DS1820_FULL)
 	if (DRV_IsRunning("DS1820_full")) {		//DS1820_full.c with possibly multiple sensors
-		printer(request, DS1820_full_jsonSensors());
+		char *str = DS1820_full_jsonSensors();
+		int toprint = strlen(str);
+		while (*str && toprint > 250) {		// string can be long, longer than request, this would break output if not split
+			char t = str[250];
+			str[250]=0;
+			printer(request, str);
+			str[250]=t;
+			str+=250;
+			toprint -= 250;
+		}	 
+		printer(request, str);
 	}
 #endif
 	if (DRV_IsRunning("CHT83XX")) {

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -278,6 +278,23 @@ static int http_tasmota_json_SENSOR(void* request, jsonCb_t printer) {
 		// close ENERGY block
 		printer(request, "},");
 	}
+	if (DRV_IsRunning("DS1820")) {		//DS1820_simple.c with one sensor
+		g_pin_1 = PIN_FindPinIndexForRole(IOR_DS1820_IO, g_pin_1);
+		channel_1 = g_cfg.pins.channels[g_pin_1];
+		chan_val1 = CHANNEL_GetFloat(channel_1) / 100.0f;
+
+		// writer header
+		printer(request, "\"DS1820\":");
+		// following check will clear NaN values
+		printer(request, "{");
+		printer(request, "\"Temperature\": %.1f", chan_val1);
+		// close ENERGY block
+		printer(request, "},");
+	}
+	if (DRV_IsRunning("DS1820_full")) {		//DS1820_full.c with possibly multiple sensors
+		printer(request, DS1820_full_jsonSensors);
+	}
+
 	if (DRV_IsRunning("CHT83XX")) {
 		g_pin_1 = PIN_FindPinIndexForRole(IOR_CHT83XX_DAT, g_pin_1);
 		channel_1 = g_cfg.pins.channels[g_pin_1];
@@ -295,6 +312,7 @@ static int http_tasmota_json_SENSOR(void* request, jsonCb_t printer) {
 		// close ENERGY block
 		printer(request, "},");
 	}
+
 	for (int i = 0; i < PLATFORM_GPIO_MAX; i++) {
 		int role = PIN_GetPinRoleForPinIndex(i);
 		if (role != IOR_DHT11 && role != IOR_DHT12 && role != IOR_DHT21 && role != IOR_DHT22)

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -20,6 +20,9 @@
 #include "../driver/drv_ntp.h"
 #include "../driver/drv_local.h"
 #include "../driver/drv_bl_shared.h"
+#include "../driver/drv_ds1820_simple.h"
+#include "../driver/drv_ds1820_full.h"
+
 
 #if ENABLE_TASMOTA_JSON
 
@@ -292,7 +295,7 @@ static int http_tasmota_json_SENSOR(void* request, jsonCb_t printer) {
 		printer(request, "},");
 	}
 	if (DRV_IsRunning("DS1820_full")) {		//DS1820_full.c with possibly multiple sensors
-		printer(request, DS1820_full_jsonSensors);
+		printer(request, DS1820_full_jsonSensors());
 	}
 
 	if (DRV_IsRunning("CHT83XX")) {

--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -281,6 +281,7 @@ static int http_tasmota_json_SENSOR(void* request, jsonCb_t printer) {
 		// close ENERGY block
 		printer(request, "},");
 	}
+#if (ENABLE_DRIVER_DS1820)
 	if (DRV_IsRunning("DS1820")) {		//DS1820_simple.c with one sensor
 		g_pin_1 = PIN_FindPinIndexForRole(IOR_DS1820_IO, g_pin_1);
 		channel_1 = g_cfg.pins.channels[g_pin_1];
@@ -294,10 +295,12 @@ static int http_tasmota_json_SENSOR(void* request, jsonCb_t printer) {
 		// close ENERGY block
 		printer(request, "},");
 	}
+#endif
+#if (ENABLE_DRIVER_DS1820_FULL)
 	if (DRV_IsRunning("DS1820_full")) {		//DS1820_full.c with possibly multiple sensors
 		printer(request, DS1820_full_jsonSensors());
 	}
-
+#endif
 	if (DRV_IsRunning("CHT83XX")) {
 		g_pin_1 = PIN_FindPinIndexForRole(IOR_CHT83XX_DAT, g_pin_1);
 		channel_1 = g_cfg.pins.channels[g_pin_1];


### PR DESCRIPTION
As pointed out in #1804 , DS1820 sensors are missing in status.

This PR will add the output for "simple" 

<img width="688" height="367" alt="Bildschirmfoto vom 2025-09-25 17-24-26" src="https://github.com/user-attachments/assets/68a35b5e-caf4-479d-b571-4c6271a949b1" />



and "full" driver:
<img width="992" height="964" alt="Bildschirmfoto vom 2025-09-25 18-14-44" src="https://github.com/user-attachments/assets/52846ff9-fdcf-48f6-85b6-7601a88fba7f" />

 