### PR TITLE
Flag13 - extend pin state display to PLATFORM_GPIO_MAX

### DIFF
--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1009,7 +1009,7 @@ typedef enum {
 		}
 
 		hprintf255(request, "<h5> PIN States<br>");
-		for (i = 0; i < 29; i++)
+		for (i = 0; i < PLATFORM_GPIO_MAX; i++)
 		{
 			if ((PIN_GetPinRoleForPinIndex(i) != IOR_None) || (i == 0) || (i == 1))
 			{


### PR DESCRIPTION
previously fixed to 29 pins

https://www.elektroda.com/rtvforum/viewtopic.php?p=21708009#21708009