### PR TITLE
fix handling of "sunset" events

### DIFF
--- a/src/driver/drv_ntp_events.c
+++ b/src/driver/drv_ntp_events.c
@@ -446,9 +446,9 @@ int NTP_PrintEventList() {
 				sprintf(sun," (sunset)");
 			}
 		}
-		addLogAdv(LOG_INFO, LOG_FEATURE_CMD, "Ev %i - %i:%i:%i%s, days 0x%02x, cmd %s\n", (int)e->id, (int)e->hour, (int)e->minute, (int)e->second, sun, (int)e->weekDayFlags, e->command);
+		addLogAdv(LOG_INFO, LOG_FEATURE_CMD, "Ev %i - %02i:%02i:%02i%s, days 0x%02x, cmd %s\n", (int)e->id, (int)e->hour, (int)e->minute, (int)e->second, sun, (int)e->weekDayFlags, e->command);
 #else
-		addLogAdv(LOG_INFO, LOG_FEATURE_CMD, "Ev %i - %i:%i:%i, days 0x%02x, cmd %s\n", (int)e->id, (int)e->hour, (int)e->minute, (int)e->second, (int)e->weekDayFlags, e->command);
+		addLogAdv(LOG_INFO, LOG_FEATURE_CMD, "Ev %i - %02i:%02i:%02i, days 0x%02x, cmd %s\n", (int)e->id, (int)e->hour, (int)e->minute, (int)e->second, (int)e->weekDayFlags, e->command);
 #endif
 		t++;
 		e = e->next;


### PR DESCRIPTION
I recently wondered, why my switch didn't turn on the light around sunset, but several minutes later using this commands:
```
addClockEvent sunset 0xff 31 setChannel 0 1
addClockEvent sunrise 0xff 32 setChannel 0 0

```


Checking the events I saw that sunrise events were recalculated every day, but not sunset :-(

Digging into the code I found the cause:

Old code for handling events was using
`if (e->sunflags & (SUNRISE_FLAG || SUNSET_FLAG)) {`

This will ignore sunset events:

expanding the right "OR" expression will be true, so in the end we will only test for
(sunflags & 0x01) (which is never true for sunset with flag 0x02 ).

it's sufficient to check is "sunflags" is not 0, so simple fix:

`if (e->sunflags){
`
Additionally added code to change list events ("listClockEvents") so it also shows if a time is derived from sunset or sunrise:

before the output would be like:

```
Info:CMD:Ev 32 - 7:31:0, days 0xff, cmd setChannel 0 0 
Info:CMD:Ev 31 - 19:7:0, days 0xff, cmd setChannel 0 1

```
and you won't see this is an "dynamic" time. Now it's (I also used %02i to fix time format)

```
Info:CMD:Ev 32 - 07:31:00 (sunrise), days 0xff, cmd setChannel 0 0 
Info:CMD:Ev 31 - 19:07:00 (sunset), days 0xff, cmd setChannel 0 1
```