### PR TITLE
Fix future sunset/sunrise events after DST switch

### DIFF
--- a/src/driver/drv_ntp.c
+++ b/src/driver/drv_ntp.c
@@ -334,6 +334,16 @@ uint32_t setDST(bool setNTP)
 
 	struct tm *ltm;
 	ltm = gmtime(&tempt);
+#if ENABLE_NTP_SUNRISE_SUNSET
+    if (old_DST != g_DST){
+	// if we had a DST switch, we might corect sunset/sunrise events, which were calculated before (with "previous" DST settings)
+	// if we changed to DST, we need to add DST_offset (old_DST = 0)
+	// if we were in DST before switch, we need to sub DST_offset (old_DST = g_DST_offset)
+	ADDLOG_INFO(LOG_FEATURE_RAW, "DST switch - calling  fix_DSTforEvents(%d)\r\n", old_DST ? - g_DST_offset : g_DST_offset );
+	fix_DSTforEvents( old_DST ? - g_DST_offset : g_DST_offset );
+    }
+#endif
+
 	ADDLOG_INFO(LOG_FEATURE_RAW, "In %s time - next DST switch at %lu (" LTSTR ")\r\n",
 	(g_DST)?"summer":"standard", next_DST_switch_epoch, LTM2TIME(ltm));
 	return g_DST;

--- a/src/driver/drv_ntp.h
+++ b/src/driver/drv_ntp.h
@@ -33,6 +33,11 @@ int Time_IsDST();
 // only after setting g_ntpTime freshly from an NTP packet	--> call setDST(0)
 // we must not alter g_ntpTime inside setDST in this case (the old offsets are no longer valid)
 uint32_t setDST(bool setNTP);
+#if ENABLE_NTP_SUNRISE_SUNSET
+// in case a DST switch happens, we should change future events of sunset/sunrise, since this will be different after a switch
+// since we calculated the events in advance, we need to "fix" all events, postulating the DST switch is allways before a days sunrise and sunset
+void fix_DSTforEvents(int hours);
+#endif
 #endif
 
 extern time_t g_ntpTime;

--- a/src/driver/drv_ntp_events.c
+++ b/src/driver/drv_ntp_events.c
@@ -166,6 +166,23 @@ void NTP_CalculateSunset(byte *outHour, byte *outMinute) {
 }
 #endif
 
+#if ENABLE_NTP_SUNRISE_SUNSET && ENABLE_NTP_DST
+// in case a DST switch happens, we should change future events of sunset/sunrise, since this will be different after a switch
+// since we calculated the events in advance, we need to "fix" all events, postulating the DST switch happens allways before a days sunrise and sunset
+void fix_DSTforEvents(int hours){
+	ntpEvent_t *e;
+	e = ntp_events;
+	while (e) {
+//		addLogAdv(LOG_INFO, LOG_FEATURE_CMD,"fix_DSTforEvents(%i) - testing  %s",hours,e->command);
+		if (e->command && e->sunflags) {	// only for (future) sunflag events
+//		addLogAdv(LOG_INFO, LOG_FEATURE_CMD,"fix_DSTforEvents(%i) - fixing  %s",hours,e->command);
+			e->hour += hours;
+		}
+		e = e->next;
+	}
+}
+#endif
+
 void NTP_RunEventsForSecond(time_t runTime) {
 	ntpEvent_t *e;
 	struct tm *ltm;

--- a/src/selftest/selftest_ntp_DST.c
+++ b/src/selftest/selftest_ntp_DST.c
@@ -154,6 +154,28 @@ void Test_NTP_DST() {
 	SELFTEST_ASSERT_EXPRESSION("$isDST", 1);
 	Sim_RunSeconds(6, false);
 	SELFTEST_ASSERT_EXPRESSION("$isDST", 0);
+	
+	
+#if ENABLE_NTP_SUNRISE_SUNSET
+	// test DST and sunset/sunrise events:
+	// after such an event took place, the next event will calculated
+	// if a DST switch takes place, before the sunset/sunrise takes place
+	// the prior calculated time is no longer valid, but needs to be adjusted
+	// set Warsaw
+	CMD_ExecuteCommand("ntp_setLatlong 52.237049 21.017532", 0);
+	// 1761440395 = Sun, Oct 26 2025 02:59:55 CEST - 5 seconds before DST switch
+	NTP_SetSimulatedTime(1761440395);
+	CMD_ExecuteCommand("addClockEvent sunset 0xff 31 setChannel 0 1", 0);	// 16:17:00
+	SELFTEST_ASSERT_INTCOMPARE(NTP_GetEventTime(31), 16*3600 + 17*60);
+	CMD_ExecuteCommand("addClockEvent sunrise 0xff 32 setChannel 0 0", 0);	// 06:21:00
+	SELFTEST_ASSERT_INTCOMPARE(NTP_GetEventTime(32), 6*3600 + 21*60);
+	// 1761440395 = Sun, Oct 26 2025 02:59:55 CEST
+	Sim_RunSeconds(7, false);
+	// Switch from summertime to winter time, so time is now one hour back
+	// test, if sunset/sunrise events are corrected
+	SELFTEST_ASSERT_INTCOMPARE(NTP_GetEventTime(31), 15*3600 + 17*60);
+	SELFTEST_ASSERT_INTCOMPARE(NTP_GetEventTime(32), 5*3600 + 21*60);
+#endif
 
 }
 


### PR DESCRIPTION
If we have both daylight saving time (DST) and sunset/sunrise calculation,
a DST switch should fix the upcoming sunset/sunrise events 
(which were calculated before the switch, hence with "old" time.) 
Also added one simple test case