### PR TITLE
TuyaMCU: Allow pin assignment for autoloading TuyaMCU driver

### DIFF
--- a/docs/json/ioRoles.json
+++ b/docs/json/ioRoles.json
@@ -712,6 +712,14 @@
     "driver": "RC"
   },
   {
+	"name":"TuyaMCU_dummy",
+	"title":"TuyaMCU Dummy Pin",
+	"descr":"Dummy pin to trigger driver autoload.",
+	"enum":"IOR_TuyaMCU",
+	"file":"new_pins.h",
+	"driver":"TuyaMCU"
+  },
+  {
     "name": "Total_Options",
     "title": "TODO",
     "descr": "Current total number of available IOR roles",

--- a/src/httpserver/new_http.c
+++ b/src/httpserver/new_http.c
@@ -560,6 +560,7 @@ const char* htmlPinRoleNames[] = {
 	"HLW_8112_SCSN",
 	"RCRecv",
 	"RCRecv_nPup",
+	"TuyaMCU_dummy",
 	"error",
 	"error",
 	"error",

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -482,7 +482,8 @@ int PIN_IOR_NofChan(int test){
 			|| test == IOR_RCRecv || test == IOR_RCRecv_nPup
 			|| (test >= IOR_IRRecv && test <= IOR_DHT11)
 			|| (test >= IOR_SM2135_DAT && test <= IOR_BP1658CJ_CLK)
-			|| (test == IOR_HLW8112_SCSN)) {
+			|| (test == IOR_HLW8112_SCSN)
+			|| (test == IOR_TuyaMCU)) {
 			return 0;
 	}
 	// all others have 1 channel

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -630,6 +630,13 @@ typedef enum ioRole_e {
 	//iodetail:"file":"new_pins.h",
 	//iodetail:"driver":"RC"}
 	IOR_RCRecv_nPup,
+	//iodetail:{"name":"TuyaMCU_dummy",
+	//iodetail:"title":"TuyaMCU Dummy Pin",
+	//iodetail:"descr":"Dummy pin to trigger driver autoload.",
+	//iodetail:"enum":"IOR_TuyaMCU",
+	//iodetail:"file":"new_pins.h",
+	//iodetail:"driver":"TuyaMCU"}
+	IOR_TuyaMCU,
 	//iodetail:{"name":"Total_Options",
 	//iodetail:"title":"TODO",
 	//iodetail:"descr":"Current total number of available IOR roles",

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -1392,6 +1392,11 @@ void Main_Init_BeforeDelay_Unsafe(bool bAutoRunScripts) {
 			if (PIN_FindPinIndexForRole(IOR_HLW8112_SCSN, -1) != -1) {
 				DRV_StartDriver("HLW8112SPI");
 			}
+#if ENABLE_DRIVER_TUYAMCU
+			if (PIN_FindPinIndexForRole(IOR_TuyaMCU, -1) != -1) {
+				DRV_StartDriver("TuyaMCU");
+			}
+#endif
 //			if ((PIN_FindPinIndexForRole(IOR_TM1638_CLK, -1) != -1) &&
 //				(PIN_FindPinIndexForRole(IOR_TM1638_DAT, -1) != -1) &&
 //				(PIN_FindPinIndexForRole(IOR_TM1638_STB, -1) != -1))


### PR DESCRIPTION
Assigning TuyaMCU_dummy to a pin will allow the TuyaMCU driver to automatically load during startup. The suggested pin is either the RX or TX that the TuyaMCU communicates on, but any unused pin will trigger the loading.