### PR TITLE
drv_tclac: Added ENABLE_DRIVER_TCL to driver file

### DIFF
--- a/src/driver/drv_tclAC.c
+++ b/src/driver/drv_tclAC.c
@@ -2,6 +2,7 @@
 
 #include "../obk_config.h"
 
+#if ENABLE_DRIVER_TCL
 
 #include "../logging/logging.h"
 #include "../new_cfg.h"
@@ -875,3 +876,4 @@ void TCL_DoDiscovery(const char *topic) {
 
 }
 
+#endif // ENABLE_DRIVER_TCL


### PR DESCRIPTION
Fixed error when compiling with `#undef ENABLE_HA_DISCOVERY` and `#undef ENABLE_DRIVER_TCL`. 
