### PR TITLE
Fix bl602 crashing trying to publish NaN

### DIFF
--- a/src/driver/drv_bl_shared.c
+++ b/src/driver/drv_bl_shared.c
@@ -932,7 +932,6 @@ void BL_ProcessUpdate(float voltage, float current, float power,
         } else { //all other sensors
           float val = (float)sensdataset->sensors[i].lastReading;
           if (sensdataset->sensors[i].names.units == UNIT_WH) val = BL_ChangeEnergyUnitIfNeeded(val);
-			if (isnan(val)) { val = 0;}
           MQTT_PublishMain_StringFloat(sensdataset->sensors[i].names.name_mqtt, val, sensdataset->sensors[i].rounding_decimals, OBK_PUBLISH_FLAG_QOS_ZERO);
         }
         stat_updatesSent[asensdatasetix]++;

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -16,6 +16,7 @@
 #include "../driver/drv_deviceclock.h"
 #include "../driver/drv_tuyaMCU.h"
 #include "../hal/hal_ota.h"
+#include <math.h>
 #ifndef WINDOWS
 #include <lwip/dns.h>
 #endif
@@ -1443,6 +1444,9 @@ OBK_Publish_Result MQTT_PublishMain_StringInt(const char* sChannel, int iv, int 
 OBK_Publish_Result MQTT_PublishMain_StringFloat(const char* sChannel, float f, int maxDecimalPlaces, int flags)
 {
 	char valueStr[16];
+	if (isnan(f)) {
+		f = 0;
+	}
 
 	sprintf(valueStr, "%f", f);
 	// fix decimal places


### PR DESCRIPTION
Bl602 crashes after frequency publishing was introduced in 18.209. With bl0937 frequency is NaN and trying to publish that crashes. This fixes the problem.