### PR TITLE
Try fix flash restrictions for W600 and W800 

### DIFF
--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1553,13 +1553,6 @@ typedef struct mainConfig_s {
 	char ping_host[64];
 	// ofs 0x000005E0 (dec 1504)
 	//char initCommandLine[512];
-//20260106 - try for V4 of config for W600 and W800
-#if 0
-//#if PLATFORM_W600 || PLATFORM_W800
-#define ALLOW_SSID2 0
-#define ALLOW_WEB_PASSWORD 0
-	char initCommandLine[512];
-#else
 #define ALLOW_SSID2 1
 #define ALLOW_WEB_PASSWORD 1
 	char initCommandLine[1568];
@@ -1579,7 +1572,6 @@ typedef struct mainConfig_s {
 	byte disable_web_server;
 	// offset 0x00000CBC (3260 decimal)
 	char unused[324];
-#endif
 } mainConfig_t;
 
 // one sector is 4096 so it we still have some expand possibility


### PR DESCRIPTION
...by moving start of FLASH_VARS (changing FLASH_VARS_STRUCTURE_ADDR)

When trying to add some data to flash config for a possible usage as WPA-AP I ran into the long-standing "limitations" for W600 and W800 regarding flash config.

E.g. here for W800 https://github.com/openshwprojects/OpenBK7231T_App/issues/963
and here for W600 https://github.com/openshwprojects/OpenBK7231T_App/issues/835

While the solution was a "workaround" to reduce config size for these platforms, I think I found the real "culprit" and this should be easy to fix:
Can it be, that this simply was caused by the code for flashVars on W600 (and later also used for W800) "overwriting" the config ?!?

```
src/hal/w800/hal_flashVars_w800.c:

…
FLASH_VARS_STRUCTURE flash_vars;
static int FLASH_VARS_STRUCTURE_SIZE = sizeof(FLASH_VARS_STRUCTURE);

//W800 - 0x1F0303 is based on sdk\OpenW600\demo\wm_flash_demo.c
//W600 - 0xF0000 is based on sdk\OpenW600\demo\wm_flash_demo.c
//2528 was picked based on current sizeof(mainConfig_t) which is 2016 with 512 buffer bytes.

#if defined(PLATFORM_W600) 
#define FLASH_VARS_STRUCTURE_ADDR (0xF0000 + 2528)
#else
#include "easyflash.h"
#endif
…
```

Maybe simply the "hardcoded" start in flash (FLASH_CONFIG_ADDR + 2528) prevented the enlarged config to be saved (or config "beyond" 2528 been overwritten)?
I tried with an increased value and it seems this really solves the issue, so the special case for W600 would be obsolete and the restrictions in new_pins.h (allowing e.g. no second SSID for W600 and W800) could be removed.

BTW: For W800 restriction should have been resolved some time ago when it was moved to easyflash ?!?

@divadiow kindly did some promising tests (since I don't have a W600) and I tried on W800 (reverting change to easyflash) in my testing branch https://github.com/MaxineMuster/OpenBK7231T_App/tree/_WPA%2BGUI.

But I think it would be better to "seperate" this fix from adding a new feature ...