### PR TITLE
logging: enhance logging

### DIFF
--- a/src/driver/drv_battery.c
+++ b/src/driver/drv_battery.c
@@ -22,6 +22,7 @@ static void Batt_Measure() {
 	//this command has only been tested on CBU
 	float batt_ref, batt_res, vref;
 	int writeVal = 1;
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 	ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY : Measure Battery volt en perc");
 	g_pin_adc = PIN_FindPinIndexForRole(IOR_BAT_ADC, g_pin_adc);
 	if (PIN_FindPinIndexForRole(IOR_BAT_Relay, -1) == -1 && PIN_FindPinIndexForRole(IOR_BAT_Relay_n, -1) == -1) {
@@ -147,6 +148,7 @@ commandResult_t Battery_cycle(const void* context, const char* cmd, const char* 
 
 // startDriver Battery
 void Batt_Init() {
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 
 	//cmddetail:{"name":"Battery_Setup","args":"[minbatt][maxbatt][V_divider][Vref][AD Bits]",
 	//cmddetail:"descr":"measure battery based on ADC. <br />req. args: minbatt in mv, maxbatt in mv. <br />optional: V_divider(2), Vref(default 2400), ADC bits(4096)",

--- a/src/driver/drv_doorSensorWithDeepSleep.c
+++ b/src/driver/drv_doorSensorWithDeepSleep.c
@@ -62,6 +62,7 @@ commandResult_t DoorDeepSleep_SetTime(const void* context, const char* cmd, cons
 }
 
 void DoorDeepSleep_Init() {
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 	// 0 seconds since last change
 	g_noChangeTimePassed = 0;
 
@@ -96,6 +97,7 @@ void DoorDeepSleep_QueueNewEvents() {
 
 			curr_value = CHANNEL_Get(channel);
 			if (curr_value != g_lastEventState) {
+				ADDLOGF_TIMING("%i - %s - Channel %i is being set to state %i, last state %i", xTaskGetTickCount(), __func__, channel, curr_value, g_lastEventState);
 				g_lastEventState = curr_value;
 				sprintf(sValue, "%i", curr_value); // get the value of the channel
 #if ENABLE_MQTT

--- a/src/driver/drv_ntp.c
+++ b/src/driver/drv_ntp.c
@@ -279,7 +279,8 @@ void NTP_CheckForReceive() {
     // combine the four bytes (two words) into a long integer
     // this is NTP time (seconds since Jan 1 1900):
     secsSince1900 = highWord << 16 | lowWord;
-    addLogAdv(LOG_INFO, LOG_FEATURE_NTP,"Seconds since Jan 1 1900 = %u",secsSince1900);
+	ADDLOGF_TIMING("%i - %s - Seconds since Jan 1 1900 = %u", xTaskGetTickCount(), __func__, secsSince1900);
+    ADDLOG_INFO(LOG_FEATURE_NTP,"Seconds since Jan 1 1900 = %u",secsSince1900);
 
 /*
     g_ntpTime = secsSince1900 - NTP_OFFSET;

--- a/src/driver/drv_tuyaMCU.c
+++ b/src/driver/drv_tuyaMCU.c
@@ -1272,7 +1272,7 @@ void TuyaMCU_ParseQueryProductInformation(const byte* data, int len) {
 	memcpy(name, data, useLen);
 	name[useLen] = 0;
 
-	addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "ParseQueryProductInformation: received %s\n", name);
+	ADDLOG_DEBUG(LOG_FEATURE_TUYAMCU, "ParseQueryProductInformation: received %s\n", name);
 
 	if (g_sensorMode) {
 		if (g_tuyaBatteryPoweredState == TM0_STATE_AWAITING_INFO) {
@@ -1618,7 +1618,7 @@ void TuyaMCU_ParseStateMessage(const byte* data, int len) {
 		sectorLen = data[ofs + 2] << 8 | data[ofs + 3];
 		dpId = data[ofs];
 		dataType = data[ofs + 1];
-		addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "ParseState: id %i type %i-%s len %i\n",
+		ADDLOG_DEBUG(LOG_FEATURE_TUYAMCU, "ParseState: id %i type %i-%s len %i\n",
 			dpId, dataType, TuyaMCU_GetDataTypeString(dataType), sectorLen);
 
 		mapping = TuyaMCU_FindDefForID(dpId);
@@ -1938,7 +1938,7 @@ void TuyaMCU_V0_SendDPCacheReply() {
 }
 void TuyaMCU_ParseReportStatusType(const byte *value, int len) {
 	int subcommand = value[0];
-	addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "0x%X command, subcommand 0x%X\n", TUYA_CMD_REPORT_STATUS_RECORD_TYPE, subcommand);
+	ADDLOG_DEBUG(LOG_FEATURE_TUYAMCU, "command %i, subcommand %i\n", TUYA_CMD_REPORT_STATUS_RECORD_TYPE, subcommand);
 	byte reply[2] = { 0x00, 0x00 };
 	reply[0] = subcommand;
 	switch (subcommand)
@@ -1990,7 +1990,8 @@ void TuyaMCU_ProcessIncoming(const byte* data, int len) {
 		return;
 	}
 	cmd = data[3];
-	addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "ProcessIncoming[v=%i]: cmd %i (%s) len %i\n", version, cmd, TuyaMCU_GetCommandTypeLabel(cmd), len);
+	ADDLOGF_TIMING("%i - %s - ProcessIncoming[v=%i]: cmd %i (%s) len %i", xTaskGetTickCount(), __func__, version, cmd, TuyaMCU_GetCommandTypeLabel(cmd), len);
+	ADDLOG_INFO(LOG_FEATURE_TUYAMCU, "ProcessIncoming[v=%i]: cmd %i (%s) len %i\n", version, cmd, TuyaMCU_GetCommandTypeLabel(cmd), len);
 	switch (cmd)
 	{
 	case TUYA_CMD_HEARTBEAT:
@@ -2328,7 +2329,7 @@ void TuyaMCU_PrintPacket(byte *data, int len) {
 				snprintf(buffer2, sizeof(buffer2), "%02X ", data[i]);
 				strcat_safe(buffer_for_log, buffer2, sizeof(buffer_for_log));
 			}
-			addLogAdv(LOG_INFO, LOG_FEATURE_TUYAMCU, "Received: %s\n", buffer_for_log);
+			ADDLOG_DEBUG(LOG_FEATURE_TUYAMCU, "Received: %s\n", buffer_for_log);
 #if 1
 			// redo sprintf without spaces
 			buffer_for_log[0] = 0;
@@ -2827,6 +2828,8 @@ void TuyaMCU_Init()
 	//cmddetail:"fn":"Cmd_TuyaMCU_BatteryPoweredMode","file":"driver/drv_tuyaMCU.c","requires":"",
 	//cmddetail:"examples":"tuyaMcu_batteryPoweredMode "}
 	CMD_RegisterCommand("tuyaMcu_batteryPoweredMode", Cmd_TuyaMCU_BatteryPoweredMode, NULL);
+
+	ADDLOGF_TIMING("%i - %s - Initialization of TuyaMCU", xTaskGetTickCount(), __func__);
 }
 
 

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -17,18 +17,41 @@
 void addLogAdv(int level, int feature, const char *fmt, ...);
 void LOG_SetRawSocketCallback(int newFD);
 
+#if OBK_LOG_TIMING_DISABLED
+#define ADDLOGF_TIMING(fmt, ...)
+#else
+#define ADDLOGF_TIMING(fmt, ...)  addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, fmt, ##__VA_ARGS__)
+#endif
+
+#if OBK_LOG_INFO_DISABLED
+#define ADDLOG_INFO(x, fmt, ...)
+#define ADDLOGF_INFO(fmt, ...)
+#else
+#define ADDLOG_INFO(x, fmt, ...)  addLogAdv(LOG_INFO, x, fmt, ##__VA_ARGS__)
+#define ADDLOGF_INFO(fmt, ...)  addLogAdv(LOG_INFO, LOG_FEATURE, fmt, ##__VA_ARGS__)
+#endif
+
+#if OBK_LOG_DEBUG_DISABLED
+#define ADDLOG_DEBUG(x, fmt, ...)
+#define ADDLOGF_DEBUG(fmt, ...)
+#else
+#define ADDLOG_DEBUG(x, fmt, ...) addLogAdv(LOG_DEBUG, x, fmt, ##__VA_ARGS__)
+#define ADDLOGF_DEBUG(fmt, ...) addLogAdv(LOG_DEBUG, LOG_FEATURE, fmt, ##__VA_ARGS__)
+#endif
+
+#if OBK_LOG_EXTRADEBUG_DISABLED
+#define ADDLOG_EXTRADEBUG(x, fmt, ...)
+#define ADDLOGF_EXTRADEBUG(fmt, ...)
+#else
+#define ADDLOG_EXTRADEBUG(x, fmt, ...) addLogAdv(LOG_EXTRADEBUG, x, fmt, ##__VA_ARGS__)
+#define ADDLOGF_EXTRADEBUG(fmt, ...) addLogAdv(LOG_EXTRADEBUG, LOG_FEATURE, fmt, ##__VA_ARGS__)
+#endif
+
 #define ADDLOG_ERROR(x, fmt, ...) addLogAdv(LOG_ERROR, x, fmt, ##__VA_ARGS__)
 #define ADDLOG_WARN(x, fmt, ...)  addLogAdv(LOG_WARN, x, fmt, ##__VA_ARGS__)
-#define ADDLOG_INFO(x, fmt, ...)  addLogAdv(LOG_INFO, x, fmt, ##__VA_ARGS__)
-#define ADDLOG_DEBUG(x, fmt, ...) addLogAdv(LOG_DEBUG, x, fmt, ##__VA_ARGS__)
-#define ADDLOG_EXTRADEBUG(x, fmt, ...) addLogAdv(LOG_EXTRADEBUG, x, fmt, ##__VA_ARGS__)
 
 #define ADDLOGF_ERROR(fmt, ...) addLogAdv(LOG_ERROR, LOG_FEATURE, fmt, ##__VA_ARGS__)
 #define ADDLOGF_WARN(fmt, ...)  addLogAdv(LOG_WARN, LOG_FEATURE, fmt, ##__VA_ARGS__)
-#define ADDLOGF_INFO(fmt, ...)  addLogAdv(LOG_INFO, LOG_FEATURE, fmt, ##__VA_ARGS__)
-#define ADDLOGF_DEBUG(fmt, ...) addLogAdv(LOG_DEBUG, LOG_FEATURE, fmt, ##__VA_ARGS__)
-#define ADDLOGF_EXTRADEBUG(fmt, ...) addLogAdv(LOG_EXTRADEBUG, LOG_FEATURE, fmt, ##__VA_ARGS__)
-
 
 extern int g_loglevel;
 extern char *loglevelnames[];

--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -928,10 +928,12 @@ static OBK_Publish_Result MQTT_PublishTopicToClient(mqtt_client_t* client, const
 		}
 		if (sVal_len < 128)
 		{
-			addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "Publishing val %s to %s retain=%i\n", sVal, pub_topic, retain);
+			ADDLOGF_TIMING("%i - %s - Publishing val %s to %s retain=%i", xTaskGetTickCount(), __func__, sVal, pub_topic, retain);
+			ADDLOG_INFO(LOG_FEATURE_MQTT, "Publishing val %s to %s retain=%i\n", sVal, pub_topic, retain);
 		}
 		else {
-			addLogAdv(LOG_INFO, LOG_FEATURE_MQTT, "Publishing val (%d bytes) to %s retain=%i\n", sVal_len, pub_topic, retain);
+			ADDLOGF_TIMING("%i - %s - Publishing val (%d bytes) to %s retain=%i", xTaskGetTickCount(), __func__,  sVal_len, pub_topic, retain);
+			ADDLOG_INFO(LOG_FEATURE_MQTT, "Publishing val (%d bytes) to %s retain=%i\n", sVal_len, pub_topic, retain);
 		}
 
 
@@ -1121,6 +1123,7 @@ static void mqtt_connection_cb(mqtt_client_t* client, void* arg, mqtt_connection
 	err_t err = ERR_OK;
 	const struct mqtt_connect_client_info_t* client_info = (const struct mqtt_connect_client_info_t*)arg;
 	LWIP_UNUSED_ARG(client);
+	ADDLOGF_TIMING("%i - %s - Status: %i", xTaskGetTickCount(), __func__, status);
 
 	//   addLogAdv(LOG_INFO,LOG_FEATURE_MQTT,"MQTT client < removed name > connection cb: status %d\n",  (int)status);
 	 //  addLogAdv(LOG_INFO,LOG_FEATURE_MQTT,"MQTT client \"%s\" connection cb: status %d\n", client_info->client_id, (int)status);
@@ -1232,6 +1235,7 @@ static int MQTT_do_connect(mqtt_client_t* client)
 		snprintf(mqtt_status_message, sizeof(mqtt_status_message), "mqtt_host empty, not starting mqtt");
 		return 0;
 	}
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 
 	mqtt_userName = CFG_GetMQTTUserName();
 	mqtt_pass = CFG_GetMQTTPass();

--- a/src/new_cfg.c
+++ b/src/new_cfg.c
@@ -230,6 +230,7 @@ const char *CFG_GetWebappRoot(){
 	return g_cfg.webappRoot;
 }
 const char *CFG_GetShortStartupCommand() {
+	ADDLOGF_TIMING("%i - %s - Running startup command.", xTaskGetTickCount(), __func__);
 	return g_cfg.initCommandLine;
 }
 

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -19,7 +19,7 @@
 
 // Logging defines
 // Allows timing information in ticks to be displayed
-#define OBK_LOG_TIMING_DISABLED					1
+//#define OBK_LOG_TIMING_DISABLED					1
 //#define OBK_LOG_INFO_DISABLED					1
 //#define OBK_LOG_DEBUG_DISABLED					1
 //#define OBK_LOG_EXTRADEBUG_DISABLED				1

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -17,6 +17,13 @@
 
 // Starts with all driver flags undefined
 
+// Logging defines
+// Allows timing information in ticks to be displayed
+#define OBK_LOG_TIMING_DISABLED					1
+//#define OBK_LOG_INFO_DISABLED					1
+//#define OBK_LOG_DEBUG_DISABLED					1
+//#define OBK_LOG_EXTRADEBUG_DISABLED				1
+
 // NOTE:
 // Defines for HTTP/HTMP (UI) pages: ENABLE_HTTP_*
 // Defines for drivers from drv_main.c: ENABLE_DRIVER_*

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -562,6 +562,7 @@ void Main_OnWiFiStatusChange(int code)
 	default:
 		break;
 	}
+	ADDLOGF_TIMING("%i - %s - Code: %i", xTaskGetTickCount(), __func__, code);
 	g_newWiFiStatus = code;
 }
 
@@ -1273,6 +1274,7 @@ void Main_Init_AfterDelay_Unsafe(bool bStartAutoRunScripts) {
 	}
 }
 void Main_Init_BeforeDelay_Unsafe(bool bAutoRunScripts) {
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 	g_unsafeInitDone = true;
 #ifndef OBK_DISABLE_ALL_DRIVERS
 	DRV_Generic_Init();
@@ -1426,6 +1428,7 @@ void Main_ForceUnsafeInit() {
 // power on.
 void Main_Init_Before_Delay()
 {
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 	ADDLOGF_INFO("%s", __func__);
 	// read or initialise the boot count flash area
 	HAL_FlashVars_IncreaseBootCount();
@@ -1469,6 +1472,7 @@ void Main_Init_Before_Delay()
 // (e.g. are we delayed by it reading temperature?)
 void Main_Init_Delay()
 {
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 	ADDLOGF_INFO("%s", __func__);
 	bk_printf("\r\%s\r\n", __func__);
 
@@ -1488,8 +1492,8 @@ void Main_Init_Delay()
 void Main_Init_After_Delay()
 {
 	const char* wifi_ssid, * wifi_pass;
+	ADDLOGF_TIMING("%i - %s", xTaskGetTickCount(), __func__);
 	ADDLOGF_INFO("%s", __func__);
-
 	// we can log this after delay.
 	if (bSafeMode) {
 		ADDLOGF_INFO("###### safe mode activated - boot failures %d", g_bootFailures);


### PR DESCRIPTION
- added timing lines to some routines
- added the ability to exclude timing, info, debug and extradebug code

obk_config defaults to
```
#define OBK_LOG_TIMING_DISABLED					1
```
which will disable timing information from showing.