### PR TITLE
logging: fix in tcp_log_ports declaration

### DIFF
--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -99,7 +99,7 @@ static int g_extraSocketToSendLOG = 0;
 static char g_loggingBuffer[LOGGING_BUFFER_SIZE];
 
 #define MAX_TCP_LOG_PORTS 2
-int tcp_log_ports[MAX_TCP_LOG_PORTS] = {-1};
+int tcp_log_ports[MAX_TCP_LOG_PORTS] = {-1, -1};
 
 
 void LOG_SetRawSocketCallback(int newFD)


### PR DESCRIPTION
TCP log ports were initialized as {-1, 0} which would lead to the first one being assigned and the second one being used as client_fd = 0 at least once. Might have caused problems. Not sure but I changed it to be {-1, -1}.