### PR TITLE
fix plausible regression from d491a71a938135f9, made avty disable global

### DIFF
--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -635,7 +635,7 @@ HassDeviceInfo* hass_init_device_info(ENTITY_TYPE type, int index, const char* p
 	if (DRV_IsRunning("DoorSensor") == false && DRV_IsRunning("tmSensor") == false)
 #endif
 	{
-		if (!isSensor && !flagavty) {
+		if (!flagavty) {
 			cJSON_AddStringToObject(info->root, "avty_t", "~/connected");   //availability_topic, `online` value is broadcasted
 		}
 	}


### PR DESCRIPTION
It's easier to reason about the change if we consider when the availability topic is not added.
Originally that was when `isSensor && flagavty`, that is, when an entity was considered to be a sensor _and_ flag 35 was set.
After commit d491a71a938135f9, it became `isSensor || flagavty`. That is, (A) if flag 35 is set then all entities are stripped of the availability topic and (B) even when the flag is not set, then any entity considered to be a sensor would also be stripped of the topic.
I am confident that (A) was the intent and (B) is a bug.
So, we should simply check only `flagavty`.