### PR TITLE
Refactor datetime formatting for ECR6600 platform

### DIFF
--- a/src/driver/drv_bl_shared.c
+++ b/src/driver/drv_bl_shared.c
@@ -930,8 +930,15 @@ void BL_ProcessUpdate(float voltage, float current, float power,
                 ltm->tm_year+1900, ltm->tm_mon+1, ltm->tm_mday, ltm->tm_hour, ltm->tm_min,
                 TIME_GetTimesZoneOfsSeconds()/3600, (abs(TIME_GetTimesZoneOfsSeconds())/60) % 60);
 */
+#if PLATFORM_ECR6600
+            // for ECR6000 printf("%+03i", 1); will not be "+01" but "0+1" ...
+            int ttm = TIME_GetTimesZoneOfsSeconds()/60;	// used to get +/- sign and minutes
+			snprintf(datetime, sizeof(datetime), "%.16s%c%02i:%02i",TS2STR(ConsumptionResetTime, TIME_FORMAT_ISO_8601),
+                ttm < 0 ? '-': '+', abs(ttm/60), abs(ttm) % 60);
+#else
             snprintf(datetime, sizeof(datetime), "%.16s%+03i:%02i",TS2STR(ConsumptionResetTime, TIME_FORMAT_ISO_8601),
                 TIME_GetTimesZoneOfsSeconds()/3600, (abs(TIME_GetTimesZoneOfsSeconds())/60) % 60);
+#endif
             
             MQTT_PublishMain_StringString(sensdataset->sensors[i].names.name_mqtt, datetime, 0);
           }


### PR DESCRIPTION
Try fixing bad mqtt mesage for energycounter_clear_date on ECR6600 described in #1987 