### PR TITLE
mqtt: fix to incoming callback

### DIFF
--- a/src/mqtt/new_mqtt.c
+++ b/src/mqtt/new_mqtt.c
@@ -1094,7 +1094,7 @@ static void mqtt_incoming_publish_cb(void* arg, const char* topic, u32_t tot_len
 	for (i = 0; i < numCallbacks; i++)
 	{
 		char* cbtopic = callbacks[i]->topic;
-		if (strncmp(topic, cbtopic, strlen(cbtopic)))
+		if (!strncmp(topic, cbtopic, strlen(cbtopic)))
 		{
 			strncpy(g_mqtt_request.topic, topic, sizeof(g_mqtt_request.topic) - 1);
 			g_mqtt_request.topic[sizeof(g_mqtt_request.topic) - 1] = 0;


### PR DESCRIPTION
Process an incoming topic when matched to a stored callback topic.

Previously, it processed when any callback topic didn't match the incoming topic. Which because both shortname and group topics were stored, was always.

It that what you want or should it only process when matched?
