### PR TITLE
Some fixes so Linux Simulator can also be run "standalone" with GUI:

### DIFF
--- a/src/hal/win32/hal_wifi_win32.c
+++ b/src/hal/win32/hal_wifi_win32.c
@@ -61,12 +61,21 @@ int WiFI_SetMacAddress(char *mac) {
 
 }
 void WiFI_GetMacAddress(char *mac) {
+#ifndef LINUX
 	mac[0] = 0xBA;
 	mac[1] = 0xDA;
 	mac[2] = 0x31;
 	mac[3] = 0x45;
 	mac[4] = 0xCA;
 	mac[5] = 0xFF;
+#else
+	mac[0] = 0xCA;
+	mac[1] = 0xFF;
+	mac[2] = 0xEE;
+	mac[3] = 0xCA;
+	mac[4] = 0xFF;
+	mac[5] = 0xEE;
+#endif
 }
 
 void HAL_PrintNetworkInfo() {

--- a/src/httpserver/rest_interface.c
+++ b/src/httpserver/rest_interface.c
@@ -278,9 +278,14 @@ static int http_rest_post(http_request_t* request) {
 
 static int http_rest_app(http_request_t* request) {
 	const char* webhost = CFG_GetWebappRoot();
-	const char* ourip = HAL_GetMyIPString(); //CFG_GetOurIP();
+//	const char* ourip = HAL_GetMyIPString(); //CFG_GetOurIP();
 	http_setup(request, httpMimeTypeHTML);
-	if (webhost && ourip) {
+//	if (webhost && ourip) {
+// we don't need to rely on any function here for our IP.
+// If this code is used, someone is accessing the webif, so we
+// know our ip (and port) inside the browser (JS "location").
+// Knowing/using the port from location.host is very usefull e.g. in simulator ;-) 
+	if (webhost) {
 		poststr(request, htmlDoctype);
 
 		poststr(request, "<head><title>");
@@ -289,7 +294,7 @@ static int http_rest_app(http_request_t* request) {
 
 		poststr(request, htmlShortcutIcon);
 		poststr(request, htmlHeadMeta);
-		hprintf255(request, "<script>var root='%s',device='http://%s';</script>", webhost, ourip);
+		hprintf255(request, "<script>var root='%s',device='http://'+location.host;</script>", webhost);
 		hprintf255(request, "<script src='%s/startup.js'></script>", webhost);
 		poststr(request, "</head><body></body></html>");
 	}

--- a/src/new_common.h
+++ b/src/new_common.h
@@ -42,10 +42,17 @@ extern unsigned char hexbyte(const char* hex);
 void OTA_RequestDownloadFromHTTP(const char *s);
 
 #if WINDOWS
+#ifndef LINUX
 #define DEVICENAME_PREFIX_FULL "WinTest"
 #define DEVICENAME_PREFIX_SHORT "WT"
 #define PLATFORM_MCU_NAME "WIN32"
 #define MANUFACTURER "Microsoft"
+#else
+#define DEVICENAME_PREFIX_FULL "LinuxSim"
+#define DEVICENAME_PREFIX_SHORT "LS"
+#define PLATFORM_MCU_NAME "LIN"
+#define MANUFACTURER "Linux"
+#endif
 #elif PLATFORM_XR806
 #define DEVICENAME_PREFIX_FULL "OpenXR806"
 #define DEVICENAME_PREFIX_SHORT "oxr"
@@ -207,7 +214,11 @@ This platform is not supported, error!
 // but it may not be set while doing a test build on developer PC
 #ifndef USER_SW_VER
 #ifdef WINDOWS
+#ifndef LINUX
 #define USER_SW_VER "Win_Test"
+#else
+#define USER_SW_VER "Lin_Test"
+#endif
 #elif PLATFORM_XR809
 #define USER_SW_VER "XR809_Test"
 #elif PLATFORM_XR872

--- a/src/win32/stubs/win_rtos_stub.c
+++ b/src/win32/stubs/win_rtos_stub.c
@@ -16,7 +16,9 @@
 #define DWORD uint
 
 #define SOCKET_ERROR SO_ERROR
-#define Sleep sleep
+// sleep ms, not seconds!
+//#define Sleep sleep
+#define Sleep(x) usleep((x*1000))
 #define ioctlsocket ioctl
 #define closesocket close
 #define GETSOCKETERRNO() (errno)

--- a/src/win_main.c
+++ b/src/win_main.c
@@ -24,7 +24,9 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
-#define Sleep sleep
+// sleep ms, not seconds!
+//#define Sleep sleep
+#define Sleep(x) usleep((x*1000))
 
 #endif
 
@@ -620,6 +622,10 @@ int __cdecl main(int argc, char **argv)
 
 #ifndef LINUX
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_CHECK_ALWAYS_DF);
+#else
+	// I still didn't figure out, where Init_Main is called in Windows binyry if g_selfTestsMode is 0
+	// but we need it, so commands are registered and HTTPServer_Start() is called ...
+	SIM_StartOBK(0);
 #endif
 
 	if (g_selfTestsMode)
@@ -643,15 +649,15 @@ int __cdecl main(int argc, char **argv)
 #endif
 
 	CMD_ExecuteCommand("startDriver MQTTServer", 0);
-#if 1
+#ifndef LINUX
 	CMD_ExecuteCommand("MQTTHost 192.168.0.113", 0);
 	CMD_ExecuteCommand("MqttPassword ma1oovoo0pooTie7koa8Eiwae9vohth1vool8ekaej8Voohi7beif5uMuph9Diex", 0);
 	CMD_ExecuteCommand("MqttClient WindowsOBK", 0);
 	CMD_ExecuteCommand("MqttUser homeassistant", 0);
 #else
-	CMD_ExecuteCommand("MQTTHost 192.168.0.118", 0);
-	CMD_ExecuteCommand("MqttPassword Test1", 0);
-	CMD_ExecuteCommand("MqttClient WindowsOBK", 0);
+	CMD_ExecuteCommand("MQTTHost 192.168.0.113", 0);
+	CMD_ExecuteCommand("MqttPassword ma1oovoo0pooTie7koa8Eiwae9vohth1vool8ekaej8Voohi7beif5uMuph9Diex", 0);
+	CMD_ExecuteCommand("MqttClient LinuxOBK", 0);
 	CMD_ExecuteCommand("MqttUser homeassistant", 0);
 #endif
 	CMD_ExecuteCommand("reboot", 0);


### PR DESCRIPTION
Fixed some wrong timing defines (Windows "Sleep" will sleep ms, Linux "sleep" will sleep seconds(!)). Added start of Simulator

Changed some constants so Linux sim uses an own MAC, device name ...

Also fixed Web-App code not to rely on "ourip" ( HAL_GetMyIPString(); ) which won't work on all platforms and will ignore port by using JavaScript "location.host" which (since we are using the webif) is known and even containing a non standard port, useful together with simulators "-port" option.

Now Linux Simulator runs with webif:

<img width="824" height="804" alt="grafik" src="https://github.com/user-attachments/assets/00ed2bee-8a53-4dd4-bff6-7d5ccd21a807" />
<img width="824" height="804" alt="grafik" src="https://github.com/user-attachments/assets/ef44a453-af3e-48ea-bb08-0b60bcdc65d2" />

And even with a non standard port, WebApp is loading:

<img width="1438" height="1220" alt="grafik" src="https://github.com/user-attachments/assets/300562b9-8bb7-46a5-bd2f-d184399eccdf" />
