### PR TITLE
Adding new command setPinUsedString(int index, const char *str)

### DIFF
--- a/src/driver/drv_aht2x.c
+++ b/src/driver/drv_aht2x.c
@@ -180,7 +180,7 @@ commandResult_t AHT2X_Reinit(const void* context, const char* cmd, const char* a
 	return CMD_RES_OK;
 }
 
-// startDriver AHT2X 4 5 3 4
+// startDriver AHT2X <clk pin> <sda pin> <channel temperature> <channel humidity>
 void AHT2X_Init()
 {
 	g_softI2C.pin_clk = Tokenizer_GetPin(1, 9);
@@ -188,8 +188,20 @@ void AHT2X_Init()
 	channel_temp = Tokenizer_GetArgIntegerDefault(3, -1);
 	channel_humid = Tokenizer_GetArgIntegerDefault(4, -1);
 
+/*
+// maybe later if extended tokenizer is accepted
+	// test, if extended arguments are present
+	g_softI2C.pin_clk   = Tokenizer_GetPinEqual("SCL",    g_softI2C.pin_clk);
+	g_softI2C.pin_data  = Tokenizer_GetPinEqual("SDA",    g_softI2C.pin_data);
+	channel_temp  = Tokenizer_GetArgEqualInteger("chan_t", channel_temp);
+	channel_humid = Tokenizer_GetArgEqualInteger("chan_h", channel_humid);
+*/
+
 	Soft_I2C_PreInit(&g_softI2C);
 	rtos_delay_milliseconds(100);
+	setPinUsedString(g_softI2C.pin_clk, "AHT2X SCL");
+	setPinUsedString(g_softI2C.pin_data, "AHT2X SDA");
+
 
 	AHT2X_Initialization();
 

--- a/src/driver/drv_local.h
+++ b/src/driver/drv_local.h
@@ -313,3 +313,8 @@ void LTR_AppendInformationToHTTPIndexPage(http_request_t* request, int bPreState
 void TinyIR_NEC_Init();
 void TinyIR_NEC_Deinit();
 void TinyIR_NEC_RunFrame();
+
+// show pins w/o own IORole as "used" in config page
+// implemented in http_fns.c
+int setPinUsedString(int index, const char *str);
+

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -208,6 +208,39 @@ int http_fn_testmsg(http_request_t* request) {
 
 }
 
+// START add code to show pins in use py driver w/o IORole
+// array to hold possible used function names
+char *pinUsedName[PLATFORM_GPIO_MAX];
+
+// Function to set the string in the pinUsedName array
+int setPinUsedString(int index, const char *str) {
+    if (index < 0 || index >= IOR_Total_Options) {
+        return -1; // Return an error if index is out of bounds
+    }
+
+    // If setting to NULL, free existing memory
+    if (str == NULL) {
+        if (pinUsedName[index] != NULL) {
+            free(pinUsedName[index]); // Free the existing string
+            pinUsedName[index] = NULL; // Reset to NULL
+        }
+    } else {
+        // Allocate memory for the string and copy it into the array
+        // We could use MAX_STRING_LENGTH to limit the string length if needed
+        pinUsedName[index] = malloc((strlen(str) + 1) * sizeof(char)); // +1 for the null terminator
+        if (pinUsedName[index]) {
+            strcpy(pinUsedName[index], str);
+        } else {
+            return -1; // Allocation error
+        }
+    }
+
+    return 0; // Success
+}
+
+
+// END add code to show pins in use py driver w/o IORole
+
 #if ENABLE_TIME_PMNTP
 // poor mans NTP
 int http_fn_pmntp(http_request_t* request) {
@@ -2977,6 +3010,17 @@ int http_fn_cfg_pins(http_request_t* request) {
 		"d.className = \"hdiv\";"
 		"d.innerHTML = \"<span class='disp-inline' style='min-width: 15ch'>\"+alias+\"</span>\";"
 		"f.appendChild(d);"
+		"var y = document.createElement(\"input\");"
+// START add code to show pins in use py driver w/o IORole
+		"if (typeof c =='string'){"
+		"y.disabled = true;"
+		"y.value='Pin '+id+' used by '+c;"
+		"y.style.color='dimgray';"
+		"y.style.width='56%';"
+		"d.appendChild(y);"
+		"return;"
+		"}"
+// END add code to show pins in use py driver w/o IORole
 		"let s = document.createElement(\"select\");"
 		"s.className = \"hele\";"
 		"s.name = id;"
@@ -2989,7 +3033,6 @@ int http_fn_cfg_pins(http_request_t* request) {
 		"	o.selected = (sr[i][1] == c);"
 		"s.add(o);s.onchange = hide_show;"
 		"}"
-		"var y = document.createElement(\"input\");"
 		"y.className = \"hele\";"
 		"y.name = \"r\"+id;"
 		"y.id = \"r\"+id;"
@@ -3035,7 +3078,15 @@ int http_fn_cfg_pins(http_request_t* request) {
 		else {
 			hprintf255(request, "P%i ", i);
 		}
-		hprintf255(request, "\",%i,%i, %i,", i, si, !bCanThisPINbePWM);
+//		hprintf255(request, "\",%i,%i, %i,", i, si, !bCanThisPINbePWM);
+// START changed code to show pins in use py driver w/o IORole
+		hprintf255(request, "\",%i,", i);
+		if (pinUsedName[i]){
+			hprintf255(request, "'%s',", pinUsedName[i]);
+		} else {
+			hprintf255(request, "%i, %i,", si, !bCanThisPINbePWM);
+		}
+// END changed code to show pins in use py driver w/o IORole
 		// Primary linked channel
 		int NofC = PIN_IOR_NofChan(si);
 		if (NofC >= 1)


### PR DESCRIPTION
If I use a driver without an own "IORole" selectable in config page, the usage is not shown there.

`startdriver aht2x 10 11 3 4`

will show:
<img width="811" height="1505" alt="Bildschirmfoto vom 2026-03-14 18-30-45" src="https://github.com/user-attachments/assets/6090b083-3a08-497a-8136-e084089a066f" />


My idea is to show the usage by introducing a new command

`setPinUsedString(int index, const char *str)`

which will show the pin as "used" in cfg config page, even if there is no "IORole" for this driver.

Sample usage in AHT2x:

```
	setPinUsedString(g_softI2C.pin_clk, "AHT2X SCL");
	setPinUsedString(g_softI2C.pin_data, "AHT2X SDA");

```
which will show (for `startdriver aht2x 10 11 3 4` as above)

"Pin 10 used by AHT2X SCL" / "Pin 11 used by AHT2X SDA"

<img width="811" height="1505" alt="Bildschirmfoto vom 2026-03-14 18-31-56" src="https://github.com/user-attachments/assets/1197e68d-c98c-458e-9ae0-b8794d5f0d70" />

