### PR TITLE
json: fix full-length matching for SENSOR and MQTTClient reply branches

### DIFF
--- a/src/httpserver/json_interface.c
+++ b/src/httpserver/json_interface.c
@@ -1006,7 +1006,7 @@ int JSON_ProcessCommandReply(const char* cmd, const char* arg, void* request, js
 		}
 #endif
 	}
-	else if (!wal_strnicmp(cmd, "SENSOR", 5)) {
+	else if (!wal_strnicmp(cmd, "SENSOR", 6)) {
 		// not a Tasmota command, but still required for us
 		http_tasmota_json_status_SNS(request, printer, false);
 #if ENABLE_MQTT
@@ -1124,7 +1124,7 @@ int JSON_ProcessCommandReply(const char* cmd, const char* arg, void* request, js
 		printer(request, "}");
 	}
 #endif
-	else if (!wal_strnicmp(cmd, "MQTTClient", 8)) {
+	else if (!wal_strnicmp(cmd, "MQTTClient", 10)) {
 		printer(request, "{");
 		JSON_PrintKeyValue_String(request, printer, "MQTTClient", CFG_GetMQTTClientId(), false);
 		printer(request, "}");


### PR DESCRIPTION
This tightens two reply-path command matches in json_interface.c:

- SENSOR: compare length 5 -> 6
- MQTTClient: compare length 8 -> 10

Before this change, truncated prefixes such as SENSO and MQTTCli could still match the JSON reply branches even though command execution itself uses full-name lookup. That could make malformed commands appear accepted during HTTP/MQTT testing.

This patch keeps normal documented command usage unchanged and only removes accidental truncated-prefix matches.