### PR TITLE
Fixing bug that causes cool emulated LED with RGB to be way to dimm, when smooth transition is enabled.

### DIFF
--- a/src/cmnds/cmd_newLEDDriver.c
+++ b/src/cmnds/cmd_newLEDDriver.c
@@ -262,8 +262,7 @@ void LED_I2CDriver_WriteRGBCW(float* finalRGBCW) {
 			// the format is RGBCW
 			// Emulate C with RGB
 			LED_CalculateEmulatedCool(finalRGBCW[3], finalRGBCW);
-			// C is unused
-			finalRGBCW[3] = 0;
+			// keep C unchanged, because it is the lerp value for emulated cool LED
 			// keep W unchanged
 		}
 	}


### PR DESCRIPTION
Issue:
When smooth transition (flag 18) and emulate cool white with RGB (flag 24) are enabled, cool lighting is extremely dim.

Resolution:
Not setting the C Channel of RGBCW to 0 on every update.

Explanation:
In cmd_newLEDDriver.c:409 the lerp value array is given to LED_I2CDriver_WriteRGBCW.
The lerp value represents the current state of all led colors (RGBCW) in the color fade.
However the LED_I2CDriver_WriteRGBCW currently sets array[3] (C-Channel) to 0, which in turn causes the current lerp value of the cool LED Channel to be set to 0 in every Tick. This causes current lerp to be 5 after lerp adjustment in LED_RunQuickColorLerp.