### PR TITLE
Fix format-string misuse in logging.c

### DIFF
--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -382,7 +382,7 @@ void addLogAdv(int level, int feature, const char* fmt, ...)
 	tmp[len++] = '\n';
 	tmp[len] = '\0';
 #if WINDOWS
-	printf(tmp);
+	printf("%s", tmp);
 #endif
 	// This is used by HTTP console
 	if (g_log_alsoPrintToHTTP) {


### PR DESCRIPTION
Replace printf(tmp); with printf("%s", tmp); in the Windows logging path. The ASAN build log shows this exact call site triggers -Wformat-security and an ASAN printf interceptor warning when % appears in log text. tmp is an already-formatted buffer, so it should be printed as a string argument rather than used as the format string.

`AddressSanitizer: WARNING: unexpected format specifier in printf interceptor: %`