### PR TITLE
adds safety watchdog for led thermal throttling

### DIFF
--- a/platforms/obk_main.cmake
+++ b/platforms/obk_main.cmake
@@ -51,6 +51,7 @@ set(OBKM_SRC
 	${OBK_SRCS}new_ping.c
 	${OBK_SRCS}new_pins.c
 	${OBK_SRCS}rgb2hsv.c
+	${OBK_SRCS}safety/safety.c
 	${OBK_SRCS}tiny_crc8.c
 	${OBK_SRCS}httpclient/http_client.c
 	${OBK_SRCS}httpclient/utils_net.c

--- a/platforms/obk_main.mk
+++ b/platforms/obk_main.mk
@@ -66,6 +66,7 @@ OBKM_SRC  += $(OBK_SRCS)new_common.c
 OBKM_SRC  += $(OBK_SRCS)new_ping.c
 OBKM_SRC  += $(OBK_SRCS)new_pins.c
 OBKM_SRC  += $(OBK_SRCS)rgb2hsv.c
+OBKM_SRC  += $(OBK_SRCS)safety/safety.c
 OBKM_SRC  += $(OBK_SRCS)tiny_crc8.c
 OBKM_SRC  += $(OBK_SRCS)httpclient/http_client.c
 OBKM_SRC  += $(OBK_SRCS)httpclient/utils_net.c

--- a/src/hal/espidf/hal_main_espidf.c
+++ b/src/hal/espidf/hal_main_espidf.c
@@ -17,7 +17,6 @@ void Main_OnEverySecond();
 void HAL_BTProxy_PreInit(void);
 void HAL_BTProxy_OnEverySecond(void);
 #endif
-float g_wifi_temperature = 0;
 
 #if !CONFIG_IDF_TARGET_ESP32 && !PLATFORM_ESP8266
 

--- a/src/hal/ln882h/hal_main_ln882h.c
+++ b/src/hal/ln882h/hal_main_ln882h.c
@@ -1,5 +1,6 @@
 #if PLATFORM_LN882H || PLATFORM_LN8825
 
+#include "../../new_common.h"
 #include "osal/osal.h"
 #include "utils/debug/log.h"
 #include "wifi.h"
@@ -34,7 +35,6 @@
 #endif
 
 static OS_Thread_t g_usr_app_thread;
-float g_wifi_temperature = 0.0f;
 
 extern void Main_Init();
 extern void Main_OnEverySecond();
@@ -49,6 +49,7 @@ void usr_app_task_entry(void *params)
 
 	int8_t cap_comp = 0;
 	uint16_t adc_val = 0;
+	float new_wifi_temperature;
 
 	if(NVDS_ERR_OK == ln_nvds_get_xtal_comp_val((uint8_t*)&cap_comp))
 	{
@@ -68,7 +69,8 @@ void usr_app_task_entry(void *params)
 	{
 		adc_val = HAL_ADC_Read(HAL_TEMP_ADC);
 		wifi_do_temp_cal_period(adc_val);
-		g_wifi_temperature = (25 + ((adc_val & 0xFFF) - 770) / 2.54f);
+		new_wifi_temperature = (25 + ((adc_val & 0xFFF) - 770) / 2.54f);
+		g_wifi_temperature = (0.8 * g_wifi_temperature) + (0.2 * new_wifi_temperature); // low pass IIR filter to smooth out readings
 		OS_MsDelay(1000);
 		Main_OnEverySecond();
 	}

--- a/src/hal/realtek/rtl8721da/hal_main_rtl8721da.c
+++ b/src/hal/realtek/rtl8721da/hal_main_rtl8721da.c
@@ -19,7 +19,6 @@ __attribute__((weak)) flash_t flash;
 
 #if PLATFORM_RTL8720E
 
-extern float g_wifi_temperature;
 void temp_func(void* pvParameters)
 {
 	RCC_PeriphClockCmd(APBPeriph_ATIM, APBPeriph_ATIM_CLOCK, ENABLE);

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -427,6 +427,7 @@
 #define ENABLE_DRIVER_HUE						1
 #define ENABLE_DRIVER_DHT						1
 #define ENABLE_LITTLEFS							1
+#define ENABLE_SAFETY							1
 //#define ENABLE_TEST_COMMANDS					1
 #define ENABLE_EXPAND_CONSTANT					1
 #define ENABLE_DRIVER_OPENWEATHERMAP			1

--- a/src/safety/safety.c
+++ b/src/safety/safety.c
@@ -1,0 +1,77 @@
+/* Copyright 2026 kamilsss655
+ * https://github.com/kamilsss655
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+#include "safety.h"
+#include "../cmnds/cmd_public.h"
+#include "../logging/logging.h"
+#include "../new_common.h"
+
+static const float MAX_TEMP = 95.0; 		    	  		  // any temperature higher than this will enable thermal throttling (60.0-130.0C)
+static const int LED_THROTTLE_STEP_SMALL = 1;    			  // percentage throttle small step for the LED dimmer (1-100%)
+static const int LED_THROTTLE_STEP_BIG = 5;      			  // percentage throttle big step for the LED dimmer (1-100%)
+static const int LED_THROTTLE_PERIOD = 15;        			  // seconds between each throttling step (1-1000s)
+
+static int ledThrottleCountdownSeconds = LED_THROTTLE_PERIOD; // countdown to next led throttle step
+
+#if ENABLE_SAFETY
+void SAFETY_OnEverySecond()
+{
+	#if ENABLE_LED_BASIC
+	led_safety_tick_1s();
+	// other device types can be defined here
+	#endif
+}
+
+// led related safety invoked every second
+static void led_safety_tick_1s(void)
+{
+	// if led is overheated and on
+	if(g_wifi_temperature > MAX_TEMP && LED_GetEnableAll())
+	{
+		if(ledThrottleCountdownSeconds > 0) // if it is too soon to throttle
+		{
+			ledThrottleCountdownSeconds--; // countdown until next throttle step down
+		}
+		else
+		{	
+			led_throttle_brightness(); // throttle the led
+			ledThrottleCountdownSeconds = LED_THROTTLE_PERIOD; // start the countdown again
+		}
+	}
+}
+
+// throttle led brightness based on current conditions
+static void led_throttle_brightness(void)
+{
+	int brightness = LED_GetDimmer(); // get current brightness 0-100
+	int new_brightness = 0; // target brightness
+	float temp_overshoot = (g_wifi_temperature > MAX_TEMP) ? (g_wifi_temperature - MAX_TEMP) : 0.0f; // calculate temperature overshoot
+
+	if(temp_overshoot > 0.0f && temp_overshoot <= 5.0) {
+		new_brightness = (brightness > LED_THROTTLE_STEP_SMALL) ? (brightness - LED_THROTTLE_STEP_SMALL) : 0; // if overshoot is small - use small steps
+	}
+	else if (temp_overshoot > 5.0 && temp_overshoot <= 20.0) {
+		new_brightness = (brightness > LED_THROTTLE_STEP_BIG) ? (brightness - LED_THROTTLE_STEP_BIG) : 0; // if overshoot is big - use big steps
+	}
+    else if (temp_overshoot > 20.0)
+	{
+		new_brightness = 0; // if overshoot is huge set brightness to 0 - emergency shutdown
+	}
+
+	LED_SetDimmer(new_brightness);
+	addLogAdv (LOG_WARN, LOG_FEATURE_EVENT, "Temp reached: %.2f. Max temp: %.2f. Throttling dimmer to: %i", g_wifi_temperature, MAX_TEMP, new_brightness);
+}
+#endif

--- a/src/safety/safety.c
+++ b/src/safety/safety.c
@@ -19,10 +19,12 @@
 #include "../logging/logging.h"
 #include "../new_common.h"
 
-static const float MAX_TEMP = 95.0; 		    	  		  // any temperature higher than this will enable thermal throttling (60.0-130.0C)
-static const int LED_THROTTLE_STEP_SMALL = 1;    			  // percentage throttle small step for the LED dimmer (1-100%)
-static const int LED_THROTTLE_STEP_BIG = 5;      			  // percentage throttle big step for the LED dimmer (1-100%)
-static const int LED_THROTTLE_PERIOD = 15;        			  // seconds between each throttling step (1-1000s)
+#define LED_THROTTLE_PERIOD 15        	      // seconds between each throttling step (1-1000s)
+
+											  // idea: these can probably be made configurable by user in the future:
+static const float MAX_TEMP = 95.0; 		  // any temperature higher than this will enable thermal throttling (60.0-130.0C)
+static const int LED_THROTTLE_STEP_SMALL = 1; // percentage throttle small step for the LED dimmer (1-100%)
+static const int LED_THROTTLE_STEP_BIG = 5;   // percentage throttle big step for the LED dimmer (1-100%)
 
 static int ledThrottleCountdownSeconds = LED_THROTTLE_PERIOD; // countdown to next led throttle step
 

--- a/src/safety/safety.c
+++ b/src/safety/safety.c
@@ -18,6 +18,7 @@
 #include "../cmnds/cmd_public.h"
 #include "../logging/logging.h"
 #include "../new_common.h"
+#if ENABLE_SAFETY
 
 #define LED_THROTTLE_PERIOD 15        	      // seconds between each throttling step (1-1000s)
 
@@ -28,7 +29,6 @@ static const int LED_THROTTLE_STEP_BIG = 5;   // percentage throttle big step fo
 
 static int ledThrottleCountdownSeconds = LED_THROTTLE_PERIOD; // countdown to next led throttle step
 
-#if ENABLE_SAFETY
 void SAFETY_OnEverySecond()
 {
 	#if ENABLE_LED_BASIC

--- a/src/safety/safety.h
+++ b/src/safety/safety.h
@@ -1,0 +1,3 @@
+void SAFETY_OnEverySecond(void);
+static void led_safety_tick_1s(void);
+static void led_throttle_brightness(void);

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -22,6 +22,11 @@
 // overall config variables for app - like ENABLE_LITTLEFS
 #include "obk_config.h"
 
+// Safety supervisor - thermal throttling, etc
+#if ENABLE_SAFETY
+#include "safety/safety.h"
+#endif
+
 #include "httpserver/new_http.h"
 #include "httpserver/http_fns.h"
 #include "new_pins.h"
@@ -718,13 +723,8 @@ bool Main_HasFastConnect() {
 	}
 	return false;
 }
-#if PLATFORM_LN882H || PLATFORM_ESPIDF || PLATFORM_ESP8266 || PLATFORM_LN8825
-// Quick hack to display LN-only temperature,
-// we may improve it in the future
-extern float g_wifi_temperature;
-#else
-float g_wifi_temperature = 0;
-#endif
+// declare and define global var ONCE!
+float g_wifi_temperature = 0.0f;
 
 static byte g_secondsSpentInLowMemoryWarning = 0;
 void Main_OnEverySecond()
@@ -809,6 +809,9 @@ void Main_OnEverySecond()
 #endif
 #if ENABLE_LED_BASIC
 	LED_RunOnEverySecond();
+#endif
+#if ENABLE_SAFETY
+	SAFETY_OnEverySecond();
 #endif
 #ifndef OBK_DISABLE_ALL_DRIVERS
 	DRV_OnEverySecond();


### PR DESCRIPTION
Closes: https://github.com/openshwprojects/OpenBK7231T_App/issues/2054

Tested this with 3 different bulbs, it works really well. My stronger bulbs are throttled less, than the ones that get hot more easily. The constants I've added are sane defaults that I think make sense for the model I tested with, however ideally these could be configured by users themselves. I didn't dive into config implementation so I didn't want it to be part of this PR.

I've enabled it only for LN882H, because that's what I could test with. However it likely could work with other platforms as well.

Notes:
- Additionally I fixed multiple re-definitions of `g_wifi_temperature` - as including `new_common.h` is sufficient and proper approach IMO
- Added low pass IIR filter to LN882H temp readings to smooth it out
  - you might consider porting it to all the other sensors as it really smooths out the signal and helps the throttling algorithm 

Please let me know if you have any questions/suggestions.