### PR TITLE
Log start2 lfs

### DIFF
--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -8,6 +8,13 @@
 // Commands register, execution API and cmd tokenizer
 #include "../cmnds/cmd_public.h"
 
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+#include "../littlefs/our_lfs.h"
+#include "../new_cfg.h"	// we will use CFG_Set_log2lfs();
+// uptime counter - seconds since boot to know how long to logg to LFS
+extern int g_secondsElapsed;
+#endif
+
 #if PLATFORM_BEKEN_NEW
 #include "uart.h"
 #include "arm_arch.h"
@@ -15,6 +22,7 @@
 #endif
 
 extern uint8_t g_StartupDelayOver;
+
 
 int g_loglevel = LOG_INFO; // default to info
 unsigned int logfeatures = (
@@ -128,6 +136,7 @@ static struct tag_logMemory {
 	int tailserial;
 	int tailtcp;
 	int tailhttp;
+	int taillfs;
 	SemaphoreHandle_t mutex;
 } logMemory;
 
@@ -224,10 +233,41 @@ SetFlag 31 1
 logPort 1 
 */
 
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+// forward declaration - we'll need function here
+static void LOG_LFS_StartThread(const char *prefix);
+
+static commandResult_t CMD_logStartup2lfs(const void* context, const char* cmd, const char* args, int cmdFlags) {
+	Tokenizer_TokenizeString(args, 0);
+	uint8_t secs = (uint8_t)Tokenizer_GetArgIntegerDefault(0,10);
+	if (secs > LOG2LFS_MAX_SECONDS) {
+		ADDLOG_ERROR(LOG_FEATURE_CMD, "log2lfs: Seconds out of range. Set seconds to maximum value %i",LOG2LFS_MAX_SECONDS);
+		secs = LOG2LFS_MAX_SECONDS;
+	}
+	uint8_t repeats = (uint8_t)Tokenizer_GetArgIntegerDefault(1,1);
+	if (repeats > LOG2LFS_MAX_REPEATS) {
+		ADDLOG_ERROR(LOG_FEATURE_CMD, "log2lfs: Repeats out of range. Set repeats to maximum value %i",LOG2LFS_MAX_REPEATS);
+		repeats = LOG2LFS_MAX_REPEATS;
+	}
+	CFG_Set_log2lfs(LOG2LFS_ENCODE(secs,repeats));
+	CFG_Save_IfThereArePendingChanges();
+	return CMD_RES_OK;
+}
+
+void initLog2LFS(void){
+	// since logging will be called beforeflash config is initialized, we can get
+	// information, if we should log startup to LFS, not at init
+	// so we need a separate function to set this up if logStartup2lfs is configureded
+	// if so, g_log2lfs will hold the numbers of seconds to log to LFS
+	if (g_log2lfs >0 && g_secondsElapsed < g_log2lfs) {
+		LOG_LFS_StartThread("startupLog");
+	}
+}
+#endif
 static void initLog(void)
 {
 	bk_printf("Entering initLog()...\r\n");
-	logMemory.head = logMemory.tailserial = logMemory.tailtcp = logMemory.tailhttp = 0;
+	logMemory.head = logMemory.tailserial = logMemory.tailtcp = logMemory.tailhttp = logMemory.taillfs = 0;
 	logMemory.mutex = xSemaphoreCreateMutex();
 	initialised = 1;
 	startSerialLog();
@@ -254,6 +294,13 @@ static void initLog(void)
 	//cmddetail:"fn":"log_command","file":"logging/logging.c","requires":"",
 	//cmddetail:"examples":""}
 	CMD_RegisterCommand("logdelay", log_command, NULL);
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+	//cmddetail:{"name":"logStartup2lfs","args":"[Seconds - default: 10s] [repetitions - default 1]",
+	//cmddetail:"descr":"Enable startup logging to LittleFS. Value is the number of seconds from boot during which log lines are appended to startupLog_N.txt on LFS. Set to 0 to disable.\nIf you want to log severals startups, use optional repeats argument",
+	//cmddetail:"fn":"log_command","file":"logging/logging.c","requires":"",
+	//cmddetail:"examples":"logStartup2lfs 15"}
+	CMD_RegisterCommand("logStartup2lfs", CMD_logStartup2lfs, NULL);
+#endif
 #if PLATFORM_BEKEN || PLATFORM_LN882H
 	//cmddetail:{"name":"logport","args":"[Index]",
 	//cmddetail:"descr":"Allows you to change log output port. On Beken, the UART1 is used for flashing and for TuyaMCU/BL0942, while UART2 is for log. Sometimes it might be easier for you to have log on UART1, so now you can just use this command like backlog uartInit 115200; logport 1 to enable logging on UART1..",
@@ -432,6 +479,10 @@ void addLogAdv(int level, int feature, const char* fmt, ...)
 		{
 			logMemory.tailhttp = (logMemory.tailhttp + 1) % LOGSIZE;
 		}
+		if (logMemory.taillfs == logMemory.head)
+		{
+			logMemory.taillfs = (logMemory.taillfs + 1) % LOGSIZE;
+		}
 	}
 
 	if (taken == pdTRUE) {
@@ -552,6 +603,134 @@ static int getHttp(char* buff, int buffsize) {
 	//printf("got tcp: %d:%s\r\n", len,buff);
 	return len;
 }
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+
+// Startup log filename, chosen when the thread first opens the file.
+static char g_lfsLogName[48] = {0};
+static const char *g_lfsLogPrefix = "startupLog"; // default name
+
+// Continuous-drain thread: mirrors log_serial_thread / log_client_thread.
+// Waits for LFS to mount, then drains logMemory.taillfs into the file in
+// small chunks until the capture window closes. Writing in a thread means
+// flash erase/program never blocks the main system or IRQ watchdog.
+// lfs_file_t is in a local struct on the heap to keep the thread stack lean.
+
+// how much to write in one chunk
+#define LOG2LFS_WRITE_CHUNK             128
+
+// after sucesfull logging, set new value for the next start:
+// set to 0, if this was the only/last logging configured
+// else set new value for next start (decrease repeat count by 1)
+void log2lfs_set_next_startup(){
+	uint8_t act = CFG_Get_log2lfs();
+	// shall we repeat logging?
+	// then set value for next startup
+	if (LOG2LFS_REPEATS(act) > 1) {
+		CFG_Set_log2lfs(LOG2LFS_DECREASE_REPEAT(act));
+	} else {
+	// not repeating? Set to 0 for next startup
+		CFG_Set_log2lfs(0);
+	}
+	ADDLOG_INFO(LOG_FEATURE_RAW, "log2lfs: Remaining logs to LFS: %i",LOG2LFS_REPEATS(act)-1);
+}
+
+// Just write to LFS until we finished writing ---
+// or writing returns an error if we filled up the whole remaining LFS
+static void log2lfs_thread(beken_thread_arg_t arg)
+{
+    char chunk[LOG2LFS_WRITE_CHUNK];
+    lfs_file_t *lf = os_malloc(sizeof(lfs_file_t));
+    int file_open = 0;
+    int n;
+
+    if (!lf) {
+        ADDLOG_ERROR(LOG_FEATURE_RAW, "log2lfs: could not allocate lfs_file_t");
+        goto done;
+    }
+
+    // Wait for LFS to become available before opening the file.
+    while (!lfs_present()) {
+// not needed if logging only on startup
+//        if (g_secondsElapsed > log2lfs_end)
+        if (g_secondsElapsed > g_log2lfs)
+                    goto done; // logging window closed before LFS ever mounted
+        rtos_delay_milliseconds(100);
+    }
+
+    int highest = -1;
+    unsigned int cnt;
+    // caution: we made cnt an unsigned int, so it won't accept "negative numbers" in sscanf (using %u instead of %d)
+    // to compare them, make sure to cast cnt to int
+    // else highest will be casted as unsigned, resulting in a huge number if it was negative!!!
+    char t = '0';
+    lfs_dir_t dir;
+    struct lfs_info info;
+    char scanfmt[32];
+    // since we might have some "timestamp" files, dont use date as number - check after the number there's the '.' from ".txt"
+    snprintf(scanfmt, sizeof(scanfmt), "%s_%%u%%ctxt", g_lfsLogPrefix);
+    if (lfs_dir_open(&lfs, &dir, "/") >= 0) {
+        while (lfs_dir_read(&lfs, &dir, &info) > 0) {
+            t = '0';
+            if (info.type == LFS_TYPE_REG &&
+                sscanf(info.name, scanfmt, &cnt, &t) == 2 &&
+                t == '.' &&
+                (int)cnt > highest) {
+                    highest = (int)cnt;
+                }
+        }
+        lfs_dir_close(&lfs, &dir);
+    }
+    snprintf(g_lfsLogName, sizeof(g_lfsLogName), "%s_%d.txt", g_lfsLogPrefix, highest + 1);
+
+    if (lfs_file_open(&lfs, lf, g_lfsLogName, LFS_O_RDWR | LFS_O_CREAT) < 0) {
+        ADDLOG_ERROR(LOG_FEATURE_RAW, "log2lfs: could not open %s", g_lfsLogName);
+        goto done;
+    }
+    file_open = 1;
+    lfs_file_seek(&lfs, lf, 0, LFS_SEEK_END);
+    ADDLOG_INFO(LOG_FEATURE_RAW, "log2lfs: writing to %s", g_lfsLogName);
+
+    // Drain taillfs continuously until the capture window closes.
+    while (g_secondsElapsed <= g_log2lfs) {
+        while ((n = getData(chunk, sizeof(chunk), &logMemory.taillfs)) > 0) {
+            if (lfs_file_write(&lfs, lf, chunk, n) < 0) {
+                ADDLOG_ERROR(LOG_FEATURE_RAW, "log2lfs: write error, stopping");
+                goto done;
+            }
+        }
+        rtos_delay_milliseconds(200);
+    }
+
+    // Final drain: capture any lines logged in the last poll interval.
+    while ((n = getData(chunk, sizeof(chunk), &logMemory.taillfs)) > 0)
+        if (lfs_file_write(&lfs, lf, chunk, n) < 0)
+            break;
+
+done:
+    if (file_open) {
+        lfs_file_close(&lfs, lf);
+        ADDLOG_INFO(LOG_FEATURE_RAW, "log2lfs: done, file closed");
+    }
+    os_free(lf);
+    log2lfs_set_next_startup();
+    g_log2lfs = 0;
+    rtos_delete_thread(NULL);
+}
+
+static void LOG_LFS_StartThread(const char *prefix)
+{
+    if (rtos_create_thread(NULL, BEKEN_APPLICATION_PRIORITY,
+            "log2lfs",
+            (beken_thread_function_t)log2lfs_thread,
+            0x800,
+            (beken_thread_arg_t)0) != kNoErr) {
+        ADDLOG_ERROR(LOG_FEATURE_RAW, "log2lfs: could not create thread");
+    } else {
+        ADDLOG_DEBUG(LOG_FEATURE_RAW, "log2lfs: created thread");
+    }
+}
+
+#endif // ENABLE_LITTLEFS && ENABLE_LOG2LFS
 
 void startLogServer() {
 #if WINDOWS
@@ -860,7 +1039,6 @@ commandResult_t log_command(const void* context, const char* cmd, const char* ar
 			result = CMD_RES_OK;
 			break;
 		}
-
 	} while (0);
 
 	return result;

--- a/src/logging/logging.c
+++ b/src/logging/logging.c
@@ -136,7 +136,9 @@ static struct tag_logMemory {
 	int tailserial;
 	int tailtcp;
 	int tailhttp;
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
 	int taillfs;
+#endif
 	SemaphoreHandle_t mutex;
 } logMemory;
 
@@ -267,7 +269,11 @@ void initLog2LFS(void){
 static void initLog(void)
 {
 	bk_printf("Entering initLog()...\r\n");
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
 	logMemory.head = logMemory.tailserial = logMemory.tailtcp = logMemory.tailhttp = logMemory.taillfs = 0;
+#else
+	logMemory.head = logMemory.tailserial = logMemory.tailtcp = logMemory.tailhttp = 0;
+#endif
 	logMemory.mutex = xSemaphoreCreateMutex();
 	initialised = 1;
 	startSerialLog();
@@ -479,10 +485,12 @@ void addLogAdv(int level, int feature, const char* fmt, ...)
 		{
 			logMemory.tailhttp = (logMemory.tailhttp + 1) % LOGSIZE;
 		}
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
 		if (logMemory.taillfs == logMemory.head)
 		{
 			logMemory.taillfs = (logMemory.taillfs + 1) % LOGSIZE;
 		}
+#endif
 	}
 
 	if (taken == pdTRUE) {

--- a/src/logging/logging.h
+++ b/src/logging/logging.h
@@ -38,6 +38,30 @@ extern char *logfeaturenames[];
 
 extern volatile int direct_serial_log;
 
+
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+// LFS (startup) logging
+#include "../driver/drv_deviceclock.h"		// for TIME_IsTimeSynced() / TIME_GetCurrentTime()
+// To enable optional clock timestamp for the LFS startup log filename if clock is set.
+#include "../libraries/obktime/obktime.h"	// for formatting time as str (TS2STR and TIME_FORMAT_SHORT)
+
+// Set to 0 to disable, or N to log for the first N seconds of uptime.
+// The log is written to "startupLog_<timestamp_or_counter>.txt" on LittleFS.
+// Controlled at runtime with the "log2lfs" command.
+extern uint8_t g_log2lfs;
+#define LOG2LFS_MAX_SECONDS 	30
+#define LOG2LFS_BASE 		(uint8_t)(LOG2LFS_MAX_SECONDS + 1)
+#define LOG2LFS_MAX_REPEATS 	(uint8_t)((255 / LOG2LFS_BASE) + 1 )		// adding 0 will mean once / one repetition
+
+// some helpers
+#define LOG2LFS_SECONDS(X) 	(uint8_t)(X % LOG2LFS_BASE)
+#define LOG2LFS_REPEATS(X) 	(uint8_t)(X / LOG2LFS_BASE + 1)
+#define LOG2LFS_ENCODE(S,R) 	(uint8_t)(S + ((R > 1) ? LOG2LFS_BASE * (R - 1) : 0))
+#define LOG2LFS_DECREASE_REPEAT(X) 	(uint8_t)(X >= (LOG2LFS_BASE) ? X - LOG2LFS_BASE : X)
+
+
+#endif
+
 typedef enum logType_e {
 	LOGTYPE_NONE,
 	LOGTYPE_DIRECT,

--- a/src/new_cfg.c
+++ b/src/new_cfg.c
@@ -789,6 +789,16 @@ uint32_t CFG_GetLFS_Size() {
 	}
 	return size;
 }
+// time to write log messages to lfs (0=disabled)
+uint8_t CFG_Get_log2lfs() {
+	return g_cfg.log2lfs;
+}
+void CFG_Set_log2lfs(uint8_t value) {
+	if(g_cfg.log2lfs != value) {
+		g_cfg.log2lfs = value;
+		g_cfg_pendingChanges++;
+	}
+}
 #endif
 
 #if MQTT_USE_TLS

--- a/src/new_cfg.h
+++ b/src/new_cfg.h
@@ -96,6 +96,8 @@ void CFG_SetWebPassword(const char *s);
 #if ENABLE_LITTLEFS
 void CFG_SetLFS_Size(uint32_t value);
 uint32_t CFG_GetLFS_Size();
+uint8_t CFG_Get_log2lfs();
+void CFG_Set_log2lfs(uint8_t value);
 #endif 
 
 #if MQTT_USE_TLS

--- a/src/new_pins.h
+++ b/src/new_pins.h
@@ -1528,35 +1528,127 @@ typedef struct mainConfig_s {
 	//pins at offs 0x0000033E
 	// 160 bytes
 	pinsState_t pins;
-	// startChannelValues at offs 0x000003DE
-	// 64 * 2
+	// pinsState_t size is PLATFORM-DEPENDENT:
+	//   D  else / default / ESP8266:               roles[32]+channels[32]+channels2[32]+channelTypes[64] = 160 bytes (0xA0)
+	//   A  W800 / BK7252 / BK7252N / XR872 / BL616: roles[48]+channels[48]+channels2[48]+channelTypes[64] = 208 bytes (0xD0)
+	//   B  ESPIDF:                                  roles[50]+channels[50]+channels2[50]+channelTypes[64] = 214 bytes (0xD6)
+	//   C  RTL8720D / RTL8721DA / RTL8720E / TXW81X: roles[64]+channels[64]+channels2[64]+channelTypes[64] = 256 bytes (0x100)
+	// All offsets AFTER this field therefore differ by platform group.
+	//
+	// startChannelValues at offset:
+	//   0x000003DE (D: else/default/ESP8266)
+	//   0x0000040E (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x00000414 (B: ESPIDF)
+	//   0x0000043E (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	short startChannelValues[CHANNEL_MAX];
-	// unused_fill at offs 0x0000045E 
-	short unused_fill; // correct alignment
-	// dgr_sendFlags at offs 0x00000460 
+	// log2lfs at offset:
+	//   0x0000045E (D: else/default/ESP8266)
+	//   0x0000048E (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x00000494 (B: ESPIDF)
+	//   0x000004BE (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
+	//
+	// log2lfs usage / meaning:
+	// 0: disabled  - else: combined number of seconds to log (for logging at startup) + number of repetitions
+	// use log2lf % LOG2LFS_BASE for "seconds to log", log2lfs / LOG2LFS_BASE for the number of startups to folow (reduce by 31 for every start, if < LOG2LFS_BASE, set to 0)
+	// for LOG2LFS_BASE 31 it's
+	// 0 : don't log
+	// 1 - 30: log (once) for 1 to 30 seconds, set to 0 afterwards
+	// 31 / 62 93 ... invalid / don't log
+	// 32 - 61 : log for (log2lfs - 31) seconds during two starts --> set to (log2lfs - 31) after logging, so one log to follow
+	// ...
+	// after logging : log2lfs =  (log2lfs >= 31) ? (log2lfs - 31) : 0
+	uint8_t log2lfs;
+	// for two byte alignment:
+	byte unused_fill; // correct alignment
+#if PLATFORM_ESPIDF
+	//   0x00000496 (for ESPIDF)
+	//		--> NOT aligned for 4 byte int
+	//		--> will be padded to 0x00000498
+	// 	so add short to make this visible !!!
+	short unused_espidf;
+#endif
+	// dgr_sendFlags at offset:
+	//   0x00000460 (D: else/default/ESP8266)
+	//   0x00000490 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x00000498 (B: ESPIDF) - now 4 byte aligned
+	//   0x000004C0 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	int dgr_sendFlags;
-	// dgr_recvFlags at offs 0x00000464 
+	// dgr_recvFlags at offset:
+	//   0x00000464 (D: else/default/ESP8266)
+	//   0x00000494 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x0000049C (B: ESPIDF)
+	//   0x000004C4 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	int dgr_recvFlags;
-	// dgr_name at offs 0x00000468
+	// dgr_name at offset:
+	//   0x00000468 (D: else/default/ESP8266)
+	//   0x00000498 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004A0 (B: ESPIDF)
+	//   0x000004C8 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	char dgr_name[16];
-	// at offs 0x478
+	// ntpServer at offset:
+	//   0x00000478 (D: else/default/ESP8266)
+	//   0x000004A8 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004B0 (B: ESPIDF)
+	//   0x000004D8 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	char ntpServer[32];
+	// cal at offset:
+	//   0x00000498 (D: else/default/ESP8266)
+	//   0x000004C8 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004D0 (B: ESPIDF)
+	//   0x000004F8 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	// 8 * 4 = 32 bytes
 	cfgPowerMeasurementCalibration_t cal;
-	// offs 0x000004B8
+	// buttonShortPress at offset:
+	//   0x000004B8 (D: else/default/ESP8266)
+	//   0x000004E8 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004F0 (B: ESPIDF)
+	//   0x00000518 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	// short press 1 means 100 ms short press time
 	// So basically unit is 0.1 second
 	byte buttonShortPress;
-	// offs 0x000004B9
+	// buttonLongPress at offset:
+	//   0x000004B9 (D: else/default/ESP8266)
+	//   0x000004E9 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004F1 (B: ESPIDF)
+	//   0x00000519 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	byte buttonLongPress;
-	// offs 0x000004BA
+	// buttonHoldRepeat at offset:
+	//   0x000004BA (D: else/default/ESP8266)
+	//   0x000004EA (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004F2 (B: ESPIDF)
+	//   0x0000051A (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	byte buttonHoldRepeat;
-	// offs 0x000004BB
+	// unused_fill1 at offset:
+	//   0x000004BB (D: else/default/ESP8266)
+	//   0x000004EB (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004F3 (B: ESPIDF)
+	//   0x000004F1 (B: ESPIDF)
+	//   0x0000051B (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	byte unused_fill1;
 
-	// offset 0x000004BC
-	unsigned long LFS_Size; // szie of LFS volume.  it's aligned against the end of OTA
+	// LFS_Size at offset:
+	//   0x000004BC (D: else/default/ESP8266)
+	//   0x000004EC (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004F4 (B: ESPIDF)
+	//   0x0000051C (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
+	// NOTE: 'unsigned long' is 4 bytes on all supported 32-bit platforms.
+	// Caution: On 64 bit platforms (like Linux simulator) compiler will use
+	// alignment to reach 0x4C0 ('unsigned long' is 8 bytes (LP64/64-bit))
+	// so the following is only valid for 32 bit targets!
+	unsigned long LFS_Size; // size of LFS volume, aligned against the end of OTA
+	// loggerFlags at offset:
+	//   0x000004C0 (D: else/default/ESP8266)
+	//   0x000004F0 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x000004F8 (B: ESPIDF)
+	//   0x00000520 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	int loggerFlags;
+// unusedSectorAB: sized per platform to keep obkStaticIP_t
+// and the fields following them aligned "identically".
+//
+// Sadly this (by incident, I suppose) doesn't align all eqal, but builds two groups:
+//	groups A, B and D:	they "land" at 0x0527 after this
+// 	group C (RTL...):	they "land" 2 bytes earlier (staticIP at 0x0525 instead of 0x0527).
+//		this is later "fixed" with the 4 byte alignment/padding for "led_corr"
 #if PLATFORM_W800 || PLATFORM_BK7252 || PLATFORM_BK7252N || PLATFORM_XR872 || PLATFORM_BL616
 	byte unusedSectorAB[51];
 #elif PLATFORM_ESPIDF
@@ -1566,42 +1658,83 @@ typedef struct mainConfig_s {
 #else    
 	byte unusedSectorAB[99];
 #endif    
+	// staticIP at offset:
+	//   0x00000527 (D: else/default/ESP8266)
+	//   0x00000527 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x00000527 (B: ESPIDF)
+	//   0x00000525 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	obkStaticIP_t staticIP;
+	// ledRemap_t (5 bytes) at offset:
+	//   0x00000537 (D: else/default/ESP8266)
+	//   0x00000537 (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x00000537 (B: ESPIDF)
+	//   0x00000535 (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X)
 	ledRemap_t ledRemap;
+	// actual offset:
+	//   0x0000053C (D: else/default/ESP8266)
+	//   0x0000053C (A: W800/BK7252/BK7252N/XR872/BL616)
+	//   0x0000053C (B: ESPIDF)
+	//   0x0000053A (C: RTL8720D/RTL8721DA/RTL8720E/TXW81X) NOT 4 byte aligend for led_corr using floats!
+	// 	--> make padding to start at 0x0000053C visible with a short
+#if PLATFORM_RTL8720D || PLATFORM_RTL8721DA || PLATFORM_RTL8720E || PLATFORM_TXW81X
+	short unused_RTL;
+#endif
+	// so from now on, all platforms are "aligned" to the same adresses
+	// led_corr_t (24 bytes) at offset:
+	//   0x0000053C
+	//
 	led_corr_t led_corr;
+	// mqtt_group at offset:
+	//   0x00000554
 	// alternate topic name for receiving MQTT commands
-	// offset 0x00000554
 	char mqtt_group[64];
-	// offs 0x00000594
+	// unused_bytefill at offset:
+	//   0x00000594
 	byte unused_bytefill[3];
-	// offs 0x00000597
+	// timeRequiredToMarkBootSuccessfull at offset:
+	//   0x00000597
 	byte timeRequiredToMarkBootSuccessfull;
-	//offs 0x00000598
+	// ping_interval at offset:
+	//   0x00000598
 	int ping_interval;
+	// ping_seconds at offset:
+	//   0x0000059C
 	int ping_seconds;
-	// 0x000005A0
+	// ping_host at offset:
+	//   0x000005A0
 	char ping_host[64];
-	// ofs 0x000005E0 (dec 1504)
-	//char initCommandLine[512];
 #define ALLOW_SSID2 1
 #define ALLOW_WEB_PASSWORD 1
+	// initCommandLine at offset:
+	//   0x000005E0 (dec 1504)
+	//char initCommandLine[512];
 	char initCommandLine[1568];
-	// offset 0x00000C00 (3072 decimal)
+	// wifi_ssid2 at offset:
+	//   0x00000C00 (3072 decimal)
 	char wifi_ssid2[64];
-	// offset 0x00000C40 (3136 decimal)
+	// wifi_pass2 at offset:
+	//   0x00000C40 (3136 decimal)
 	char wifi_pass2[68];
-	// offset 0x00000C84 (3204 decimal)
+	// webPassword at offset:
+	//   0x00000C84 (3204 decimal)
 	char webPassword[33];
-	// offset 0x00000CA5 (3237 decimal)
+	// mqtt_use_tls at offset:
+	//   0x00000CA5 (3237 decimal)
 	byte mqtt_use_tls;
-	// offset 0x00000CA6 (3238 decimal)
+	// mqtt_verify_tls_cert at offset:
+	//   0x00000CA6 (3238 decimal)
 	byte mqtt_verify_tls_cert;
-	// offset 0x00000CA7 (3239 decimal)
+	// mqtt_cert_file at offset:
+	//   0x00000CA7 (3239 decimal)
 	char mqtt_cert_file[20];
-	// offset 0x00000CBB (3259 decimal)
+	// disable_web_server at offset:
+	//   0x00000CBB (3259 decimal)
 	byte disable_web_server;
-	// offset 0x00000CBC (3260 decimal)
+	// unused at offset:
+	//   0x00000CBC (3260 decimal)
 	char unused[324];
+	// total struct size:
+	//   0x0E00 (= 3584 bytes)
 } mainConfig_t;
 
 // one sector is 4096 so it we still have some expand possibility

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -744,5 +744,12 @@
 #undef ENABLE_DRIVER_IR
 #endif
 
+
+// for testing: enable log2lfs if FLS is present
+#if ENABLE_LITTLEFS
+#define ENABLE_LOG2LFS						1
+#endif
+
+
 // closing OBK_CONFIG_H
 #endif

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -34,6 +34,12 @@
 #define ENABLE_HTTP_PING						1
 #define ENABLE_LED_BASIC						1
 
+// for debugging: Enable logging startup to LFS (only if LFS is present)
+#if ENABLE_LITTLEFS
+//#define ENABLE_LOG2LFS						1
+#endif
+
+
 #if PLATFORM_XRADIO
 
 // #define ENABLE_SEND_POSTANDGET				1
@@ -745,9 +751,9 @@
 #endif
 
 
-// for testing: enable log2lfs if FLS is present
-#if ENABLE_LITTLEFS
-#define ENABLE_LOG2LFS						1
+// ensure no log2lfs without LFS present
+#if ! ENABLE_LITTLEFS
+#undef ENABLE_LOG2LFS						1
 #endif
 
 

--- a/src/user_main.c
+++ b/src/user_main.c
@@ -36,6 +36,9 @@
 #if ENABLE_LITTLEFS
 #include "littlefs/our_lfs.h"
 #endif
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+uint8_t g_log2lfs;
+#endif
 
 
 #include "driver/drv_ntp.h"
@@ -1618,6 +1621,28 @@ void Main_Init_After_Delay()
 		}
 #endif
 		Main_Init_AfterDelay_Unsafe(true);
+#if ENABLE_LITTLEFS && ENABLE_LOG2LFS
+	// we have to wait until berry was run - it will else somewhow reinit/remount lfs and
+	// log2lfs will crash when its already writing ...
+	// defines/macros (LOG2LFS_SECONDS) included from logging.h
+	void initLog2LFS(void);	// implemented in logging.c
+	// Now CFG flash is ininitialized, immediatley check
+	// if we want startup log to be saved to LFS
+	g_log2lfs = LOG2LFS_SECONDS(CFG_Get_log2lfs());
+#if WINDOWS
+	// don't run log2lfs in selfTestMode  - it will kill LFS while
+	// log2lfs uses LFS
+	extern int g_selfTestsMode;
+	if ( g_selfTestsMode != 0) g_log2lfs = 0;
+	// uncomment for testing on Simulator: set to log first 20 seconds
+/*
+	else
+		if (g_log2lfs == 0) g_log2lfs = 20;
+*/
+#endif
+	if (g_log2lfs > 0) initLog2LFS();
+//	bk_printf("g_log2lfs=%i\r\n", g_log2lfs);
+#endif
 	}
 
 	ADDLOGF_INFO("%s done", __func__);


### PR DESCRIPTION
Implement logging of startup messages to LFS - new version of #2076:

`logStartup2lfs [optional seconds] [optional repeats]` &emsp; Enable writing startup log to lfs for this number of seconds.
&emsp;&emsp;&emsp; `seconds`:  up to 30 - default 10s
&emsp;&emsp;&emsp; `repeats`:  default only once

Disable (running and further logging to LFS ) with `logStartup2lfs 0`

Feature an be enabled (if LFS is enabled, too) with `#define ENABLE_LOG2LFS	1` in obk_config.h

Example use:
Start logging first ten seconds of messages to LFS on next start:&emsp;&emsp;`logStartup2LFS`
Log the next 3 startups to LFS for 15 seconds :&emsp;&emsp;&emsp;&emsp; &emsp;&emsp;&emsp; &emsp;&emsp;`logStartup2LFS 15 3`

<img width="2446" alt="Bildschirmfoto" src="https://github.com/user-attachments/assets/db6724a1-ec36-42d8-ba67-1601655724c7" />


Also commented mainConfig_t member addresses (often dependent on the platform) and introduced two "short" vars to make (prior "hidden/implicit") padding visible. 