### PR TITLE
Expose HTTPButtons to Home Assistant

### DIFF
--- a/src/driver/drv_httpButtons.c
+++ b/src/driver/drv_httpButtons.c
@@ -7,6 +7,7 @@
 #include "../logging/logging.h"
 #include "../hal/hal_pins.h"
 #include "../httpserver/new_http.h"
+#include "../httpserver/hass.h"
 
 typedef struct {
 	bool bEnabled;
@@ -169,6 +170,42 @@ void DRV_HTTPButtons_AddToHtmlPage(http_request_t *request) {
 
 	}
 }
+
+#if ENABLE_HA_DISCOVERY
+void DRV_HTTPButtons_OnHassDiscovery(const char *topic) {
+	int i;
+	char buttonIndex[8];
+
+	for (i = 0; i < g_buttonCount; i++) {
+		httpButton_t *bt = g_buttons[i];
+		HassDeviceInfo *dev_info;
+		const char *label;
+
+		if (bt == 0)
+			continue;
+		if (bt->bEnabled == false)
+			continue;
+		if (bt->command == 0 || bt->command[0] == 0)
+			continue;
+		if (bt->command[0] == '*')
+			continue;
+
+		label = bt->label;
+		if (label == 0 || label[0] == 0) {
+			label = "HTTP Button";
+		}
+
+		snprintf(buttonIndex, sizeof(buttonIndex), "%i", i);
+		dev_info = hass_init_button_device_info(buttonIndex, "backlog", bt->command, HASS_CATEGORY_CONFIG);
+		if (dev_info == 0)
+			continue;
+
+		cJSON_ReplaceItemInObject(dev_info->root, "name", cJSON_CreateString(label));
+		MQTT_QueuePublish(topic, dev_info->channel, hass_build_discovery_json(dev_info), OBK_PUBLISH_FLAG_RETAIN);
+		hass_free_device_info(dev_info);
+	}
+}
+#endif
 
 commandResult_t CMD_setButtonColor(const void *context, const char *cmd, const char *args, int cmdFlags) {
 	int buttonIndex;

--- a/src/driver/drv_local.h
+++ b/src/driver/drv_local.h
@@ -135,6 +135,9 @@ void OWM_AppendInformationToHTTPIndexPage(http_request_t *request, int bPreState
 void DRV_HTTPButtons_ProcessChanges(http_request_t *request);
 void DRV_HTTPButtons_AddToHtmlPage(http_request_t *request);
 void DRV_InitHTTPButtons();
+#if ENABLE_HA_DISCOVERY
+void DRV_HTTPButtons_OnHassDiscovery(const char *topic);
+#endif
 
 void CHT83XX_Init();
 void CHT83XX_OnEverySecond();

--- a/src/driver/drv_main.c
+++ b/src/driver/drv_main.c
@@ -427,7 +427,11 @@ static driver_t g_drivers[] = {
 	NULL,                                    // runQuickTick
 	NULL,                                    // stopFunction
 	NULL,                                    // onChannelChanged
+#if ENABLE_HA_DISCOVERY
+	DRV_HTTPButtons_OnHassDiscovery,        // onHassDiscovery
+#else
 	NULL,                                    // onHassDiscovery
+#endif
 	false,                                   // loaded
 	},
 #endif


### PR DESCRIPTION
<img width="1036" height="1036" alt="image" src="https://github.com/user-attachments/assets/0dcce406-7909-4c4f-8882-106d04d6a858" />
<img width="1180" height="1196" alt="image" src="https://github.com/user-attachments/assets/673177c1-3c6d-450e-91f9-b95507975793" />


startDriver httpButtons

setButtonEnabled 0 1
setButtonLabel 0 "Force power off"
setButtonCommand 0 "addRepeatingEvent 10 1 setChannel 1 1"
//setButtonColor 0 "#FF0000"

SetChannelLabel 1 PWR
SetChannelLabel 2 RESET
SetChannelLabel 3 PWR_ON

