### PR TITLE
Hide unavailable BL frequency from HA

### DIFF
--- a/src/driver/drv_bl_shared.c
+++ b/src/driver/drv_bl_shared.c
@@ -861,6 +861,7 @@ void BL_ProcessUpdate(float voltage, float current, float power,
     //in twin mode, for ix0 is last OBK_CONSUMPTION_YESTERDAY, for ix1 ,OBK_CONSUMPTION_TODAY
     if ((i > OBK_CONSUMPTION_STORED_LAST[asensdatasetix]) && (i <= OBK_CONSUMPTION__DAILY_LAST)) continue;
 #endif
+	if (isnan(sensdataset->sensors[i].lastReading)) continue;
       // send update only if there was a big change or if certain time has passed
     // Do not send message with every measurement. 
     diff = (float)sensdataset->sensors[i].lastSentValue - (float)sensdataset->sensors[i].lastReading;
@@ -992,6 +993,15 @@ void BL_Shared_Init(void) {
       sensdataset->sensors[i].noChangeFrame = 0;
       sensdataset->sensors[i].lastReading = 0;
     }
+	sensdataset->sensors[OBK_FREQUENCY].lastReading = NAN;
+#if ENABLE_BL_TWIN
+	for(i = OBK__FIRST; i <= OBK__LAST; i++)
+	{
+		sensdataset1->sensors[i].noChangeFrame = 0;
+		sensdataset1->sensors[i].lastReading = 0;
+	}
+	sensdataset1->sensors[OBK_FREQUENCY].lastReading = NAN;
+#endif
     {
 
       if (energyCounterStatsEnable == true)
@@ -1075,6 +1085,20 @@ void BL_Shared_Init(void) {
 float DRV_GetReading(energySensor_t type) 
 {
 	return (float)datasetlist[BL_SENSORS_IX_0].sensors[type].lastReading;
+}
+
+int BL_HasEnergySensorReadingEx(int asensdatasetix, energySensor_t type)
+{
+	if (asensdatasetix < 0) return false;
+	if (asensdatasetix >= BL_SENSDATASETS_COUNT) return false;
+	if (type < OBK__FIRST) return false;
+	if (type > OBK__LAST) return false;
+	return !isnan(datasetlist[asensdatasetix].sensors[type].lastReading);
+}
+
+int BL_HasEnergySensorReading(energySensor_t type)
+{
+	return BL_HasEnergySensorReadingEx(BL_SENSORS_IX_0, type);
 }
 
 #if ENABLE_BL_TWIN

--- a/src/driver/drv_public.h
+++ b/src/driver/drv_public.h
@@ -77,6 +77,8 @@ void DRV_DGR_OnLedFinalColorsChange(byte rgbcw[5]);
 
 // OBK_POWER etc
 float DRV_GetReading(energySensor_t type);
+int BL_HasEnergySensorReadingEx(int asensdatasetix, energySensor_t type);
+int BL_HasEnergySensorReading(energySensor_t type);
 energySensorNames_t* DRV_GetEnergySensorNames(energySensor_t type);
 energySensorNames_t* DRV_GetEnergySensorNamesEx(int asensdatasetix, energySensor_t type);
 bool DRV_IsMeasuringPower();

--- a/src/httpserver/hass.c
+++ b/src/httpserver/hass.c
@@ -899,6 +899,7 @@ HassDeviceInfo* hass_init_energy_sensor_device_info(int index, int asensdataseti
 	//in twin mode, for ix0 is last OBK_CONSUMPTION_YESTERDAY, for ix1 ,OBK_CONSUMPTION_TODAY
 	if ((index > OBK_CONSUMPTION_STORED_LAST[asensdatasetix]) && (index <= OBK_CONSUMPTION__DAILY_LAST)) return info;
 #endif
+	if (index == OBK_FREQUENCY && !BL_HasEnergySensorReadingEx(asensdatasetix, index)) return info;
 	info = hass_init_device_info(ENERGY_METER_SENSOR, index, NULL, NULL, asensdatasetix, NULL);
 
 	cJSON_AddStringToObject(info->root, "dev_cla", DRV_GetEnergySensorNamesEx(asensdatasetix,index)->hass_dev_class);   //device_class=voltage,current,power, energy, timestamp

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2200,14 +2200,6 @@ void doHomeAssistantDiscovery(const char* topic, http_request_t* request) {
 					discoveryQueued = true;
 				}
 			}
-			else if (i == OBK_VOLTAGE) {
-				dev_info = hass_init_sensor_device_info(FREQUENCY_SENSOR, SPECIAL_CHANNEL_OBK_FREQUENCY, -1, -1, -1);
-				if (dev_info) {
-					MQTT_QueuePublish(topic, dev_info->channel, "", OBK_PUBLISH_FLAG_RETAIN);
-					hass_free_device_info(dev_info);
-					discoveryQueued = true;
-				}
-			}
 		}
 #if ENABLE_BL_TWIN
 		//BL_SENSORS_IX_1 - mqtt hass discovery using hass_uniq_id_suffix (_b) from drv_bl_shared.c

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -2191,11 +2191,19 @@ void doHomeAssistantDiscovery(const char* topic, http_request_t* request) {
 				hass_free_device_info(dev_info);
 				discoveryQueued = true;
 			}
-			if (i == OBK_VOLTAGE) {
+			if (i == OBK_VOLTAGE && BL_HasEnergySensorReading(OBK_FREQUENCY)) {
 				//20250319 XJIKKA to simplify and save space in flash frequency together with voltage
 				dev_info = hass_init_sensor_device_info(FREQUENCY_SENSOR, SPECIAL_CHANNEL_OBK_FREQUENCY, -1, -1, -1);
 				if (dev_info) {
 					MQTT_QueuePublish(topic, dev_info->channel, hass_build_discovery_json(dev_info), OBK_PUBLISH_FLAG_RETAIN);
+					hass_free_device_info(dev_info);
+					discoveryQueued = true;
+				}
+			}
+			else if (i == OBK_VOLTAGE) {
+				dev_info = hass_init_sensor_device_info(FREQUENCY_SENSOR, SPECIAL_CHANNEL_OBK_FREQUENCY, -1, -1, -1);
+				if (dev_info) {
+					MQTT_QueuePublish(topic, dev_info->channel, "", OBK_PUBLISH_FLAG_RETAIN);
 					hass_free_device_info(dev_info);
 					discoveryQueued = true;
 				}

--- a/src/selftest/selftest_hass_discovery.c
+++ b/src/selftest/selftest_hass_discovery.c
@@ -411,7 +411,6 @@ void Test_HassDiscovery_BL0937() {
 
 	Test_VerifyForCommonPowerMeteringStuff();
 	SELFTEST_ASSERT_HAS_NOT_MQTT_JSON_SENT_ANY("homeassistant", true, 0, 0, "stat_t", "~/138/get");
-	SELFTEST_ASSERT_HAD_MQTT_PUBLISH_STR("homeassistant/sensor/Windows_Fake_BL0937_sensor_138/config", "", true);
 }
 void Test_HassDiscovery_digitalInput() {
 	const char *shortName = "DigitalInputTest";

--- a/src/selftest/selftest_hass_discovery.c
+++ b/src/selftest/selftest_hass_discovery.c
@@ -1,6 +1,7 @@
 ﻿#ifdef WINDOWS
 
 #include "selftest_local.h"
+#include "../driver/drv_bl_shared.h"
 
 void CheckForCommonVars() {
 
@@ -378,12 +379,14 @@ void Test_HassDiscovery_BL0942() {
 	CFG_SetDeviceName(fullName);
 
 	CMD_ExecuteCommand("startDriver BL0942", 0);
+	BL_ProcessUpdate(230, 0.26f, 60, 50, 0);
 	SIM_ClearMQTTHistory();
 
 	CMD_ExecuteCommand("scheduleHADiscovery 1", 0);
 	Sim_RunSeconds(10, false);
 
 	Test_VerifyForCommonPowerMeteringStuff();
+	SELFTEST_ASSERT_HAS_MQTT_JSON_SENT_ANY("homeassistant", true, 0, 0, "stat_t", "~/138/get");
 }
 void Test_HassDiscovery_BL0937() {
 	const char *shortName = "PowerMeteringFake";
@@ -407,6 +410,8 @@ void Test_HassDiscovery_BL0937() {
 	Sim_RunSeconds(10, false);
 
 	Test_VerifyForCommonPowerMeteringStuff();
+	SELFTEST_ASSERT_HAS_NOT_MQTT_JSON_SENT_ANY("homeassistant", true, 0, 0, "stat_t", "~/138/get");
+	SELFTEST_ASSERT_HAD_MQTT_PUBLISH_STR("homeassistant/sensor/Windows_Fake_BL0937_sensor_138/config", "", true);
 }
 void Test_HassDiscovery_digitalInput() {
 	const char *shortName = "DigitalInputTest";


### PR DESCRIPTION
Treat unsupported BL0937 and HLW8112 frequency as unavailable instead of publishing 0 Hz. Skip NaN metering publishes, suppress HA discovery for unavailable frequency, and clear retained special frequency discovery when absent.