### PR TITLE
BL602: import WiFi/device config injected into firmware image

### DIFF
--- a/src/hal/bl602/hal_ota_config_bl602.c
+++ b/src/hal/bl602/hal_ota_config_bl602.c
@@ -1,0 +1,123 @@
+#if PLATFORM_BL602
+
+#include "../../new_common.h"
+#include "../../new_pins.h"
+#include "../../new_cfg.h"
+#include "../../logging/logging.h"
+#include "hal_ota_config_bl602.h"
+#include <easyflash.h>
+#include <string.h>
+
+#define KV_KEY_OTA_CFG_CRC "obkcfg_crc"
+
+__attribute__((used, section(".rodata")))
+const obk_ota_config_v1_t obk_ota_config_v1 = {
+    .magic     = OBK_OTA_CONFIG_MAGIC,
+    .version   = OBK_OTA_CONFIG_VERSION,
+    .flags     = 0,
+    .total_len = sizeof(obk_ota_config_v1_t),
+};
+
+extern void InitEasyFlashIfNeeded(void);
+
+static uint32_t crc32_compute(const uint8_t *data, size_t len) {
+    uint32_t crc = 0xFFFFFFFF;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; j++)
+            crc = (crc >> 1) ^ (0xEDB88320u & -(crc & 1));
+    }
+    return ~crc;
+}
+
+static uint32_t obk_ota_config_crc32(const obk_ota_config_v1_t *cfg) {
+    obk_ota_config_v1_t tmp;
+    memcpy(&tmp, cfg, sizeof(tmp));
+    tmp.crc32 = 0;
+    return crc32_compute((const uint8_t *)&tmp, sizeof(tmp));
+}
+
+static void obk_ota_config_read(obk_ota_config_v1_t *out) {
+    volatile const uint8_t *src = (volatile const uint8_t *)&obk_ota_config_v1;
+    uint8_t *dst = (uint8_t *)out;
+    for (size_t i = 0; i < sizeof(*out); i++) {
+        dst[i] = src[i];
+    }
+}
+
+void OBK_OtaConfig_TryImport(void) {
+    obk_ota_config_v1_t cfg_storage;
+    const obk_ota_config_v1_t *cfg = &cfg_storage;
+
+    obk_ota_config_read(&cfg_storage);
+
+    addLogAdv(LOG_WARN, LOG_FEATURE_CFG,
+        "OtaCfg: block v=%d flags=0x%02x len=%d crc=0x%08x",
+        cfg->version, cfg->flags, cfg->total_len, cfg->crc32);
+
+    if (memcmp(cfg->magic, OBK_OTA_CONFIG_MAGIC "\0", 8) != 0) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: bad magic, skip");
+        return;
+    }
+    if (cfg->version != OBK_OTA_CONFIG_VERSION) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: unknown version %d, skip", cfg->version);
+        return;
+    }
+    if (!(cfg->flags & OBK_OTA_FLAG_VALID)) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: not marked valid (flags=0x%02x), skip", cfg->flags);
+        return;
+    }
+    if (cfg->total_len != sizeof(obk_ota_config_v1_t)) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: wrong total_len %d (expect %d), skip",
+            cfg->total_len, (int)sizeof(obk_ota_config_v1_t));
+        return;
+    }
+
+    uint32_t computed = obk_ota_config_crc32(cfg);
+    if (computed != cfg->crc32) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: CRC mismatch (got 0x%08x expect 0x%08x), skip",
+            computed, cfg->crc32);
+        return;
+    }
+    if (cfg->ssid_len == 0) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: empty SSID, skip import");
+        return;
+    }
+
+    InitEasyFlashIfNeeded();
+    uint32_t saved_crc = 0;
+    size_t read_len = 0;
+    ef_get_env_blob(KV_KEY_OTA_CFG_CRC, &saved_crc, sizeof(saved_crc), &read_len);
+    if (read_len == sizeof(saved_crc) && saved_crc == cfg->crc32) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: already imported (crc=0x%08x), skip", saved_crc);
+        return;
+    }
+
+    if (g_cfg.wifi_ssid[0] != 0) {
+        addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "OtaCfg: WiFi already set ('%s'), skip import", g_cfg.wifi_ssid);
+        ef_set_env_blob(KV_KEY_OTA_CFG_CRC, (void *)&cfg->crc32, sizeof(cfg->crc32));
+        return;
+    }
+
+    if (cfg->ssid_len > 0 && cfg->ssid_len < sizeof(g_cfg.wifi_ssid)) {
+        memcpy(g_cfg.wifi_ssid, cfg->ssid, cfg->ssid_len);
+        g_cfg.wifi_ssid[cfg->ssid_len] = 0;
+    }
+    if (cfg->pass_len > 0 && cfg->pass_len < sizeof(g_cfg.wifi_pass)) {
+        memcpy(g_cfg.wifi_pass, cfg->pass, cfg->pass_len);
+        g_cfg.wifi_pass[cfg->pass_len] = 0;
+    }
+    if (cfg->device_name[0] != 0) {
+        CFG_SetShortDeviceName(cfg->device_name);
+        CFG_SetDeviceName(cfg->device_name);
+    }
+
+    ef_set_env_blob(KV_KEY_OTA_CFG_CRC, (void *)&cfg->crc32, sizeof(cfg->crc32));
+    g_cfg_pendingChanges++;
+
+    addLogAdv(LOG_WARN, LOG_FEATURE_CFG,
+        "OtaCfg: IMPORTED ssid='%s' pass_len=%d name='%s'",
+        g_cfg.wifi_ssid, cfg->pass_len, g_cfg.shortDeviceName);
+}
+
+#endif // PLATFORM_BL602

--- a/src/hal/bl602/hal_ota_config_bl602.h
+++ b/src/hal/bl602/hal_ota_config_bl602.h
@@ -1,0 +1,33 @@
+#pragma once
+#if PLATFORM_BL602
+
+#include <stdint.h>
+
+#define OBK_OTA_CONFIG_MAGIC "OBKCFG1"
+#define OBK_OTA_CONFIG_VERSION 1
+
+#define OBK_OTA_FLAG_VALID    0x01
+#define OBK_OTA_FLAG_ONE_SHOT 0x02
+
+typedef struct __attribute__((packed)) {
+    char     magic[8];       // "OBKCFG1\0"
+    uint8_t  version;        // 1
+    uint8_t  flags;          // OBK_OTA_FLAG_*
+    uint16_t total_len;      // sizeof(obk_ota_config_v1_t)
+    uint32_t crc32;          // CRC32 of whole struct with this field = 0
+
+    uint8_t  ssid_len;
+    uint8_t  pass_len;
+    uint8_t  reserved0[2];
+
+    char     ssid[32];
+    char     pass[64];
+    char     device_name[32];
+    uint8_t  reserved1[128];
+} obk_ota_config_v1_t;
+
+extern const obk_ota_config_v1_t obk_ota_config_v1;
+
+void OBK_OtaConfig_TryImport(void);
+
+#endif // PLATFORM_BL602

--- a/src/new_cfg.c
+++ b/src/new_cfg.c
@@ -8,6 +8,9 @@
 #include "hal/hal_wifi.h"
 #include "hal/hal_flashConfig.h"
 #include "cmnds/cmd_public.h"
+#if PLATFORM_BL602
+#include "hal/bl602/hal_ota_config_bl602.h"
+#endif
 #if ENABLE_LITTLEFS
 #include "littlefs/our_lfs.h"
 #endif
@@ -878,5 +881,8 @@ void CFG_InitAndLoad() {
 		CFG_SetDefaultLEDCorrectionTable();
 	}
 	g_configInitialized = 1;
+#if PLATFORM_BL602
+	OBK_OtaConfig_TryImport();
+#endif
 	CFG_Save_IfThereArePendingChanges();
 }


### PR DESCRIPTION
## Summary

Adds an embedded config block in `.rodata` (magic `OBKCFG1` + CRC32) that a provisioning tool can patch into a firmware `.bin` before OTA/flash. On boot, `CFG_InitAndLoad()` imports the SSID / password / device name into the EasyFlash config — but only if:

- the block is marked valid and its CRC32 matches
- no WiFi SSID is already configured
- this exact block (by CRC) was not already imported

This lets credentials be baked into the image without a serial console or web setup step. No-op on other platforms (guarded by `PLATFORM_BL602`).

### Files
- `src/hal/bl602/hal_ota_config_bl602.c` / `.h` — the embedded block, CRC check and import logic
- `src/new_cfg.c` — calls `OBK_OtaConfig_TryImport()` at the end of `CFG_InitAndLoad()`

## Test plan
- [x] Builds and links via `make OpenBL602` (canonical build)
- [x] On a device without an injected block, boot logs `OtaCfg: not marked valid (flags=0x00), skip` and boots normally
- [ ] Patch a valid block into the image, flash, and confirm SSID/name are imported on first boot and skipped on subsequent boots