### PR TITLE
Add SuperScanner and FindSensorPower to drv_multiPinI2CScanner

### DIFF
--- a/src/driver/drv_multiPinI2CScanner.c
+++ b/src/driver/drv_multiPinI2CScanner.c
@@ -6,6 +6,7 @@
 #include "../new_cfg.h"
 #include "../new_pins.h"
 #include "../cmnds/cmd_public.h"
+#include "../hal/hal_pins.h"
 
 int g_adr = 1;
 int g_scl = 0;
@@ -72,7 +73,158 @@ void MultiPinI2CScanner_RunFrame() {
 	}
 }
 
-void MultiPinI2CScanner_Init() {
+static commandResult_t CMD_FindSensorPower(const void* context, const char* cmd, const char* args, int cmdFlags);
+static commandResult_t CMD_SuperScanner(const void* context, const char* cmd, const char* args, int cmdFlags);
 
+void MultiPinI2CScanner_Init() {
+	CMD_RegisterCommand("FindSensorPower", CMD_FindSensorPower, NULL);
+	CMD_RegisterCommand("SuperScanner", CMD_SuperScanner, NULL);
 }
 
+static commandResult_t CMD_FindSensorPower(const void* context, const char* cmd, const char* args, int cmdFlags) {
+	int i, j;
+	int sda, scl;
+	uint8_t addrs[] = {0x38, 0x40, 0x44, 0x45};
+	
+	Tokenizer_TokenizeString(args, 0);
+	if (Tokenizer_GetArgsCount() < 2) {
+		addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "Usage: FindSensorPower <sda_pin> <scl_pin>");
+		return CMD_RES_NOT_ENOUGH_ARGUMENTS;
+	}
+	sda = Tokenizer_GetArgInteger(0);
+	scl = Tokenizer_GetArgInteger(1);
+	
+	softI2C_t scanI2C;
+	scanI2C.pin_data = sda;
+	scanI2C.pin_clk = scl;
+	Soft_I2C_PreInit(&scanI2C);
+	
+	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "Starting universal sensor power brute force on SDA=%i and SCL=%i...", sda, scl);
+	
+	for (i = 0; i < 30; i++) {
+		if (i == scl || i == sda || i == 1 || i == 2) continue; // skip i2c pins and TX/RX
+		
+		HAL_PIN_Setup_Output(i);
+		HAL_PIN_SetOutputValue(i, 1);
+		rtos_delay_milliseconds(100);
+		
+		for (j = 0; j < 4; j++) {
+			uint8_t addr = addrs[j] << 1;
+			bool ack = Soft_I2C_Start(&scanI2C, addr);
+			Soft_I2C_Stop(&scanI2C);
+			
+			if (ack) {
+				// double check by reading
+				Soft_I2C_Start(&scanI2C, addr | 1);
+				uint8_t d1 = Soft_I2C_ReadByte(&scanI2C, false);
+				Soft_I2C_Stop(&scanI2C);
+				if (d1 != 0 && d1 != 0xFF) {
+					addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "SUCCESS! Sensor 0x%02X powered by GPIO %i (HIGH)! Data: %02X", addrs[j], i, d1);
+				}
+			}
+		}
+		
+		HAL_PIN_Setup_Input(i);
+		
+		// Set pin LOW (Active-Low Power)
+		HAL_PIN_Setup_Output(i);
+		HAL_PIN_SetOutputValue(i, 0);
+		rtos_delay_milliseconds(100);
+		
+		for (j = 0; j < 4; j++) {
+			uint8_t addr = addrs[j] << 1;
+			bool ack = Soft_I2C_Start(&scanI2C, addr);
+			Soft_I2C_Stop(&scanI2C);
+			
+			if (ack) {
+				// double check by reading
+				Soft_I2C_Start(&scanI2C, addr | 1);
+				uint8_t d1 = Soft_I2C_ReadByte(&scanI2C, false);
+				Soft_I2C_Stop(&scanI2C);
+				if (d1 != 0 && d1 != 0xFF) {
+					addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "SUCCESS! Sensor 0x%02X powered by GPIO %i (LOW)! Data: %02X", addrs[j], i, d1);
+				}
+			}
+		}
+		
+		HAL_PIN_Setup_Input(i);
+	}
+	
+	addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "Finished universal brute force test.");
+	return CMD_RES_OK;
+}
+
+static commandResult_t CMD_SuperScanner(const void* context, const char* cmd, const char* args, int cmdFlags) {
+    int pwr, sda, scl, j, state;
+    softI2C_t scanI2C;
+    uint8_t addrs[] = {0x38, 0x40, 0x44, 0x45};
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "Starting SUPER SCANNER. This will check 108,000 combinations. Wait 1 minute...");
+    
+    // state: 2=no power pin, 1=power pin high, 0=power pin low
+    for (state = 2; state >= 0; state--) {
+        for (pwr = -1; pwr < 30; pwr++) {
+            if (pwr == 1 || pwr == 2) continue; // skip TX/RX
+            if (state == 2 && pwr != -1) continue; // Only test pwr=-1 once
+            if (state < 2 && pwr == -1) continue;
+            
+            if (pwr != -1) {
+                HAL_PIN_Setup_Output(pwr);
+                HAL_PIN_SetOutputValue(pwr, state);
+                rtos_delay_milliseconds(50);
+            }
+            
+            for (sda = 0; sda < 30; sda++) {
+                if (sda == pwr || sda == 1 || sda == 2) continue;
+                for (scl = 0; scl < 30; scl++) {
+                    if (scl == pwr || scl == sda || scl == 1 || scl == 2) continue;
+                    
+                    scanI2C.pin_data = sda;
+                    scanI2C.pin_clk = scl;
+                    Soft_I2C_PreInit(&scanI2C);
+                    
+                    HAL_PIN_Setup_Input_Pullup(sda);
+                    HAL_PIN_Setup_Input_Pullup(scl);
+                    
+                    if (HAL_PIN_ReadDigitalInput(sda) == 0) {
+                        // Bus clear
+                        HAL_PIN_Setup_Output(scl);
+                        for(int k=0; k<18; k++) {
+                            HAL_PIN_SetOutputValue(scl, k%2);
+                            for(volatile int x=0; x<500; x++);
+                        }
+                        HAL_PIN_Setup_Input_Pullup(scl);
+                    }
+                    
+                    if (HAL_PIN_ReadDigitalInput(sda) == 0 || HAL_PIN_ReadDigitalInput(scl) == 0) continue;
+                    
+                    for (j = 0; j < 4; j++) {
+                        uint8_t addr = addrs[j] << 1;
+                        bool ack = Soft_I2C_Start(&scanI2C, addr);
+                        Soft_I2C_Stop(&scanI2C);
+                        
+                        if (ack) {
+                            Soft_I2C_Start(&scanI2C, addr | 1);
+                            uint8_t d1 = Soft_I2C_ReadByte(&scanI2C, false);
+                            Soft_I2C_Stop(&scanI2C);
+                            
+                            if (d1 != 0 && d1 != 0xFF) {
+                                if (pwr == -1) {
+                                    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "SUCCESS! Sensor 0x%02X on SDA=%i, SCL=%i! (No pwr)", addrs[j], sda, scl);
+                                } else {
+                                    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "SUCCESS! Sensor 0x%02X on SDA=%i, SCL=%i! Pwr GPIO %i (%s)", addrs[j], sda, scl, pwr, state?"HIGH":"LOW");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            
+            if (pwr != -1) {
+                HAL_PIN_Setup_Input(pwr);
+            }
+        }
+    }
+    
+    addLogAdv(LOG_INFO, LOG_FEATURE_SENSOR, "SUPER SCANNER FINISHED.");
+    return CMD_RES_OK;
+}


### PR DESCRIPTION
Title: Add SuperScanner and FindSensorPower to I2C Scanner for undocumented devices

Description: This PR introduces two powerful brute-force I2C hardware discovery commands into drv_multiPinI2CScanner.c. These tools are specifically designed to help the community reverse-engineer undocumented Tuya devices where the I2C pins (and sensor power pins) are unknown.

Often, manufacturers connect sensors (like temperature/humidity) to random GPIOs and power them dynamically via another GPIO. Finding these manually without hardware tracing is extremely tedious.

Changes
Added two new console commands registered in MultiPinI2CScanner_Init():

1. FindSensorPower <sda_pin> <scl_pin>

Purpose: Finds the dynamic power GPIO for an I2C sensor when the SDA and SCL pins are already known.
How it works: It iterates through all available GPIOs (excluding UART and the provided I2C pins). For each GPIO, it tests both Active-High and Active-Low power states. It applies the state, waits 100ms, and probes standard environmental sensor addresses (0x38, 0x40, 0x44, 0x45). If an ACK is received and valid data is read, it reports the power pin and its active state to the console.
2. SuperScanner

Purpose: A complete, hands-off brute-force discovery tool for unknown hardware.
How it works: It tests over 108,000 combinations of [Power Pin] x [SDA Pin] x [SCL Pin].
It iterates through three power states: No Power Pin, Active-High, and Active-Low.
It safely configures internal pull-ups for testing SDA/SCL pairs.
It includes I2C Bus Clear logic (if SDA is held low, it pulses SCL up to 18 times) to prevent hung buses from halting the scan.
It probes standard sensor addresses (0x38, 0x40, 0x44, 0x45) and double-checks with a dummy read to avoid false positives.
Logs the successful combination of Power, SDA, and SCL pins to the console.
Motivation
During the porting of a new undocumented generic Tuya CHT83XX sensor device (early 2026 revision), the hardware ID was reading as 0xFFFF. It turned out the I2C lines were simply floating because the default pins were incorrect and the sensor required a specific GPIO to be driven high to power on. These tools successfully brute-forced the correct pinout, saving hours of manual multimeter tracing.

Integrating this into the generic multiPinI2CScanner driver makes it available for anyone compiling with ENABLE_MULTIPINI2CSCANNER, without bloating default builds or specific sensor drivers.

All has been fully IA generated, but is tested to get running a new Tuya device. I hope it helps