### PR TITLE
IRSend: add support for sending AC state protocols (e.g. Mitsubishi)

### DIFF
--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -419,7 +419,10 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 				}
 				if (rawlen > 0 && pIRsend) {
 					pIRsend->enableIROut(freq, duty);
-					pIRsend->sendRaw(rawbuf, rawlen, freq);
+					for (int i = 0; i < rawlen; i++) {
+						if (i & 1) pIRsend->space(rawbuf[i]);
+						else pIRsend->mark(rawbuf[i]);
+					}
 					pIRsend->delay(100);
 					ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send RAW: freq %d, duty %d, %d values", (int)freq, (int)duty, rawlen);
 					return CMD_RES_OK;

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -370,6 +370,7 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 		p++;
 	}
 
+	/*IDEIGLENESEN KISZEDVE
 	if ((*p != '-') && (*p != ' ')) {
 		// try to decode "new" format, separated by comma
 		// the format is bits,0xDATA[,repeat]
@@ -381,7 +382,48 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 		{
 			*p='\0';
 			decode_type_t protocol = strToDecodeType(args);
+			p++; EDDIG EREDETI*/
+	//TESZT
+	if ((*p != '-') && (*p != ' ')) {
+		// try to decode "new" format, separated by comma
+		// the format is bits,0xDATA[,repeat]
+		char *p = args;
+		while (*p && (*p != ',')) {
 			p++;
+		}
+		if(*p==',')
+		{
+			*p='\0';
+			if (!my_strnicmp(args, "RAW", 4)) {
+				p++;
+				char *_freq = p;
+				while (*p && (*p != ',')) p++;
+				uint16_t freq = (uint16_t)strtol(_freq, NULL, 10);
+				if (*p == ',') p++;
+				uint16_t rawbuf[300];
+				int rawlen = 0;
+				while (*p && rawlen < 300) {
+					char *tokenstart = p;
+					while (*p && (*p != ',')) p++;
+					bool haveComma = (*p == ',');
+					if (haveComma) *p = '\0';
+					rawbuf[rawlen++] = (uint16_t)strtol(tokenstart, NULL, 10);
+					if (haveComma) p++;
+					else break;
+				}
+				if (rawlen > 0 && pIRsend) {
+					pIRsend->sendRaw(rawbuf, rawlen, freq);
+					pIRsend->delay(100);
+					ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send RAW: freq %d, %d values", (int)freq, rawlen);
+					return CMD_RES_OK;
+				} else {
+					ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IR send RAW: no values or no sender");
+					return CMD_RES_BAD_ARGUMENT;
+				}
+			}
+			decode_type_t protocol = strToDecodeType(args);
+			p++;
+	//TESZT
 			char *_bits=p;
 			while (*p && (*p != ',')) {
 				p++;

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -384,7 +384,7 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 			*p='\0';
 			decode_type_t protocol = strToDecodeType(args);
 			p++; EDDIG EREDETI*/
-	//TESZT
+	//TESZT kezdete
 	if ((*p != '-') && (*p != ' ')) {
 		// try to decode "new" format, separated by comma
 		// the format is bits,0xDATA[,repeat]
@@ -396,10 +396,15 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 		{
 			*p='\0';
 			if (!my_strnicmp(args, "RAW", 3)) {
+				// Format: RAW,<freq_hz>,<duty_percent>,<mark1>,<space1>,<mark2>,<space2>,...
 				p++;
 				char *_freq = p;
 				while (*p && (*p != ',')) p++;
 				uint16_t freq = (uint16_t)strtol(_freq, NULL, 10);
+				if (*p == ',') p++;
+				char *_duty = p;
+				while (*p && (*p != ',')) p++;
+				uint8_t duty = (uint8_t)strtol(_duty, NULL, 10);
 				if (*p == ',') p++;
 				uint16_t rawbuf[300];
 				int rawlen = 0;
@@ -413,9 +418,10 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 					else break;
 				}
 				if (rawlen > 0 && pIRsend) {
+					pIRsend->enableIROut(freq, duty);
 					pIRsend->sendRaw(rawbuf, rawlen, freq);
 					pIRsend->delay(100);
-					ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send RAW: freq %d, %d values", (int)freq, rawlen);
+					ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send RAW: freq %d, duty %d, %d values", (int)freq, (int)duty, rawlen);
 					return CMD_RES_OK;
 				} else {
 					ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IR send RAW: no values or no sender");
@@ -424,7 +430,7 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 			}
 			decode_type_t protocol = strToDecodeType(args);
 			p++;
-	//TESZT
+	//TESZT vége
 			char *_bits=p;
 			while (*p && (*p != ',')) {
 				p++;

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -707,7 +707,8 @@ extern "C" void DRV_IR_Init() {
 		//bk_gpio_config_input_pup((GPIO_INDEX)pin); // enabled by enableIRIn
 
 		//TODO: we should specify buffer size (now set to 1024), timeout (now 90ms) and tolerance 
-		 ourReceiver = new IRrecv(pin);
+		//ourReceiver = new IRrecv(pin);
+		 ourReceiver = new IRrecv(pin, kRawBuf, 20, false);
 		 ourReceiver->enableIRIn(pup);
 	}
 

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -360,7 +360,8 @@ extern "C" void DRV_IR_ISR(void* arg)
 
 extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, const char *args_in, int cmdFlags) {
 	if (!args_in) return CMD_RES_NOT_ENOUGH_ARGUMENTS;
-	char args[128];
+	//char args[128]; TESZTELÉS
+	char args[1024];
 	strncpy(args, args_in, sizeof(args) - 1);
 	args[sizeof(args) - 1] = 0;
 
@@ -394,7 +395,7 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 		if(*p==',')
 		{
 			*p='\0';
-			if (!my_strnicmp(args, "RAW", 4)) {
+			if (!my_strnicmp(args, "RAW", 3)) {
 				p++;
 				char *_freq = p;
 				while (*p && (*p != ',')) p++;

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -400,7 +400,17 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 						int repeats=1;
 						if(*p==',')
 							repeats=strtol(p+1,NULL,10);
-						
+					//TESZT
+						if (protocol == decode_type_t::DENON && bits == 15) {
+							uint64_t inverted = data ^ 0x3FF;
+							pIRsend->sendSharpRaw(data, 15, 0);
+							pIRsend->delay(43);
+							pIRsend->sendSharpRaw(inverted, 15, 0);
+							pIRsend->delay(100);
+							ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send DENON (2-frame): data 0x%llX inverted 0x%llX", (long long int)data, (long long int)inverted);
+							return CMD_RES_OK;
+						}
+					//TESZT	
 						if( pIRsend->send(protocol,data,bits,repeats) )
 						{
 							pIRsend->delay(100);

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -707,8 +707,7 @@ extern "C" void DRV_IR_Init() {
 		//bk_gpio_config_input_pup((GPIO_INDEX)pin); // enabled by enableIRIn
 
 		//TODO: we should specify buffer size (now set to 1024), timeout (now 90ms) and tolerance 
-		//ourReceiver = new IRrecv(pin);
-		 ourReceiver = new IRrecv(pin, kRawBuf, 10, false);
+		 ourReceiver = new IRrecv(pin);
 		 ourReceiver->enableIRIn(pup);
 	}
 

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -708,7 +708,7 @@ extern "C" void DRV_IR_Init() {
 
 		//TODO: we should specify buffer size (now set to 1024), timeout (now 90ms) and tolerance 
 		//ourReceiver = new IRrecv(pin);
-		 ourReceiver = new IRrecv(pin, kRawBuf, 20, false);
+		 ourReceiver = new IRrecv(pin, kRawBuf, 10, false);
 		 ourReceiver->enableIRIn(pup);
 	}
 

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -177,7 +177,8 @@ SpoofIrReceiver IrReceiver;
 // we simply note the numbers into a rolling buffer, assume the first is a mark()
 // and then every 50us service the rolling buffer, changing the PWM from 0 duty to 50% duty
 // appropriately.
-#define SEND_MAXBITS 128
+#undef SEND_MAXBITS
+#define SEND_MAXBITS 350
 
 class myIRsend : public IRsend {
 public:
@@ -425,6 +426,7 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 						hp += 2;
 					}
 					if (nBytes == 18) {
+						pIRsend->resetsendqueue();
 						pIRsend->sendMitsubishiAC(stateBytes, 18);
 						pIRsend->delay(100);
 						ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send MITSUBISHI_AC state, %d bytes", nBytes);

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -400,17 +400,6 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 						int repeats=1;
 						if(*p==',')
 							repeats=strtol(p+1,NULL,10);
-					//TESZT
-						if (protocol == decode_type_t::DENON && bits == 15) {
-							uint64_t inverted = data ^ 0x3FF;
-							pIRsend->sendSharpRaw(data, 15, 0);
-							pIRsend->delay(43);
-							pIRsend->sendSharpRaw(inverted, 15, 0);
-							pIRsend->delay(100);
-							ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send DENON (2-frame): data 0x%llX inverted 0x%llX", (long long int)data, (long long int)inverted);
-							return CMD_RES_OK;
-						}
-					//TESZT	
 						if( pIRsend->send(protocol,data,bits,repeats) )
 						{
 							pIRsend->delay(100);

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -178,7 +178,7 @@ SpoofIrReceiver IrReceiver;
 // and then every 50us service the rolling buffer, changing the PWM from 0 duty to 50% duty
 // appropriately.
 #undef SEND_MAXBITS
-#define SEND_MAXBITS 350
+#define SEND_MAXBITS 512
 
 class myIRsend : public IRsend {
 public:
@@ -411,34 +411,29 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 							return CMD_RES_BAD_ARGUMENT;
 						}
 					}
-				} else if (protocol == decode_type_t::MITSUBISHI_AC) {
+				} else if (hasACState(protocol)) {
 					char *_data = p;
 					if (_data[0] == '0' && (_data[1] == 'x' || _data[1] == 'X')) {
 						_data += 2;
 					}
-					uint8_t stateBytes[18];
+					uint8_t stateBytes[64];
 					int nBytes = 0;
 					char *hp = _data;
-					while (*hp && *hp != ',' && hp[1] && nBytes < 18) {
+					while (*hp && *hp != ',' && hp[1] && nBytes < 64) {
 						char hex[3] = { hp[0], hp[1], 0 };
 						stateBytes[nBytes] = (uint8_t)strtol(hex, NULL, 16);
 						nBytes++;
 						hp += 2;
 					}
-					if (nBytes == 18) {
-						pIRsend->resetsendqueue();
-						pIRsend->sendMitsubishiAC(stateBytes, 18);
+					if (nBytes > 0) {
+						pIRsend->send(protocol, stateBytes, nBytes);
 						pIRsend->delay(100);
-						ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send MITSUBISHI_AC state, %d bytes", nBytes);
+						ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send %s state, %d bytes", args, nBytes);
 						return CMD_RES_OK;
 					} else {
-						ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IR MITSUBISHI_AC state needs 18 bytes, got %d", nBytes);
+						ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IR %s state: no valid hex bytes found", args);
 						return CMD_RES_BAD_ARGUMENT;
 					}
-				} else {
-					// TODO: implement longer protocols
-					ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IRSend currently only protocol with up to 64bits are supported", args);
-					return CMD_RES_BAD_ARGUMENT;
 				}
 			} 
 		}

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -418,6 +418,7 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 					else break;
 				}
 				if (rawlen > 0 && pIRsend) {
+					pIRsend->resetsendqueue();
 					pIRsend->enableIROut(freq, duty);
 					for (int i = 0; i < rawlen; i++) {
 						if (i & 1) pIRsend->space(rawbuf[i]);

--- a/src/driver/drv_ir_new.cpp
+++ b/src/driver/drv_ir_new.cpp
@@ -410,6 +410,29 @@ extern "C" commandResult_t IR_Send_Cmd(const void *context, const char *cmd, con
 							return CMD_RES_BAD_ARGUMENT;
 						}
 					}
+				} else if (protocol == decode_type_t::MITSUBISHI_AC) {
+					char *_data = p;
+					if (_data[0] == '0' && (_data[1] == 'x' || _data[1] == 'X')) {
+						_data += 2;
+					}
+					uint8_t stateBytes[18];
+					int nBytes = 0;
+					char *hp = _data;
+					while (*hp && *hp != ',' && hp[1] && nBytes < 18) {
+						char hex[3] = { hp[0], hp[1], 0 };
+						stateBytes[nBytes] = (uint8_t)strtol(hex, NULL, 16);
+						nBytes++;
+						hp += 2;
+					}
+					if (nBytes == 18) {
+						pIRsend->sendMitsubishiAC(stateBytes, 18);
+						pIRsend->delay(100);
+						ADDLOG_INFO(LOG_FEATURE_IR, (char *)"IR send MITSUBISHI_AC state, %d bytes", nBytes);
+						return CMD_RES_OK;
+					} else {
+						ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IR MITSUBISHI_AC state needs 18 bytes, got %d", nBytes);
+						return CMD_RES_BAD_ARGUMENT;
+					}
 				} else {
 					// TODO: implement longer protocols
 					ADDLOG_ERROR(LOG_FEATURE_IR, (char *)"IRSend currently only protocol with up to 64bits are supported", args);

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -337,7 +337,7 @@
 #endif
 #define ENABLE_DRIVER_IR						1
 #define ENABLE_DRIVER_RC						1
-//#define ENABLE_DRIVER_IR2					1
+// #define ENABLE_DRIVER_IR2					1
 #define ENABLE_DRIVER_DS1820					1
 #define ENABLE_DRIVER_CHT83XX					1
 #define ENABLE_DRIVER_KP18058					1

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -338,10 +338,6 @@
 #define ENABLE_DRIVER_IR						1
 #define ENABLE_DRIVER_RC						1
 //#define ENABLE_DRIVER_IR2					1
-#if PLATFORM_BK7238
-#undef ENABLE_DRIVER_IR					1
-#define ENABLE_DRIVER_IR2					1
-#endif
 #define ENABLE_DRIVER_DS1820					1
 #define ENABLE_DRIVER_CHT83XX					1
 #define ENABLE_DRIVER_KP18058					1

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -337,7 +337,7 @@
 #endif
 #define ENABLE_DRIVER_IR						1
 #define ENABLE_DRIVER_RC						1
-// #define ENABLE_DRIVER_IR2					1
+#define ENABLE_DRIVER_IR2					1
 #define ENABLE_DRIVER_DS1820					1
 #define ENABLE_DRIVER_CHT83XX					1
 #define ENABLE_DRIVER_KP18058					1

--- a/src/obk_config.h
+++ b/src/obk_config.h
@@ -337,7 +337,11 @@
 #endif
 #define ENABLE_DRIVER_IR						1
 #define ENABLE_DRIVER_RC						1
+//#define ENABLE_DRIVER_IR2					1
+#if PLATFORM_BK7238
+#undef ENABLE_DRIVER_IR					1
 #define ENABLE_DRIVER_IR2					1
+#endif
 #define ENABLE_DRIVER_DS1820					1
 #define ENABLE_DRIVER_CHT83XX					1
 #define ENABLE_DRIVER_KP18058					1


### PR DESCRIPTION
IRSend used to reject AC protocols (e.g. Mitsubishi), even though
sendMitsubishiAC() and pIRsend->send(protocol, bytes, len) already
existed in the code - there was just no command wired up to them.

Added a branch that parses the hex string into a byte array and sends
it through this existing function. Also bumped SEND_MAXBITS from 128
to 512, because Mitsubishi's 144-bit state, sent twice by default,
didn't fit in the old buffer size.

Usage:
IRSend MITSUBISHI_AC,144,0x23CB26010020180B364C00000000000000DA

Tested on BK7238 (T1-M module) (Nous L5) with a real Mitsubishi MSZ-DM35VA A/C
unit - power, mode, temperature, fan, vane work over MQTT.