### PR TITLE
drv_battery: keep the configured voltage divider, and don't publish ADC errors as a voltage

### DIFF
--- a/src/driver/drv_battery.c
+++ b/src/driver/drv_battery.c
@@ -29,6 +29,9 @@ static void Batt_Measure() {
 	if (g_vdividerFromUser == false
 		&& PIN_FindPinIndexForRole(IOR_BAT_Relay, -1) == -1
 		&& PIN_FindPinIndexForRole(IOR_BAT_Relay_n, -1) == -1) {
+		if (g_vdivider != 1) {
+			ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY: no relay pin and no divider given, ignoring divider %f and measuring directly", g_vdivider);
+		}
 		g_vdivider = 1;
 	}
 	// if divider equal to 1 then no need for relay activation
@@ -56,18 +59,20 @@ static void Batt_Measure() {
 		rtos_delay_milliseconds(10);
 	}
 	raw = HAL_ADC_Read(g_pin_adc);
-	if (raw < 0) {
-		ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY: ADC read failed (%i), keeping %i mV", raw, g_lastbattvoltage);
-		return;
-	}
-	g_battvoltage = raw;
-	ADDLOG_DEBUG(LOG_FEATURE_DRV, "DRV_BATTERY: ADC binary Measurement: %f and channel %i", g_battvoltage, channel_adc);
+	// switch the divider back off on both paths, so a failed conversion
+	// cannot leave it powered until the next measurement
 	if (g_vdivider > 1) {
 		if (g_pin_rel > 0) {
 			HAL_PIN_SetOutputValue(g_pin_rel, !writeVal);
 		}
 		//CHANNEL_Set(channel_rel, 0, 0);
 	}
+	if (raw < 0) {
+		ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY: ADC read failed (%i), keeping %i mV", raw, g_lastbattvoltage);
+		return;
+	}
+	g_battvoltage = raw;
+	ADDLOG_DEBUG(LOG_FEATURE_DRV, "DRV_BATTERY: ADC binary Measurement: %f and channel %i", g_battvoltage, channel_adc);
 	ADDLOG_DEBUG(LOG_FEATURE_DRV, "DRV_BATTERY: Calculation with param: %f %f %f", g_vref, g_adcbits, g_vdivider);
 	// batt_value = batt_value / vref / 12bits value should be 10 un doc ... but on CBU is 12 ....
 	vref = g_vref / g_adcbits;

--- a/src/driver/drv_battery.c
+++ b/src/driver/drv_battery.c
@@ -17,6 +17,7 @@ static int g_pin_adc = 0, channel_adc = 0, g_pin_rel = 0, g_battcycle = 1, g_bat
 static float g_battvoltage = 0.0, g_battlevel = 0.0;
 static int g_lastbattvoltage = 0, g_lastbattlevel = 0;
 static float g_vref = 2400, g_vdivider = 2.29, g_maxbatt = 3000, g_minbatt = 2000, g_adcbits = 4096;
+static bool g_vdividerFromUser = false;
 
 static void Batt_Measure() {
 	//this command has only been tested on CBU
@@ -24,7 +25,9 @@ static void Batt_Measure() {
 	int writeVal = 1;
 	ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY: Measure Battery volt en perc");
 	g_pin_adc = PIN_FindPinIndexForRole(IOR_BAT_ADC, g_pin_adc);
-	if (PIN_FindPinIndexForRole(IOR_BAT_Relay, -1) == -1 && PIN_FindPinIndexForRole(IOR_BAT_Relay_n, -1) == -1) {
+	if (g_vdividerFromUser == false
+		&& PIN_FindPinIndexForRole(IOR_BAT_Relay, -1) == -1
+		&& PIN_FindPinIndexForRole(IOR_BAT_Relay_n, -1) == -1) {
 		g_vdivider = 1;
 	}
 	// if divider equal to 1 then no need for relay activation
@@ -113,6 +116,7 @@ commandResult_t Battery_Setup(const void* context, const char* cmd, const char* 
 	g_maxbatt = Tokenizer_GetArgFloat(1);
 	if (Tokenizer_GetArgsCount() > 2) {
 		g_vdivider = Tokenizer_GetArgFloat(2);
+		g_vdividerFromUser = true;
 	}
 	if (Tokenizer_GetArgsCount() > 3) {
 		g_vref = Tokenizer_GetArgFloat(3);

--- a/src/driver/drv_battery.c
+++ b/src/driver/drv_battery.c
@@ -23,6 +23,7 @@ static void Batt_Measure() {
 	//this command has only been tested on CBU
 	float batt_ref, batt_res, vref;
 	int writeVal = 1;
+	int raw;
 	ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY: Measure Battery volt en perc");
 	g_pin_adc = PIN_FindPinIndexForRole(IOR_BAT_ADC, g_pin_adc);
 	if (g_vdividerFromUser == false
@@ -54,7 +55,12 @@ static void Batt_Measure() {
 		}
 		rtos_delay_milliseconds(10);
 	}
-	g_battvoltage = HAL_ADC_Read(g_pin_adc);
+	raw = HAL_ADC_Read(g_pin_adc);
+	if (raw < 0) {
+		ADDLOG_INFO(LOG_FEATURE_DRV, "DRV_BATTERY: ADC read failed (%i), keeping %i mV", raw, g_lastbattvoltage);
+		return;
+	}
+	g_battvoltage = raw;
 	ADDLOG_DEBUG(LOG_FEATURE_DRV, "DRV_BATTERY: ADC binary Measurement: %f and channel %i", g_battvoltage, channel_adc);
 	if (g_vdivider > 1) {
 		if (g_pin_rel > 0) {


### PR DESCRIPTION
Two things I ran into getting battery reporting working on a camera board. They're
unrelated, but both live in `Batt_Measure()`, so splitting them into separate PRs would
just create a conflict.

The first one: `Battery_Setup` takes a divider argument, and `Batt_Measure()` throws it
away again unless a `BAT_Relay` pin happens to be assigned.

```c
if (PIN_FindPinIndexForRole(IOR_BAT_Relay, -1) == -1 && PIN_FindPinIndexForRole(IOR_BAT_Relay_n, -1) == -1) {
    g_vdivider = 1;
}
```

My board has the divider soldered on permanently with no relay to switch it. I first
wrote that I didn't think this was unusual, and I've since been put right on that: most
battery-powered designs use a dedicated FET to switch the measurement on and save the
current, so mine is the odd one out. Either way, `Battery_Setup 3400 4100 3 2400 4096`
reported a third of the real voltage, and nothing in the log hinted at why. Took me
longer than I'd like to admit to spot, since the rest of the arithmetic checks out fine.

I kept the fallback for anyone who never passes a divider at all. It only stops
overriding a value that was set on purpose.

The other one: `HAL_ADC_Read` signals failure with a negative return value. On Beken
that's -1 for a pin with no channel behind it, -2 if the ADC won't open, -3 on a
conversion timeout. Nothing checks for it, so it gets scaled and published to MQTT and
the index page. One failed conversion shows up as -3.5 mV sitting in among normal
4000 mV readings, and drops the percentage to 0 for that cycle.

Now it keeps the previous value and logs the failure instead.

Tested on BK7252N.
