### PR TITLE
ota: bounds check on /api/flash only covers the first chunk, and runs after init_ota

### DIFF
--- a/src/hal/bk7231/hal_ota_bk7231.c
+++ b/src/hal/bk7231/hal_ota_bk7231.c
@@ -231,18 +231,18 @@ int http_rest_post_flash(http_request_t* request, int startaddr, int maxaddr)
 
 	ADDLOG_DEBUG(LOG_FEATURE_OTA, "OTA post len %d", request->contentLength);
 
-	init_ota(startaddr);
-
 	if (request->contentLength >= 0)
 	{
 		towrite = request->contentLength;
 	}
 
-	if (writelen < 0 || (startaddr + writelen > maxaddr))
+	if (writelen < 0 || towrite < 0 || (startaddr + towrite > maxaddr))
 	{
-		ADDLOG_DEBUG(LOG_FEATURE_OTA, "ABORTED: %d bytes to write", writelen);
-		return http_rest_error(request, -20, "writelen < 0 or end > 0x200000");
+		ADDLOG_DEBUG(LOG_FEATURE_OTA, "ABORTED: %d bytes to write", towrite);
+		return http_rest_error(request, -20, "invalid length, or end beyond maxaddr");
 	}
+
+	init_ota(startaddr);
 
 	do
 	{

--- a/src/hal/bk7231/hal_ota_bk7231.c
+++ b/src/hal/bk7231/hal_ota_bk7231.c
@@ -236,7 +236,8 @@ int http_rest_post_flash(http_request_t* request, int startaddr, int maxaddr)
 		towrite = request->contentLength;
 	}
 
-	if (writelen < 0 || towrite < 0 || (startaddr + towrite > maxaddr))
+	if (writelen < 0 || towrite <= 0 || startaddr < 0 || startaddr > maxaddr
+		|| towrite > maxaddr - startaddr)
 	{
 		ADDLOG_DEBUG(LOG_FEATURE_OTA, "ABORTED: %d bytes to write", towrite);
 		return http_rest_error(request, -20, "invalid length, or end beyond maxaddr");


### PR DESCRIPTION

`http_rest_post_flash` in the Beken HAL has a bounds check that doesn't cover what
actually gets written, and it runs too late to be safe when it does reject something.

The check is this:

```c
init_ota(startaddr);

if (request->contentLength >= 0) {
    towrite = request->contentLength;
}

if (writelen < 0 || (startaddr + writelen > maxaddr)) {
    return http_rest_error(request, -20, "writelen < 0 or end > 0x200000");
}
```

`writelen` is `request->bodylen`, which is only the part of the body that arrived
along with the headers. The loop underneath writes `towrite` bytes, which comes from
`Content-Length`, pulling the rest off the socket with `recv` and bumping `startaddr`
each time round. It never checks again, and nothing below it does either:
`add_otadata` walks `addr` forward per sector and `store_sector` goes straight to
`CMD_FLASH_ERASE_SECTOR` followed by `flash_write`. So a POST to `/api/flash/<addr>`
with a large `Content-Length` and a small first chunk passes the check and then erases
its way past `maxaddr`. That endpoint takes the start address from the URL and only
requires it to be at or above the OTA partition.

The second half is the ordering. `init_ota` clears flash write protection and mallocs
the sector buffer before the check happens, and the error path returns without
`close_ota()`, which is the only place that frees the buffer and puts protection back.
`init_ota` also refuses to run while `sector` is non-null, so one rejected upload
leaves write protection off and OTA unusable until the device reboots.

I moved the check above `init_ota` and pointed it at `towrite`. Nothing else in the
function changed. I left the -20 error code alone in case anything depends on it, but
reworded the message, since it named a constant that isn't what's being compared.

Only the Beken HAL has this check at all. The other HALs take `maxaddr` and ignore it,
which is worth a separate look, but I didn't want to touch platforms I can't test.

Tested on BK7252N.

