### PR TITLE
adc: a timed out read leaves the SARADC open and poisons the next one

### DIFF
--- a/src/hal/bk7231/hal_adc_bk7231.c
+++ b/src/hal/bk7231/hal_adc_bk7231.c
@@ -159,6 +159,7 @@ int HAL_ADC_Read(int pinNumber)
     UINT32 ret;
     int result;
 	int channel;
+	int value;
 
 	channel = gpioToAdc(pinNumber);
 
@@ -170,17 +171,25 @@ int HAL_ADC_Read(int pinNumber)
         result = rtos_init_semaphore(&tmp_single_semaphore, 1);
         ASSERT(kNoErr == result);
     }
-    
+
+	while(rtos_get_semaphore(&tmp_single_semaphore, 0) == kNoErr) {
+	}
+
 	if(temp_single_get_enable(channel)==SARADC_FAILURE) {
 
 		return -2;
 	}
-    
+
     ret = 1000; // 1s
     result = rtos_get_semaphore(&tmp_single_semaphore, ret);
     if(result == kNoErr) {
-        return tmp_single_desc.pData[0];
-    } 
-    return -3;
+        value = tmp_single_desc.pData[0];
+    } else {
+		if(tmp_single_hdl != DD_HANDLE_UNVALID) {
+			temp_single_get_disable();
+		}
+		value = -3;
+	}
+    return value;
 }
 

--- a/src/hal/bk7231/hal_adc_bk7231.c
+++ b/src/hal/bk7231/hal_adc_bk7231.c
@@ -92,20 +92,25 @@ static beken_mutex_t tmp_single_mutex = NULL;
 
 static void temp_single_get_disable(void)
 {
-    UINT32 status = DRV_SUCCESS;
-    
-    status = ddev_close(tmp_single_hdl);
-    if(DRV_FAILURE == status )
-    {
-        //TMP_DETECT_PRT("saradc disable failed\r\n");
-        //return;
-    }
-    saradc_ensure_close();
+    UINT32 status;
+    DD_HANDLE hdl;
+    GLOBAL_INT_DECLARATION();
+
+    GLOBAL_INT_DISABLE();
+    hdl = tmp_single_hdl;
     tmp_single_hdl = DD_HANDLE_UNVALID;
-    
+    GLOBAL_INT_RESTORE();
+
+    if(DD_HANDLE_UNVALID == hdl)
+    {
+        return;
+    }
+
+    ddev_close(hdl);
+    saradc_ensure_close();
+
     status = BLK_BIT_TEMPRATURE_SENSOR;
     sddev_control(SCTRL_DEV_NAME, CMD_SCTRL_BLK_DISABLE, &status);
-    
 }
 static void temp_single_detect_handler(void)
 {
@@ -193,9 +198,7 @@ int HAL_ADC_Read(int pinNumber)
     if(result == kNoErr) {
 		value = tmp_single_desc.pData[0];
 	} else {
-		if(tmp_single_hdl != DD_HANDLE_UNVALID) {
-			temp_single_get_disable();
-		}
+		temp_single_get_disable();
 		value = -3;
 	}
 	rtos_unlock_mutex(&tmp_single_mutex);

--- a/src/hal/bk7231/hal_adc_bk7231.c
+++ b/src/hal/bk7231/hal_adc_bk7231.c
@@ -173,13 +173,18 @@ int HAL_ADC_Read(int pinNumber)
 		return -1;
 	}
 
-    if(tmp_single_semaphore == NULL) {
-        result = rtos_init_semaphore(&tmp_single_semaphore, 1);
-        ASSERT(kNoErr == result);
-    }
-	if(tmp_single_mutex == NULL) {
-		result = rtos_init_mutex(&tmp_single_mutex);
-		ASSERT(kNoErr == result);
+	{
+		GLOBAL_INT_DECLARATION();
+		GLOBAL_INT_DISABLE();
+		if(tmp_single_semaphore == NULL) {
+			result = rtos_init_semaphore(&tmp_single_semaphore, 1);
+			ASSERT(kNoErr == result);
+		}
+		if(tmp_single_mutex == NULL) {
+			result = rtos_init_mutex(&tmp_single_mutex);
+			ASSERT(kNoErr == result);
+		}
+		GLOBAL_INT_RESTORE();
 	}
 
 	rtos_lock_mutex(&tmp_single_mutex);

--- a/src/hal/bk7231/hal_adc_bk7231.c
+++ b/src/hal/bk7231/hal_adc_bk7231.c
@@ -87,6 +87,7 @@ static saradc_desc_t tmp_single_desc;
 static UINT16 tmp_single_buff[ADC_TEMP_BUFFER_SIZE];
 static volatile DD_HANDLE tmp_single_hdl = DD_HANDLE_UNVALID;
 static beken_semaphore_t tmp_single_semaphore = NULL;
+static beken_mutex_t tmp_single_mutex = NULL;
 
 
 static void temp_single_get_disable(void)
@@ -171,25 +172,33 @@ int HAL_ADC_Read(int pinNumber)
         result = rtos_init_semaphore(&tmp_single_semaphore, 1);
         ASSERT(kNoErr == result);
     }
+	if(tmp_single_mutex == NULL) {
+		result = rtos_init_mutex(&tmp_single_mutex);
+		ASSERT(kNoErr == result);
+	}
+
+	rtos_lock_mutex(&tmp_single_mutex);
 
 	while(rtos_get_semaphore(&tmp_single_semaphore, 0) == kNoErr) {
 	}
 
 	if(temp_single_get_enable(channel)==SARADC_FAILURE) {
 
+		rtos_unlock_mutex(&tmp_single_mutex);
 		return -2;
 	}
 
     ret = 1000; // 1s
     result = rtos_get_semaphore(&tmp_single_semaphore, ret);
     if(result == kNoErr) {
-        value = tmp_single_desc.pData[0];
-    } else {
+		value = tmp_single_desc.pData[0];
+	} else {
 		if(tmp_single_hdl != DD_HANDLE_UNVALID) {
 			temp_single_get_disable();
 		}
 		value = -3;
 	}
-    return value;
+	rtos_unlock_mutex(&tmp_single_mutex);
+	return value;
 }
 


### PR DESCRIPTION
Three problems in the Beken ADC read. They are all in the same file and they
interact, so one PR.

**Correction to what this description said before.** I originally wrote that the
permanent failure comes from the device never being closed. That is backwards. It
comes from the device being closed too many times, and I have since measured it.
The rest of the original description stands.

### A read that times out skips the cleanup

The interrupt handler does the cleanup for a successful read: once the buffer fills
it calls `temp_single_get_disable()` and signals the semaphore. A read that times
out skips all of that. It returns -3 with the device still open, and if the
conversion lands a moment after the 1 second deadline the handler signals a
semaphore nobody is waiting on any more. The next read then returns immediately on
the leftover count and takes `pData` while the fresh conversion is still in flight,
so it gets the previous one's sample, on whatever channel that was.

### The handler can close the device more than once

`saradc_isr` calls `p_Int_Handler` on every interrupt where the sample count has
reached the buffer size. That test sits outside the FIFO drain loop, and the
descriptor keeps a full buffer after the conversion, so any later SARADC interrupt
runs the handler again. Both driver variants are written this way, `saradc.c` for
BK7231/7231N/7231U/7236/7271 and `saradc_bk7238.c` for 7238/7252N.

Every run reaches `ddev_close`, and `ddev_close` decrements `use_cnt` before it
tests it. `use_cnt` is `UINT32`, so one close too many wraps it to `0xFFFFFFFF`, the
zero test never passes again, and the device is left in `DD_STATE_OPENED` for good.
`ddev_open` then takes its already-open branch, which hands back a valid handle
without calling `saradc_open`. No conversion is ever started, so every read waits
out the full second and returns -3, until the board is power cycled.

Worth noting because it changes how the first fix has to be written: the close this
PR adds on the timeout path can itself be the extra one. The handler clears
`tmp_single_hdl` only after `ddev_close` returns, so a timeout landing in that
window still sees a valid handle and closes a second time.

So `temp_single_get_disable()` now takes the handle out of `tmp_single_hdl` with
interrupts masked and returns early if it has already been taken. That makes it safe
from both sides and lets the timeout path call it unconditionally.

### Nothing holds a second reader off

`tmp_single_desc`, `tmp_single_hdl` and `tmp_single_semaphore` are file statics. Two
readers on different tasks overwrite each other's channel in the descriptor, both
block on the single semaphore, and one walks away with the other's sample. There are
already four callers in tree: `Main_OnEverySecond` loops over every `IOR_ADC` pin,
plus `drv_battery`, `drv_adcSmoother` and `drv_adcButton`. It only takes one read
from outside the main loop.

I flagged when opening this that the mutex was created lazily and left a window on
the very first call. That is fixed here too: both handles are now created under one
interrupt mask, which is what the rest of the file already does and runs at most
once. It seemed a better fit than restructuring `HAL_ADC_Init`, which is empty and
only runs for pins carrying an ADC role, but say the word if you'd rather have it
there.

### Measured

On BK7252N, repeating a read across channels 0, 1, 2, 3, 8 and 9:

- before: two good conversions, then every later read failed until a power cycle
- after: 18 of 18 good

The failure shows as -2 rather than -3 on the tree I measured it on, because that
tree also checks the status `ddev_open` leaves untouched on its already-open branch.
On this branch the same wedge times out instead. Same cause either way.

Only device I have, so a second pair of eyes on the interrupt reasoning would be
welcome.
