### PR TITLE
http: listen() is called with a backlog of 0

### DIFF
--- a/src/httpserver/new_tcp_server.c
+++ b/src/httpserver/new_tcp_server.c
@@ -247,7 +247,7 @@ static void tcp_server_thread(beken_thread_arg_t arg)
 	}
 	ADDLOG_EXTRADEBUG(LOG_FEATURE_HTTP, "Socket bound on 0.0.0.0:%i", HTTP_SERVER_PORT);
 
-	err = listen(listen_sock, 0);
+	err = listen(listen_sock, (int)max_socks);
 	if(err != 0)
 	{
 		ADDLOG_ERROR(LOG_FEATURE_HTTP, "Error occurred during listen");


### PR DESCRIPTION
The HTTP server calls `listen()` with a backlog of 0.

lwIP doesn't take that literally, `tcp_backlog_set` maps 0 to 1, so the accept queue
holds exactly one connection. When a second SYN turns up while one is still waiting to
be accepted, `tcp_listen_input` bails out early:

```c
#if TCP_LISTEN_BACKLOG
    if (pcb->accepts_pending >= pcb->backlog) {
      LWIP_DEBUGF(TCP_DEBUG, ("tcp_listen_input: listen backlog exceeded ...
      return;
    }
#endif
```

That's a bare return, no SYN-ACK and no RST, so the client sits there until it
retransmits. `TCP_LISTEN_BACKLOG` is on in the Beken ports, so this is live and not
compiled out.

It shows up as a page that takes a beat longer than it should, because browsers open
several connections in parallel for anything with assets on it. The rest of the server
is already set up for that, `max_socks` worker slots and an accept loop that hands each
one off, so the queue in front of it was the only part sized for a single client.

`max_socks` is the value I went with. Worth being precise about what that does and
doesn't buy, since the queue and the workers aren't two separate pools here: the Beken
ports define `MEMP_NUM_TCP_PCB` as `MAX_SOCKETS_TCP` (8, 10 or 12 depending on the lwIP
version), and `max_socks` is that minus one, so both come out of the same allocation
that MQTT and everything else also draws on.

That means the number can't reserve anything. A queued connection is already a PCB, so
the pool stays the ceiling whatever goes in here, and the worker array was already sized
at `max_socks` before this change. What the patch removes is the cap of one, not a
capacity limit.

Tested on BK7252N.

