### PR TITLE
littlefs: give BK7252N its own flash bounds

### DIFF
--- a/src/littlefs/our_lfs.h
+++ b/src/littlefs/our_lfs.h
@@ -59,6 +59,13 @@
 // end of OTA flash / before RF firmware (OTA end 0x1E0000)
 #define LFS_BLOCKS_END 0x1E0000
 
+#elif PLATFORM_BK7252N
+// start 0x1000 after OTA addr
+#define LFS_BLOCKS_START 0x133000
+#define LFS_BLOCKS_START_MIN 0x133000
+// end of OTA flash
+#define LFS_BLOCKS_END 0x1E0000
+
 #elif PLATFORM_BL602 || PLATFORM_BL_NEW
 
 #define LFS_BLOCKS_START 0x0


### PR DESCRIPTION
BK7252N has no branch of its own in `our_lfs.h`, so it falls through to the default, which carries the BK7231N addresses. The two parts do not share a flash layout.

On BK7252N the OTA partition starts at `0x132000` (`hal_ota.h`) and the download area ends at `0x1E0000`, while the default `LFS_BLOCKS_END` of `0x1AB000` sits in the middle of the region an incoming update is written to. Since `our_lfs.c` places the filesystem at `LFS_BLOCKS_END` minus its size, it lands inside that region: writing a file can corrupt a staged update, and an update can wipe the filesystem.

This follows the convention the other Beken targets use here - start one sector after the OTA address, and end where the OTA area ends.

Verified on a BK7252N device: after the change, `lfs_format` plus a write put the superblock and the file at `0x1D8000`, and the previous location is no longer used.

Note that this moves the filesystem, so content stored at the previous location is not carried over.