### PR TITLE
httpserver: keep the server up when a client thread fails to spawn

### DIFF
--- a/src/httpserver/new_tcp_server.c
+++ b/src/httpserver/new_tcp_server.c
@@ -322,7 +322,6 @@ static void tcp_server_thread(beken_thread_arg_t arg)
 					ADDLOG_ERROR(LOG_FEATURE_HTTP, "[sock=%d]: TCP Client thread creation failed!", sock[new_idx].fd);
 					lwip_close(sock[new_idx].fd);
 					sock[new_idx].fd = INVALID_SOCK;
-					goto error;
 				}
 			}
 		}


### PR DESCRIPTION
### Problem

The HTTP accept loop in `new_tcp_server.c` creates one thread per accepted connection. When `rtos_create_thread` fails — transient heap or thread-pool pressure — the connection socket is closed and its slot reset, and then the code does `goto error`.

The `error` label is meant for fatal setup failures: it closes the listen socket, deletes every other client thread, closes their sockets, and restarts the whole TCP server after a 2 s delay.

So a single failed thread allocation tears down **every** live HTTP connection and bounces the server, even though the failure only concerns the one connection that could not be served. It is most likely to trigger under load, when several connections arrive close together and heap/thread headroom is lowest — exactly when dropping every connection hurts most.

### Fix

Treat a failed spawn as a per-connection condition. The socket is already closed and the slot freed at that point, so simply keep accepting. The `error` path is left intact for the genuinely fatal cases (listen socket `EBADF`, socket/bind/listen setup failures).

One line removed.
