### PR TITLE
Persist a custom MAC on Beken, and apply it at boot without tearing WiFi down

### DIFF
--- a/src/hal/bk7231/hal_wifi_bk7231.c
+++ b/src/hal/bk7231/hal_wifi_bk7231.c
@@ -86,6 +86,25 @@ void WiFI_GetMacAddress(char* mac)
 	wifi_get_mac_address((char*)mac, CONFIG_ROLE_STA);
 }
 
+// The SDK's wifi_set_mac_address() ends with bk_wlan_stop_scan() and
+// bk_wlan_stop(BK_STATION). That is fine once WiFi is running, but at boot it
+// stops a station that was never started, and the driver is left in a state
+// where deep sleep and reboot stop working - the device then only comes back
+// on a power cycle.
+//
+// At boot we do not need any of that teardown, only the value: everything
+// reads system_mac, and cfg_load_mac() fills it exactly once, on the first
+// wifi_get_mac_address() call. So force that load, then overwrite it.
+extern uint8_t system_mac[];
+
+int WiFI_SetMacAddressAtBoot(char* mac)
+{
+	char current[6];
+	wifi_get_mac_address(current, CONFIG_ROLE_STA);
+	memcpy(system_mac, mac, 6);
+	return 1;
+}
+
 const char* HAL_GetMACStr(char* macstr)
 {
 	unsigned char mac[6];

--- a/src/hal/generic/hal_wifi_generic.c
+++ b/src/hal/generic/hal_wifi_generic.c
@@ -22,6 +22,12 @@ const char* __attribute__((weak)) HAL_GetMyMaskString()
 	return "error";;
 }
 
+// Platforms that need no special handling at boot just use the normal setter.
+int __attribute__((weak)) WiFI_SetMacAddressAtBoot(char* mac)
+{
+	return WiFI_SetMacAddress(mac);
+}
+
 int __attribute__((weak)) WiFI_SetMacAddress(char* mac)
 {
 

--- a/src/hal/hal_wifi.h
+++ b/src/hal/hal_wifi.h
@@ -67,6 +67,8 @@ uint8_t HAL_GetWiFiChannel(uint8_t *chan);
 
 void WiFI_GetMacAddress(char* mac);
 int WiFI_SetMacAddress(char* mac);
+// Same, but safe to call before the WiFi stack has been started.
+int WiFI_SetMacAddressAtBoot(char* mac);
 void HAL_PrintNetworkInfo();
 int HAL_GetWifiStrength();
 

--- a/src/httpserver/http_fns.c
+++ b/src/httpserver/http_fns.c
@@ -1935,13 +1935,23 @@ int http_fn_cfg_mac(http_request_t* request) {
 			mac[i] = hexbyte(&tmpA[i * 2]);
 		}
 		//sscanf(tmpA,"%02X%02X%02X%02X%02X%02X",&mac[0],&mac[1],&mac[2],&mac[3],&mac[4],&mac[5]);
+		// Store and flush the new MAC first - CFG_InitAndLoad() applies it on
+		// every boot, so persisting it is what actually makes the change stick.
+		CFG_SetMac((char*)mac);
+		CFG_Save_IfThereArePendingChanges();
+#if defined(PLATFORM_BEKEN)
+		// Beken's wifi_set_mac_address() is only safe before the WiFi stack is
+		// started; calling it on a live link wedges the radio until the next
+		// power cycle - so on Beken we only store it and let the reboot apply it.
+		poststr_h4(request, "New MAC saved - reboot to apply it!");
+#else
 		if (WiFI_SetMacAddress((char*)mac)) {
 			poststr_h4(request, "New MAC set!");
 		}
 		else {
 			poststr_h4(request, "MAC change error?");
 		}
-		CFG_Save_IfThereArePendingChanges();
+#endif
 	}
 
 	WiFI_GetMacAddress((char*)mac);

--- a/src/new_cfg.c
+++ b/src/new_cfg.c
@@ -829,11 +829,15 @@ void CFG_InitAndLoad() {
 		// mark as changed
 		g_cfg_pendingChanges ++;
 	} else {
-#if defined(PLATFORM_XRADIO) || defined(PLATFORM_BL602)
+#if defined(PLATFORM_XRADIO) || defined(PLATFORM_BL602) || defined(PLATFORM_BEKEN)
 		if (g_cfg.mac[0] == 0 && g_cfg.mac[1] == 0 && g_cfg.mac[2] == 0 && g_cfg.mac[3] == 0 && g_cfg.mac[4] == 0 && g_cfg.mac[5] == 0) {
 			WiFI_GetMacAddress((char*)g_cfg.mac);
 		}
-		WiFI_SetMacAddress((char*)g_cfg.mac);
+		// never apply an all-zero or a multicast/broadcast MAC - that would kill WiFi
+		if ((g_cfg.mac[0] & 1) == 0 && (g_cfg.mac[0] | g_cfg.mac[1] | g_cfg.mac[2]
+			| g_cfg.mac[3] | g_cfg.mac[4] | g_cfg.mac[5]) != 0) {
+			WiFI_SetMacAddressAtBoot((char*)g_cfg.mac);
+		}
 #endif
 		addLogAdv(LOG_WARN, LOG_FEATURE_CFG, "CFG_InitAndLoad: Correct config has been loaded with %i changes count.",g_cfg.changeCounter);
 	}


### PR DESCRIPTION
Two Tuya battery sensors I flashed with OpenBeken turned out to be genuine MAC clones - both boards send as `c8:47:8c:42:88:48`, so only one of them can be on the network at a time. `/cfg_mac` looked like the answer, but it does not survive a reboot on Beken. Digging into it turned up three separate problems.

**1. The MAC was never stored.** `http_fn_cfg_mac()` calls `WiFI_SetMacAddress()` and then `CFG_Save_IfThereArePendingChanges()`, but nothing ever writes the new value into `g_cfg.mac`, so the save has nothing to save. This affects every platform, not just Beken.

**2. The stored MAC was never reapplied on Beken.** `CFG_InitAndLoad()` only calls `WiFI_SetMacAddress()` under `PLATFORM_XRADIO` / `PLATFORM_BL602`, even though a Beken implementation has existed all along.

**3. `wifi_set_mac_address()` is not safe to call at boot.** This one cost me a night, so it is worth spelling out. From `beken378/app/config/param_config.c`:

```c
int wifi_set_mac_address(char *mac) {
    ...
    os_memcpy(system_mac, mac, sizeof(system_mac));
    ...
    bk_wlan_stop_scan();
    bk_wlan_stop(BK_SOFT_AP);
    bk_wlan_stop(BK_STATION);
}
```

Calling it on a live connection wedges the radio hard enough that the device never comes back - not even `restart` gets through. Calling it from `CFG_InitAndLoad()` looks safer, but it stops a station that was never started, and the driver is left in a state where `restart`, RTC wakeup and GPIO wakeup from deep sleep **all** stop working. The device then only recovers on a power cycle, and on a *double* one, because Beken deep sleep survives a short interruption.

That same function also explains why nothing persists: the write is gated on `WIFI_MAC_POS`, and in the EFUSE branch the call is commented out. The MAC only ever lives in RAM.

**The fix.** At boot we need the value, not the teardown. Everything reads `system_mac`, and `cfg_load_mac()` fills it exactly once - on the first `wifi_get_mac_address()` call. So `WiFI_SetMacAddressAtBoot()` forces that load and then overwrites `system_mac` directly. Other platforms get a weak fallback that just calls `WiFI_SetMacAddress()`, so nothing changes for them.

Also in here:
- `/cfg_mac` stores and flushes the MAC *before* touching the radio, and on Beken skips the runtime call entirely - the page says `New MAC saved - reboot to apply it!`
- a guard against applying an all-zero or multicast/broadcast MAC. On a battery sensor with no exposed serial header, a bad value there is unrecoverable without opening the case.

**Tested on BK7238 (T1-U-HL, 2 MB).** With the fix, one sensor runs on a changed MAC across reboots while its clone stays on the factory one, and on the same firmware `restart` works and `PinDeepSleep` wakes on a GPIO edge - verified by having the accelerometer INT wake the device, ~8 s from the knock to being reachable again. Without the fix all three of those fail; with the boot call removed entirely they work but the MAC reverts. Control run: the device slept 60 s untouched without waking.