### PR TITLE
Berry: Wire methods never touched the bus

### DIFF
--- a/src/berry/modules/be_i2c.c
+++ b/src/berry/modules/be_i2c.c
@@ -7,18 +7,40 @@
 #include "../../driver/drv_local.h"
 #include "../../logging/logging.h"
 
+// Berry calls these as methods, so stack index 1 is the instance and the
+// softI2C_t lives in its ".p" member. The old code read index 1 as a raw
+// comptr, which is never true for a method call - every call silently did
+// nothing. Raw comptrs are still accepted so direct calls keep working.
+static softI2C_t* i2c_self(bvm* vm)
+{
+	softI2C_t* i2c = NULL;
+	if(be_isinstance(vm, 1))
+	{
+		// note: be_newcomobj() stores a BE_COMOBJ, not a BE_COMPTR, so this
+		// has to go through be_tocomptr(), which unwraps both.
+		be_getmember(vm, 1, ".p");
+		i2c = be_tocomptr(vm, -1);
+		be_pop(vm, 1);
+	}
+	else
+	{
+		i2c = be_tocomptr(vm, 1);
+	}
+	return i2c;
+}
+
 static int m_initI2c(bvm* vm)
 {
 	int top = be_top(vm);
-	if(top >= 2 && be_isint(vm, 1) && be_isint(vm, 2) && be_isint(vm, 3))
+	if(top >= 3 && be_isint(vm, 2) && be_isint(vm, 3))
 	{
 		softI2C_t* i2c = malloc(sizeof(softI2C_t));
 		memset(i2c, 0, sizeof(softI2C_t));
-		i2c->pin_clk = be_toint(vm, 1);
-		i2c->pin_data = be_toint(vm, 2);
-		if(be_isint(vm, 3))
+		i2c->pin_clk = be_toint(vm, 2);
+		i2c->pin_data = be_toint(vm, 3);
+		if(top >= 4 && be_isint(vm, 4))
 		{
-			i2c->address8bit = be_toint(vm, 3) << 1;
+			i2c->address8bit = be_toint(vm, 4) << 1;
 		}
 		else
 		{
@@ -26,19 +48,19 @@ static int m_initI2c(bvm* vm)
 			be_writestring("No address configured, only scan is available");
 		}
 		Soft_I2C_PreInit(i2c);
-		be_pushcomptr(vm, i2c);
 		be_newcomobj(vm, i2c, &be_commonobj_destroy_generic);
-		be_return(vm);
+		be_setmember(vm, 1, ".p");
+		be_pop(vm, 1);
+		be_return_nil(vm);
 	}
 	be_return_nil(vm);
 }
 
 static int m_scanI2c(bvm* vm)
 {
-	int top = be_top(vm);
-	if(top >= 1 && be_iscomptr(vm, 1))
+	softI2C_t* i2c = i2c_self(vm);
+	if(i2c)
 	{
-		softI2C_t* i2c = be_tocomptr(vm, 1);
 		for(int a = 1; a < 128; a++)
 		{
 			Soft_I2C_PreInit(i2c);
@@ -56,10 +78,9 @@ static int m_scanI2c(bvm* vm)
 
 static int m_startI2c(bvm* vm)
 {
-	int top = be_top(vm);
-	if(top >= 2 && be_iscomptr(vm, 1) && be_isbool(vm, 2))
+	softI2C_t* i2c = i2c_self(vm);
+	if(i2c && be_top(vm) >= 2 && be_isbool(vm, 2))
 	{
-		softI2C_t* i2c = be_tocomptr(vm, 1);
 		bool isRead = be_tobool(vm, 2);
 		Soft_I2C_Start(i2c, i2c->address8bit | (int)isRead);
 	}
@@ -68,10 +89,9 @@ static int m_startI2c(bvm* vm)
 
 static int m_stopI2c(bvm* vm)
 {
-	int top = be_top(vm);
-	if(top >= 1 && be_iscomptr(vm, 1))
+	softI2C_t* i2c = i2c_self(vm);
+	if(i2c)
 	{
-		softI2C_t* i2c = be_tocomptr(vm, 1);
 		Soft_I2C_Stop(i2c);
 	}
 	be_return_nil(vm);
@@ -79,10 +99,9 @@ static int m_stopI2c(bvm* vm)
 
 static int m_writeI2c(bvm* vm)
 {
-	int top = be_top(vm);
-	if(top >= 2 && be_iscomptr(vm, 1) && be_isinstance(vm, 2))
+	softI2C_t* i2c = i2c_self(vm);
+	if(i2c && be_top(vm) >= 2)
 	{
-		softI2C_t* i2c = be_tocomptr(vm, 1);
 		if(be_isinstance(vm, 2))
 		{
 			size_t len;
@@ -103,10 +122,9 @@ static int m_writeI2c(bvm* vm)
 
 static int m_readByteI2c(bvm* vm)
 {
-	int top = be_top(vm);
-	if(top >= 2 && be_iscomptr(vm, 1) && be_isbool(vm, 2))
+	softI2C_t* i2c = i2c_self(vm);
+	if(i2c && be_top(vm) >= 2 && be_isbool(vm, 2))
 	{
-		softI2C_t* i2c = be_tocomptr(vm, 1);
 		int nack = be_tobool(vm, 2);
 		uint8_t data = Soft_I2C_ReadByte(i2c, nack);
 		be_pushint(vm, data);
@@ -117,10 +135,9 @@ static int m_readByteI2c(bvm* vm)
 
 static int m_readBytesI2c(bvm* vm)
 {
-	int top = be_top(vm);
-	if(top >= 2 && be_iscomptr(vm, 1) && be_isint(vm, 2))
+	softI2C_t* i2c = i2c_self(vm);
+	if(i2c && be_top(vm) >= 2 && be_isint(vm, 2))
 	{
-		softI2C_t* i2c = be_tocomptr(vm, 1);
 		int size = be_toint(vm, 2);
 		uint8_t* data = malloc(size * sizeof(uint8_t));
 		Soft_I2C_ReadBytes(i2c, data, size);


### PR DESCRIPTION
While bringing up an I2C accelerometer from Berry I could not get a single byte out of the bus - `read()` returned `nil` every time and `scan()` finished in 57 ms, which is far too fast for 127 addresses with a 5 ms delay each. It turns out none of the `Wire` methods have ever done anything.

Every method starts with `be_iscomptr(vm, 1)`, but on a method call Berry puts the *instance* at index 1, never a comptr. The check is always false, so `scan`, `start`, `stop`, `read`, `read_bytes` and `write` all fall through to `be_return_nil()` without touching the pins.

`init()` has the matching problem from the other side: it reads its arguments from index 1..3, which is `self` plus the first two arguments, and then returns the comptr via `be_return()`. Berry ignores what `init` returns, so the instance never gets a `.p` member - the class declares `.p, var` but nothing ever fills it.

This resolves the `softI2C_t` through the instance`s `.p`, stores it there in `init()`, and shifts `init()`s argument indices by one. Raw comptrs are still accepted, so any direct C-side call keeps working.

One subtlety worth flagging for anyone touching this later: `be_newcomobj()` stores a `BE_COMOBJ`, and `be_iscomptr()` returns false for that. My first attempt guarded the `be_getmember()` result with `be_iscomptr()` and threw the pointer away again. `be_tocomptr()` unwraps both types, so that is what the helper uses.

Tested on BK7238 with a MiraMEMS DA213B on a soft-I2C bus: before the change `Wire(9, 24, 0x26).read()` returned `nil`; after it, register 0x01 reads back 0x13 (the chip ID), the accelerometer can be configured, and its motion interrupt drives a GPIO as expected.