### PR TITLE
Beken: zero PS_DEEP_CTRL_PARAM before entering deep sleep

### DIFF
--- a/src/cmnds/cmd_main.c
+++ b/src/cmnds/cmd_main.c
@@ -390,6 +390,10 @@ static commandResult_t CMD_DeepSleep(const void* context, const char* cmd, const
 	return CMD_RES_OK;
 #elif defined(PLATFORM_BEKEN_NEW)
 	PS_DEEP_CTRL_PARAM params;
+	// see PINS_BeginDeepSleepWithPinWakeUp() - the struct must be zeroed, or the
+	// SDK gets stack garbage for the GPIO maps and for lpo_32k_src (the RTC
+	// clock source), and the device wakes at a random time or not at all
+	memset(&params, 0, sizeof(params));
 	params.sleep_mode = MANUAL_MODE_IDLE;
 	params.wake_up_way = PS_DEEP_WAKEUP_RTC;
 	params.sleep_time = timeMS;

--- a/src/new_pins.c
+++ b/src/new_pins.c
@@ -264,6 +264,14 @@ void PINS_BeginDeepSleepWithPinWakeUp(unsigned int wakeUpTime) {
 	addLogAdv(LOG_INFO, LOG_FEATURE_GENERAL, "Index map: %i, edge: %i", g_gpio_index_map[0], g_gpio_edge_map[0]);
 #ifdef PLATFORM_BEKEN_NEW
 	PS_DEEP_CTRL_PARAM params;
+	// PS_DEEP_CTRL_PARAM has nine fields; we only fill a few of them, so without
+	// this the SDK gets stack garbage for gpio_stay_lo_map, gpio_stay_hi_map,
+	// gpio_last_index_map, gpio_last_edge_map and - worst of all - lpo_32k_src,
+	// which picks the RTC clock source. A random clock source is why timed
+	// wakeups fired at arbitrary times. Zero also happens to be the right
+	// default here: LPO_SELECT_ROSC, the internal oscillator, which every board
+	// has (a 32k crystal may not be fitted).
+	memset(&params, 0, sizeof(params));
 	params.gpio_index_map = g_gpio_index_map[0];
 	params.gpio_edge_map = g_gpio_edge_map[0];
 	params.sleep_mode = MANUAL_MODE_IDLE;


### PR DESCRIPTION
While getting deep sleep working on a BK7238 battery sensor, timed wakeups behaved randomly: `PinDeepSleep 20` came back after ~7 s, and `DeepSleep 5` never came back at all - the device had to be power-cycled, and twice, because Beken deep sleep survives a short interruption.

`PS_DEEP_CTRL_PARAM` has nine fields:

```c
UINT32 wake_up_way;
UINT32 gpio_index_map, gpio_edge_map, gpio_stay_lo_map;
UINT32 gpio_last_index_map, gpio_last_edge_map, gpio_stay_hi_map;
UINT32 sleep_time, lpo_32k_src, sleep_mode;
```

Both call sites declare it on the stack and fill only a few. Everything else is whatever happened to be on the stack - including:

- `lpo_32k_src`, which selects the **RTC clock source** for the timed wakeup. A random value here is exactly why timed wakeups fired at arbitrary times.
- `gpio_stay_lo_map` / `gpio_stay_hi_map`, which pin GPIOs to a fixed level during sleep.
- `gpio_last_index_map` / `gpio_last_edge_map`, extra wake sources for GPIO32-39.

`CMD_DeepSleep()` additionally leaves the GPIO maps garbage, and `PINS_BeginDeepSleepWithPinWakeUp()` leaves `sleep_time` garbage when called without a timer.

Zeroing the struct fixes it, and the zero defaults happen to be the right ones: empty stay/last maps, and `lpo_32k_src = 0 = LPO_SELECT_ROSC`, the internal oscillator, which is present on every board (a 32k crystal may not be fitted).

Tested on BK7238 (T1-U-HL). Before: `PinDeepSleep 20` woke after ~7 s. After: commanded 30 s, actually slept ~31 s. GPIO wakeup also became reliable, and both sources work together - with a 600 s timer armed, a knock on the accelerometer woke the device after 4 s.